### PR TITLE
Use iterator features property to obtain count

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.qml
@@ -48,11 +48,7 @@ Rectangle {
                                 return;
                             }
 
-                            var count = 0;
-                            while (populateFromServiceResult.iterator.hasNext){
-                                populateFromServiceResult.iterator.next();
-                                ++count;
-                            }
+                            var count = populateFromServiceResult.iterator.features.length;
                             console.log("Retrieved %1 features".arg(count));
                         }
                     }


### PR DESCRIPTION
Assign to @JamesMBallard 

Update sample to use the iterator's features property to get total count of retrieved features.
