### PR TITLE
Update tests to drop QSharedPointer usages.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -29,7 +29,6 @@
 #include <QUrl>
 #include <QMap>
 #include <QUuid>
-#include <QSharedPointer>
 #include <QVariant>
 #include <QMouseEvent>
 
@@ -103,12 +102,13 @@ void AddFeaturesFeatureService::connectSignals()
     });
 
     // connect to the applyEditsCompleted signal from the ServiceFeatureTable
-    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, QList<QSharedPointer<FeatureEditResult>> featureEditResults)
+    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, const QList<FeatureEditResult*>& featureEditResults)
     {
         if (featureEditResults.isEmpty())
             return;
+
         // obtain the first item in the list
-        QSharedPointer<FeatureEditResult> featureEditResult = featureEditResults.first();
+        FeatureEditResult* featureEditResult = featureEditResults.first();
         // check if there were errors, and if not, log the new object ID
         if (!featureEditResult->isCompletedWithErrors())
             qDebug() << "New Object ID is:" << featureEditResult->objectId();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -30,7 +30,6 @@
 #include "FeatureQueryResult.h"
 #include <QUrl>
 #include <QUuid>
-#include <QSharedPointer>
 #include <QMouseEvent>
 
 using namespace Esri::ArcGISRuntime;
@@ -130,7 +129,7 @@ void DeleteFeaturesFeatureService::connectSignals()
     });
 
     // connect to the selectedFeatures signal on the feature layer
