### PR TITLE
Add comments to write out entire file for use on web pages for samples.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=ChangeBasemap, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "ChangeBasemap.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=ChangeViewpoint, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "ChangeViewpoint.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=DisplayMap, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "DisplayMap.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=ManageBookmarks, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "ManageBookmarks.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=MapLoaded, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "MapLoaded.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=MapRotation, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "MapRotation.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenExistingMap/OpenExistingMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenExistingMap/OpenExistingMap.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=OpenExistingMap, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "OpenExistingMap.h"
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=SetInitialMapArea, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "SetInitialMapArea.h"
 #include "Basemap.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp
@@ -1,3 +1,5 @@
+// [WriteFile Name=SetInitialMapLocation, Category=Maps]
+// [Legal]
 // Copyright 2015 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// [Legal]
 
 #include "SetInitialMapLocation.h"
 #include "Map.h"


### PR DESCRIPTION
The additional lines are used by one of our doc build scripts, extract_all_snippets.py. The comments indicate that the entire file should be extracted for use on the web pages describing the samples. 

@khajra Please review and merge if appropriate. 
