### PR TITLE
Connect via http to avoid SSL errors

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
@@ -67,7 +67,7 @@ void FeatureLayerQuery::componentComplete()
     m_mapView->setMap(m_map);
 
     // create the feature table
-    m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"), this);
+    m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"), this);
     // create the feature layer using the feature table
     m_featureLayer = new FeatureLayer(m_featureTable, this);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
@@ -62,7 +62,7 @@ Rectangle {
                 // feature table
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"
+                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"
 
                     onQueryFeaturesStatusChanged: {
                         if (queryFeaturesStatus === Enums.TaskStatusCompleted) {


### PR DESCRIPTION
Assign to @ldanzinger 

Connect to FeatureLayer via http to avoid certain SSL problems on iOS
