### PR TITLE
Change Edit Samples to use Center instead of Envelope

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -58,10 +58,10 @@ void AddFeaturesFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
+    m_map->setInitialViewpoint(Viewpoint(Point(-10800000, 4500000, SpatialReference(102100)), 3e7));
 
     // set map on the map view
     m_mapView->setMap(m_map);
-    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -58,10 +58,10 @@ void AddFeaturesFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
-    m_map->setInitialViewpoint(Viewpoint(Envelope(-14400186.784644607, 2328358.2989760893, -7312972.106830405, 7377998.756918708, SpatialReference::webMercator())));
 
     // set map on the map view
     m_mapView->setMap(m_map);
+    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -62,10 +62,10 @@ void DeleteFeaturesFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
-    m_map->setInitialViewpoint(Viewpoint(Envelope(-14400186.784644607, 2328358.2989760893, -7312972.106830405, 7377998.756918708, SpatialReference::webMercator())));
 
     // set map on the map view
     m_mapView->setMap(m_map);
+    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -62,10 +62,10 @@ void DeleteFeaturesFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
+    m_map->setInitialViewpoint(Viewpoint(Point(-10800000, 4500000, SpatialReference(102100)), 3e7));
 
     // set map on the map view
     m_mapView->setMap(m_map);
-    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -65,10 +65,10 @@ void EditFeatureAttachments::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
-    m_map->setInitialViewpoint(Viewpoint(Envelope(-14400186.784644607, 2328358.2989760893, -7312972.106830405, 7377998.756918708, SpatialReference::webMercator())));
 
     // set map on the map view
     m_mapView->setMap(m_map);
+    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -65,10 +65,10 @@ void EditFeatureAttachments::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
+    m_map->setInitialViewpoint(Viewpoint(Point(-10800000, 4500000, SpatialReference(102100)), 3e7));
 
     // set map on the map view
     m_mapView->setMap(m_map);
-    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -62,10 +62,10 @@ void UpdateAttributesFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
+    m_map->setInitialViewpoint(Viewpoint(Point(-10800000, 4500000, SpatialReference(102100)), 3e7));
 
     // set map on the map view
     m_mapView->setMap(m_map);
-    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -62,10 +62,10 @@ void UpdateAttributesFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
-    m_map->setInitialViewpoint(Viewpoint(Envelope(-14400186.784644607, 2328358.2989760893, -7312972.106830405, 7377998.756918708, SpatialReference::webMercator())));
 
     // set map on the map view
     m_mapView->setMap(m_map);
+    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -60,10 +60,10 @@ void UpdateGeometryFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
-    m_map->setInitialViewpoint(Viewpoint(Envelope(-14400186.784644607, 2328358.2989760893, -7312972.106830405, 7377998.756918708, SpatialReference::webMercator())));
 
     // set map on the map view
     m_mapView->setMap(m_map);
+    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -60,10 +60,10 @@ void UpdateGeometryFeatureService::componentComplete()
 
     // create a Map by passing in the Basemap
     m_map = new Map(Basemap::streets(this), this);
+    m_map->setInitialViewpoint(Viewpoint(Point(-10800000, 4500000, SpatialReference(102100)), 3e7));
 
     // set map on the map view
     m_mapView->setMap(m_map);
-    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the ServiceFeatureTable
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -57,10 +57,10 @@ void FeatureLayerSelection::componentComplete()
 
     // Create a map using the streets basemap
     m_map = new Map(Basemap::streets(this), this);
-    m_map->setInitialViewpoint(Viewpoint(Envelope(-14400186.784644607, 2328358.2989760893, -7312972.106830405, 7377998.756918708, SpatialReference::webMercator())));
 
     // Set map to map view
     m_mapView->setMap(m_map);
+    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the feature table
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -57,10 +57,10 @@ void FeatureLayerSelection::componentComplete()
 
     // Create a map using the streets basemap
     m_map = new Map(Basemap::streets(this), this);
+    m_map->setInitialViewpoint(Viewpoint(Point(-10800000, 4500000, SpatialReference(102100)), 3e7));
 
     // Set map to map view
     m_mapView->setMap(m_map);
