### PR TITLE
Use the same logic as the matching Qml sample.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -126,12 +126,12 @@ void EditFeatureAttachments::connectSignals()
             QueryParameters queryParams;
             m_whereClause = "objectid=" + identifyResult->geoElements().at(0)->attributes()->attributeValue("objectid").toString();
             queryParams.setWhereClause(m_whereClause);
-            m_featureTable->queryFeatures(queryParams);
+            m_featureLayer->selectFeatures(queryParams, SelectionMode::New);
         }
     });
 
     // connect to the queryFeaturesCompleted signal on the feature table
-    connect(m_featureTable, &FeatureTable::queryFeaturesCompleted,
+    connect(m_featureLayer, &FeatureLayer::selectFeaturesCompleted,
             this, [this](QUuid, QSharedPointer<FeatureQueryResult> featureQueryResult)
     {
         if (featureQueryResult->iterator().hasNext())


### PR DESCRIPTION
Assigned to @michael-tims 

There was a problem with the feature selection. It wasn't working like it should but at some point this one drifted from what the Qml sample is doing. Using the Qml sample logic works correctly.
