### PR TITLE
removing workaround for reverse geocode label issue

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
@@ -80,9 +80,6 @@ void MobileMap_SearchAndRoute::componentComplete()
 
     // set reverse geocoding parameters
     m_reverseGeocodeParameters.setMaxResults(1);
-    QStringList resultAttributeNames;
-    resultAttributeNames << "Address" << "Neighborhood" << "City" << "Region" << "Street";
-    m_reverseGeocodeParameters.setResultAttributeNames(resultAttributeNames);
 
     // identify and create MobileMapPackages using mmpk files in datapath
     createMobileMapPackages(0);
@@ -164,7 +161,7 @@ void MobileMap_SearchAndRoute::connectSignals()
             if (graphics[0]->symbol()->symbolType() == SymbolType::PictureMarkerSymbol)
             {
                 m_mapView->calloutData()->setGeoElement(graphics[0]);
-                m_mapView->calloutData()->setDetail(graphics[0]->attributes()->attributeValue("Match_addr").toString());
+                m_mapView->calloutData()->setDetail(graphics[0]->attributes()->attributeValue("AddressLabel").toString());
                 m_mapView->calloutData()->setVisible(true);
             }
             else if (graphics.count() > 1)
@@ -250,28 +247,7 @@ void MobileMap_SearchAndRoute::selectMap(int index)
             {
                 // create a blue pin graphic to display location
                 Graphic* bluePinGraphic = new Graphic(geocodeResults[0].displayLocation(), m_bluePinSymbol, this);
-
-                // create a label if GeocodeResult label comes back empty
-                if (geocodeResults[0].label() == "")
-                {
-                    QString formattedAddressString;
-                    QString address = geocodeResults[0].attributes()["Address"].toString();
-                    QString street = geocodeResults[0].attributes()["Street"].toString();
-                    QString city = geocodeResults[0].attributes()["City"].toString();
-                    QString region = geocodeResults[0].attributes()["Region"].toString();
-                    QString neighborhood = geocodeResults[0].attributes()["Neighborhood"].toString();
-
-                    if (address != "" && city != "" && region != "")
-                        formattedAddressString = address + " " + city + " " + region;
-                    if (address != "" && neighborhood != "")
-                        formattedAddressString = address + " " + neighborhood;
-                    if (street != "" && city != "")
-                        formattedAddressString = street + " " + city;
-
-                    bluePinGraphic->attributes()->insertAttribute("Match_addr", formattedAddressString);
-                }
-                else
-                    bluePinGraphic->attributes()->insertAttribute("Match_addr", geocodeResults[0].label());
+                bluePinGraphic->attributes()->insertAttribute("AddressLabel", geocodeResults[0].label());
 
                 m_stopsGraphicsOverlay->graphics()->append(bluePinGraphic);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
@@ -45,6 +45,7 @@ MobileMap_SearchAndRouteSample {
             Callout {
                 calloutData: mobileMapSearchRoute.calloutData
                 screenOffsetY: -19 * scaleFactor
+                accessoryButtonHidden: true
             }
 
             Rectangle {

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -90,7 +90,6 @@ void OfflineGeocode::componentComplete()
 
     // set geocode parameters
     m_geocodeParameters.setMinScore(75);
-    m_geocodeParameters.setResultAttributeNames(QStringList() << "Match_addr");
     m_geocodeParameters.setMaxResults(1);
     m_reverseGeocodeParameters.setMaxResults(1);
 
@@ -238,7 +237,7 @@ void OfflineGeocode::connectSignals()
         m_geocodeInProgress = false;
         emit geocodeInProgressChanged();
 
-        if(geocodeResults.length() > 0)
+        if (geocodeResults.length() > 0)
         {
             // dismiss no results notification
             m_noResults = false;

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.qml
@@ -40,6 +40,7 @@ OfflineGeocodeSample {
             id: callout
             calloutData: offlineGeocodeSample.calloutData
             screenOffsetY: -19 * scaleFactor
+            accessoryButtonHidden: true
         }
     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
@@ -55,6 +55,7 @@ Rectangle {
             id: callout
             calloutData: parent.calloutData
             screenOffsetY: -19 * scaleFactor
+            accessoryButtonHidden: true
         }
 
         // runs when app is geocoding
@@ -223,7 +224,7 @@ Rectangle {
                     // set callout's geoelement
                     mapView.calloutData.geoElement = identifyGraphicsOverlayResult.graphics[0].symbol.symbolType === Enums.SymbolTypePictureMarkerSymbol ?
                                 identifyGraphicsOverlayResult.graphics[0] : identifyGraphicsOverlayResult.graphics[1];
-                    mapView.calloutData.detail = mapView.calloutData.geoElement.attributes.attributeValue("Match_addr");
+                    mapView.calloutData.detail = mapView.calloutData.geoElement.attributes.attributeValue("AddressLabel");
                     callout.showCallout();
                 }
 
@@ -280,28 +281,7 @@ Rectangle {
                     // create a pin graphic to display location
                     var pinGraphic = ArcGISRuntimeEnvironment.createObject("Graphic", {geometry: currentLocatorTask.geocodeResults[0].displayLocation, symbol: bluePinSymbol});
                     stopsGraphicsOverlay.graphics.append(pinGraphic);
-
-                    // extract address from GeocodeResult and add as the an attribute of the graphic
-                    if (currentLocatorTask.geocodeResults[0].label === "") {
-                        var formattedAddressString;
-                        var address = currentLocatorTask.geocodeResults[0].attributes["Address"];
-                        var street = currentLocatorTask.geocodeResults[0].attributes["Street"];
-                        var city = currentLocatorTask.geocodeResults[0].attributes["City"];
-                        var region = currentLocatorTask.geocodeResults[0].attributes["Region"];
-                        var neighborhood = currentLocatorTask.geocodeResults[0].attributes["Region"];
-
-                        if (address !== "" && street !== "" && region !== "")
-                            formattedAddressString = address + " " + street + " " + region;
-                        if (address !== "" && neighborhood !== "")
-                            formattedAddressString = address + " " + neighborhood;
-                        if (street !== "" && city !== "")
-                            formattedAddressString = street + " " + city;
-
-                        pinGraphic.attributes.insertAttribute("Match_addr", formattedAddressString);
-                    }
-
-                    else
-                        pinGraphic.attributes.insertAttribute("Match_addr", currentLocatorTask.geocodeResults[0].label);
+                    pinGraphic.attributes.insertAttribute("AddressLabel", currentLocatorTask.geocodeResults[0].label);
 
                     if (currentLocatorTask !== null)
                         clearButton.visible = true;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.qml
@@ -93,6 +93,7 @@ Rectangle {
             id: callout
             calloutData: parent.calloutData
             screenOffsetY: -19 * scaleFactor
+            accessoryButtonHidden: true
         }
 
         // dismiss suggestions and no results notification on mouse press
@@ -163,7 +164,6 @@ Rectangle {
 
         GeocodeParameters {
             id: geocodeParams
-            resultAttributeNames: ["Match_addr"]
             minScore: 75
             maxResults: 1
         }


### PR DESCRIPTION
@michael-tims please review and merge. The underlying data had an issue, so that has been updated, and the workaround should be removed from the sample code. The label should now come back fully populated