-    m_mapView->setViewpointCenter(Point(-10800000, 4500000, SpatialReference(102100)), 3e7);
 
     // create the feature table
     m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
@@ -37,16 +37,15 @@ Rectangle {
             BasemapStreets { }
 
             // set initial viewpoint to The United States
-            ViewpointExtent {
-                extent: Envelope {
-                    xMin: -14400186.784644607
-                    yMin: 2328358.2989760893
-                    xMax: -7312972.106830405
-                    yMax: 7377998.756918708
+            ViewpointCenter {
+                Point {
+                    x: -10800000
+                    y: 4500000
                     spatialReference: SpatialReference {
                         wkid: 102100
                     }
                 }
+                scale: 3e7
             }
 
             FeatureLayer {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -40,17 +40,15 @@ Rectangle {
             BasemapStreets { }
 
             // Set the initial viewpoint over The United States
-            ViewpointExtent {
-                id: viewPoint
-                extent: Envelope {
-                    xMin: -14400186.784644607
-                    yMin: 2328358.2989760893
-                    xMax: -7312972.106830405
-                    yMax: 7377998.756918708
+            ViewpointCenter {
+                Point {
+                    x: -10800000
+                    y: 4500000
                     spatialReference: SpatialReference {
                         wkid: 102100
                     }
                 }
+                scale: 3e7
             }
 
             FeatureLayer {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -41,17 +41,15 @@ Rectangle {
             // Set the initial basemap to Streets
             BasemapStreets { }
 
-            ViewpointExtent {
-                id: viewPoint
-                extent: Envelope {
-                    xMin: -14400186.784644607
-                    yMin: 2328358.2989760893
-                    xMax: -7312972.106830405
-                    yMax: 7377998.756918708
+            ViewpointCenter {
+                Point {
+                    x: -10800000
+                    y: 4500000
                     spatialReference: SpatialReference {
                         wkid: 102100
                     }
                 }
+                scale: 3e7
             }
 
             FeatureLayer {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -42,17 +42,15 @@ Rectangle {
             BasemapStreets { }
 
             // set viewpoint over The United States
-            ViewpointExtent {
-                id: viewPoint
-                extent: Envelope {
-                    xMin: -14400186.784644607
-                    yMin: 2328358.2989760893
-                    xMax: -7312972.106830405
-                    yMax: 7377998.756918708
+            ViewpointCenter {
+                Point {
+                    x: -10800000
+                    y: 4500000
                     spatialReference: SpatialReference {
                         wkid: 102100
                     }
                 }
+                scale: 3e7
             }
 
             FeatureLayer {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -39,17 +39,15 @@ Rectangle {
             // Set the initial basemap to Streets
             BasemapStreets { }
 
-            ViewpointExtent {
-                id: viewPoint
-                extent: Envelope {
-                    xMin: -14400186.784644607
-                    yMin: 2328358.2989760893
-                    xMax: -7312972.106830405
-                    yMax: 7377998.756918708
+            ViewpointCenter {
+                Point {
+                    x: -10800000
+                    y: 4500000
                     spatialReference: SpatialReference {
                         wkid: 102100
                     }
                 }
+                scale: 3e7
             }
 
             FeatureLayer {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
@@ -64,18 +64,17 @@ Rectangle {
             }
         }
 
-        // initial viewPoint
-        ViewpointExtent {
+        // initial viewpoint
+        ViewpointCenter {
             id: viewPoint
-            extent: Envelope {
-                xMin: -14400186.784644607
-                yMin: 2328358.2989760893
-                xMax: -7312972.106830405
-                yMax: 7377998.756918708
+            Point {
+                x: -10800000
+                y: 4500000
                 spatialReference: SpatialReference {
                     wkid: 102100
                 }
             }
+            scale: 3e7
         }
 
         onMouseClicked: {


### PR DESCRIPTION
changed the initial viewpoint of the editing samples to use a center point instead of an envelope for correct viewing on mobile devices. @ldanzinger please merge, thanks.