### PR TITLE
Get the correct attachment file path

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -190,10 +190,11 @@ AttachmentListModel* EditFeatureAttachments::attachmentModel() const
     return m_selectedFeature ? m_selectedFeature->attachmentListModel() : nullptr;
 }
 
-void EditFeatureAttachments::addAttachment(QString fileUrl, QString contentType, QString fileName)
+void EditFeatureAttachments::addAttachment(QUrl fileUrl, QString contentType, QString fileName)
 {
-    QFile* file = new QFile(fileUrl, this);
-    m_selectedFeature->attachmentListModel()->addAttachment(file, contentType, fileName);
+    QFile* file = new QFile(fileUrl.toLocalFile(), this);
+    if (file->exists())
+      m_selectedFeature->attachmentListModel()->addAttachment(file, contentType, fileName);
 }
 
 void EditFeatureAttachments::deleteAttachment(int index)

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
@@ -46,7 +46,7 @@ public:
     ~EditFeatureAttachments();
 
     void componentComplete() Q_DECL_OVERRIDE;
-    Q_INVOKABLE void addAttachment(QString fileUrl, QString contentType, QString fileName);
+    Q_INVOKABLE void addAttachment(QUrl fileUrl, QString contentType, QString fileName);
     Q_INVOKABLE void deleteAttachment(int index);
 
 signals:


### PR DESCRIPTION
Fixes the local file path specified when coming from the FileDialog QML component.
