### PR TITLE
Move Symbol::opacity to PictureMarkerSymbol only

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.cpp
@@ -80,7 +80,7 @@ void GORenderers::addGraphicsOverlay()
     polylineBuilder.addPoint(-10e5, 40e5);
     polylineBuilder.addPoint(20e5, 50e5);
     // create a line symbol
-    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("blue"), 5, true, 1.0, this);
+    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("blue"), 5, this);
     // create a line graphic
     Graphic* lineGraphic = new Graphic(polylineBuilder.toGeometry(), this);
 
@@ -99,7 +99,7 @@ void GORenderers::addGraphicsOverlay()
     polygonBuilder.addPoint(20e5, 20e5);
     polygonBuilder.addPoint(20e5, -20e5);
     polygonBuilder.addPoint(-20e5, -20e5);
-    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor("yellow"), 0.7f, this);
+    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor("yellow"), this);
     Graphic* polygonGraphic = new Graphic(polygonBuilder.toGeometry(), this);
 
     GraphicsOverlay* polygonGraphicsOverlay = new GraphicsOverlay(this);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.cpp
@@ -98,7 +98,7 @@ void GOSymbols::addBuoyPoints(GraphicsOverlay* graphicsOverlay)
 
 void GOSymbols::addBoatTrip(GraphicsOverlay* graphicsOverlay)
 {
-    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Dash,QColor("blue"), 1, true, 0.7f, this);
+    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Dash,QColor("blue"), 1, this);
 
     // json for the polyline
     QString polylineJson = "{\"paths\":[[[-2.7184791227926772,56.06147084563517],"
@@ -174,9 +174,9 @@ void GOSymbols::addBoatTrip(GraphicsOverlay* graphicsOverlay)
 void GOSymbols::addNestingGround(GraphicsOverlay* graphicsOverlay)
 {
     // outline for the polygon
-    SimpleLineSymbol* outline = new SimpleLineSymbol(SimpleLineSymbolStyle::Dash, QColor("black"), 1, true, 0.5f, this);
+    SimpleLineSymbol* outline = new SimpleLineSymbol(SimpleLineSymbolStyle::Dash, QColor("black"), 1, this);
     // create a fill symbol for a polygon
-    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::DiagonalCross, QColor("green"), 0.5f, outline, this);
+    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::DiagonalCross, QColor("green"), outline, this);
 
     // create a graphic using polygon as the geometry
     Graphic* graphic = new Graphic(createNestingGround(), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
@@ -57,7 +57,7 @@ void IdentifyGraphics::componentComplete()
     m_graphicsOverlay = new GraphicsOverlay(this);
 
     // assign a renderer to the graphics overlay
-    SimpleFillSymbol* simpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor("yellow"), 0.7, this);
+    SimpleFillSymbol* simpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor("yellow"), this);
     SimpleRenderer* simpleRenderer = new SimpleRenderer(simpleFillSymbol, this);
     m_graphicsOverlay->setRenderer(simpleRenderer);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
@@ -79,7 +79,7 @@ bool FeatureLayerChangeRenderer::layerInitialized() const
 void FeatureLayerChangeRenderer::changeRenderer()
 {
     // create a line symbol
-    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("blue"), 2.0f, true, 0.8f, this);
+    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("blue"), 2.0f, this);
     // create a renderer with the symbol above
     SimpleRenderer* simpleRenderer = new SimpleRenderer(sls, this);
     // change the renderer with the renderer created above

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
@@ -69,9 +69,9 @@ void FeatureLayerQuery::componentComplete()
     m_featureLayer = new FeatureLayer(m_featureTable, this);
 
     // line symbol for the outline
-    SimpleLineSymbol* outline = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("black"), 2.0f, true, 1.0f, this);
+    SimpleLineSymbol* outline = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("black"), 2.0f, this);
     // fill symbol
-    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor("yellow"), 0.6f, outline, this);
+    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor("yellow"), outline, this);
     // create the renderer using the symbology created above
     SimpleRenderer* renderer = new SimpleRenderer(sfs, this);
     // set the renderer for the feature layer

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GORenderers/GORenderers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GORenderers/GORenderers.qml
@@ -86,7 +86,6 @@ Rectangle {
         color: "blue"
         width: 5
         antiAlias: true
-        opacity: 1
     }
 
     // the line graphic
@@ -107,7 +106,6 @@ Rectangle {
         id: fillSymbol
         style: Enums.SimpleFillSymbolStyleSolid
         color: "yellow"
-        opacity: 0.7
     }
 
     // the graphic for the polygon graphics overlay

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/GOSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/GOSymbols.qml
@@ -145,7 +145,6 @@ Rectangle {
         color: Qt.rgba(0.5, 0.0, 0.5, 1)
         width: 4
         antiAlias: true
-        opacity: 1
     }
 
     // polygon for nesting ground
@@ -159,7 +158,6 @@ Rectangle {
         id: nestingGroundSymbol
         style: Enums.SimpleFillSymbolStyleDiagonalCross
         color: Qt.rgba(0.0, 0.31, 0.0, 1)
-        opacity: 1
 
         // default property: ouline
         SimpleLineSymbol {
@@ -167,7 +165,6 @@ Rectangle {
             color: Qt.rgba(0.0, 0.0, 0.5, 1)
             width: 1
             antiAlias: true
-            opacity: 1
         }
     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
@@ -44,7 +44,6 @@ Rectangle {
                 symbol: SimpleFillSymbol {
                     style: Enums.SimpleFillSymbolStyleSolid
                     color: "yellow"
-                    opacity: 0.7
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.qml
@@ -60,7 +60,6 @@ Rectangle {
                 color: "blue"
                 antiAlias: true
                 width: 2 * scaleFactor
-                opacity: 1.0
             }
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
@@ -45,7 +45,6 @@ Rectangle {
                     SimpleFillSymbol {
                         style: Enums.SimpleFillSymbolStyleSolid
                         color: "#F2F5A9"
-                        opacity: 0.6
 
                         // default property (outline)
                         SimpleLineSymbol {
@@ -53,7 +52,6 @@ Rectangle {
                             color: "black"
                             width: 2.0 * scaleFactor
                             antiAlias: true
-                            opacity: 1.0
                         }
                     }
                 }


### PR DESCRIPTION
Assign to @JamesMBallard 

Update samples to move opacity from Symbol base class to Picture marker symbol only.
A few modified constructor params.