-    connect(m_featureLayer, &FeatureLayer::selectFeaturesCompleted, this, [this](QUuid, QSharedPointer<FeatureQueryResult> featureQueryResult)
+    connect(m_featureLayer, &FeatureLayer::selectFeaturesCompleted, this, [this](QUuid, FeatureQueryResult* featureQueryResult)
     {
         FeatureIterator iter = featureQueryResult->iterator();
         if (iter.hasNext())
@@ -152,12 +151,12 @@ void DeleteFeaturesFeatureService::connectSignals()
     });
 
     // connect to the applyEditsCompleted signal from the ServiceFeatureTable
-    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, QList<QSharedPointer<FeatureEditResult>> featureEditResults)
+    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, const QList<FeatureEditResult*>& featureEditResults)
     {
         // obtain the first item in the list
-        QSharedPointer<FeatureEditResult> featureEditResult = featureEditResults.first();
+        FeatureEditResult* featureEditResult = featureEditResults.isEmpty() ? nullptr : featureEditResults.first();
         // check if there were errors, and if not, log the new object ID
-        if (!featureEditResult->isCompletedWithErrors())
+        if (featureEditResult && !featureEditResult->isCompletedWithErrors())
             qDebug() << "Successfully deleted Object ID:" << featureEditResult->objectId();
         else
             qDebug() << "Apply edits error.";

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -31,7 +31,6 @@
 #include "AttachmentListModel.h"
 #include <QUrl>
 #include <QUuid>
-#include <QSharedPointer>
 #include <QMouseEvent>
 #include <QFile>
 
@@ -129,9 +128,9 @@ void EditFeatureAttachments::connectSignals()
 
     // connect to the queryFeaturesCompleted signal on the feature table
     connect(m_featureTable, &FeatureTable::queryFeaturesCompleted,
-            this, [this](QUuid, QSharedPointer<FeatureQueryResult> featureQueryResult)
+            this, [this](QUuid, FeatureQueryResult* featureQueryResult)
     {
-        if (featureQueryResult->iterator().hasNext())
+        if (featureQueryResult && featureQueryResult->iterator().hasNext())
         {
             // first delete if not nullptr
             if (m_selectedFeature != nullptr)
@@ -146,7 +145,7 @@ void EditFeatureAttachments::connectSignals()
 
             // get the number of attachments
             connect(m_selectedFeature->attachments(), &AttachmentListModel::fetchAttachmentsCompleted,
-                    this, [this](QUuid, const QList<QSharedPointer<Esri::ArcGISRuntime::Attachment>>)
+                    this, [this](QUuid, const QList<Attachment*>&)
             {
                 m_attachmentCount = m_selectedFeature->attachments()->rowCount();
                 emit attachmentCountChanged();
@@ -156,12 +155,12 @@ void EditFeatureAttachments::connectSignals()
 
     // connect to the applyEditsCompleted signal from the ServiceFeatureTable
     connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted,
-            this, [this](QUuid, QList<QSharedPointer<FeatureEditResult>> featureEditResults)
+            this, [this](QUuid, const QList<FeatureEditResult*>& featureEditResults)
     {
         if (featureEditResults.length() > 0)
         {
             // obtain the first item in the list
-            QSharedPointer<FeatureEditResult> featureEditResult = featureEditResults.first();
+            FeatureEditResult* featureEditResult = featureEditResults.first();
             // check if there were errors
             if (!featureEditResult->isCompletedWithErrors())
             {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -30,7 +30,6 @@
 #include "FeatureQueryResult.h"
 #include <QUrl>
 #include <QUuid>
-#include <QSharedPointer>
 #include <QMouseEvent>
 
 using namespace Esri::ArcGISRuntime;
@@ -123,9 +122,9 @@ void UpdateAttributesFeatureService::connectSignals()
     });
 
     // connect to the queryFeaturesCompleted signal on the feature table
-    connect(m_featureTable, &FeatureTable::queryFeaturesCompleted, this, [this](QUuid, QSharedPointer<FeatureQueryResult> featureQueryResult)
+    connect(m_featureTable, &FeatureTable::queryFeaturesCompleted, this, [this](QUuid, FeatureQueryResult* featureQueryResult)
     {
-        if (featureQueryResult->iterator().hasNext())
+        if (featureQueryResult && featureQueryResult->iterator().hasNext())
         {
             // first delete if not nullptr
             if (m_selectedFeature != nullptr)
@@ -148,7 +147,7 @@ void UpdateAttributesFeatureService::connectSignals()
     });
 
     // connect to the applyEditsCompleted signal from the ServiceFeatureTable
-    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, QList<QSharedPointer<FeatureEditResult>> featureEditResults)
+    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, const QList<FeatureEditResult*>& featureEditResults)
     {
         // check if result list is not empty
         if (!featureEditResults.isEmpty())

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -29,7 +29,6 @@
 #include "GeoElement.h"
 #include <QUrl>
 #include <QUuid>
-#include <QSharedPointer>
 #include <QMouseEvent>
 #include <QList>
 
@@ -139,12 +138,12 @@ void UpdateGeometryFeatureService::connectSignals()
     });
 
     // connect to the applyEditsCompleted signal from the ServiceFeatureTable
-    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, QList<QSharedPointer<FeatureEditResult>> featureEditResults)
+    connect(m_featureTable, &ServiceFeatureTable::applyEditsCompleted, this, [this](QUuid, const QList<FeatureEditResult*>& featureEditResults)
     {
         // obtain the first item in the list
-        QSharedPointer<FeatureEditResult> featureEditResult = featureEditResults.first();
+        FeatureEditResult* featureEditResult = featureEditResults.isEmpty() ? nullptr : featureEditResults.first();
         // check if there were errors, and if not, log the new object ID
-        if (!featureEditResult->isCompletedWithErrors())
+        if (featureEditResult && !featureEditResult->isCompletedWithErrors())
             qDebug() << "Successfully updated geometry for Object ID:" << featureEditResult->objectId();
         else
             qDebug() << "Apply edits error.";

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
@@ -90,9 +90,9 @@ void FeatureLayerQuery::componentComplete()
 void FeatureLayerQuery::connectSignals()
 {
     // iterate over the query results once the query is done
-    connect(m_featureTable, &ServiceFeatureTable::queryFeaturesCompleted, this, [this](QUuid, QSharedPointer<Esri::ArcGISRuntime::FeatureQueryResult> queryResult)
+    connect(m_featureTable, &ServiceFeatureTable::queryFeaturesCompleted, this, [this](QUuid, FeatureQueryResult* queryResult)
     {
-        if (!queryResult->iterator().hasNext())
+        if (queryResult && !queryResult->iterator().hasNext())
         {
             m_queryResultsCount = 0;
             emit queryResultsCountChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.cpp
@@ -57,11 +57,10 @@ OpenExistingMap::OpenExistingMap(QWidget* parent) :
       {
         // create a portal item with the item id
         QString portalId = m_portalIds.value(m_inputDialog->textValue() );
-        if( portalId.isEmpty())
+        if(portalId.isEmpty())
             return;
 
-        PortalItem portalItem;
-        portalItem.setUrl(QUrl("http://arcgis.com/sharing/rest/content/items/" + portalId));
+        PortalItem* portalItem = new PortalItem(QUrl("http://arcgis.com/sharing/rest/content/items/" + portalId), this);
 
         // create a new map from the portal item
         Map* map = new Map(portalItem, this);
@@ -83,7 +82,7 @@ void OpenExistingMap::createPortalMaps()
 {
     m_portalIds.insert("Housing with Mortgages", "2d6fa24b357d427f9c737774e7b0f977");
     m_portalIds.insert("USA Tapestry Segmentation", "01f052c8995e4b9e889d73c3e210ebe3");
-    m_portalIds.insert("Geology of United States", "74a8f6645ab44c4f82d537f1aa0e375d");
+    m_portalIds.insert("Geology of United States", "92ad152b9da94dee89b9e387dfe21acd");
 }
 
 void OpenExistingMap::createUi()


### PR DESCRIPTION
Assign to @michael-tims 

Update the samples for the new API changes. We no longer return a QSharedPointer which will be easier for users to use.

I ran all updated samples and found no issues.

`OpenExistingMap` in the widgets test app was out of date. I fixed it too.

Merging to v.next.