### PR TITLE
James/scale padding

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.cpp
@@ -73,7 +73,7 @@ void ChangeViewpoint::changeViewpoint(QString viewpoint)
     else if (viewpoint == "Geometry and padding")
     {
         Envelope envBeijing(116.380, 39.920, 116.400, 39.940, SpatialReference(4236));
-        m_mapView->setViewpointGeometry(envBeijing, 200);
+        m_mapView->setViewpointGeometry(envBeijing, 200 * screenRatio());
     }
     else if (viewpoint == "Rotation")
     {
@@ -95,4 +95,11 @@ void ChangeViewpoint::changeViewpoint(QString viewpoint)
         m_mapView->setViewpointAnimated(vpSpring, 4.0, AnimationCurve::EaseInOutCubic);
         //! [set viewpoint api snippet]
     }
+}
+
+double ChangeViewpoint::screenRatio() const
+{
+    const double width = static_cast<double>(m_mapView->width());
+    const double height = static_cast<double>(m_mapView->height());
+    return height > width ? width / height : height / width;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.cpp
@@ -99,7 +99,7 @@ void ChangeViewpoint::changeViewpoint(QString viewpoint)
 
 double ChangeViewpoint::screenRatio() const
 {
-    const double width = static_cast<double>(m_mapView->width());
-    const double height = static_cast<double>(m_mapView->height());
+    const double width = static_cast<double>(m_mapView->mapWidth());
+    const double height = static_cast<double>(m_mapView->mapHeight());
     return height > width ? width / height : height / width;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.h
@@ -40,6 +40,8 @@ public:
     Q_INVOKABLE void changeViewpoint(QString viewpoint);
 
 private:
+    double screenRatio() const;
+
     Esri::ArcGISRuntime::Map* m_map;
     Esri::ArcGISRuntime::MapQuickView* m_mapView;
     int m_rotationValue;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.cpp
@@ -116,7 +116,7 @@ void ChangeViewpoint::changeToNewViewpoint(int index)
 
 double ChangeViewpoint::screenRatio() const
 {
-    const double width = static_cast<double>(m_mapView->width());
-    const double height = static_cast<double>(m_mapView->height());
+    const double width = static_cast<double>(m_mapView->mapWidth());
+    const double height = static_cast<double>(m_mapView->mapHeight());
     return height > width ? width / height : height / width;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.cpp
@@ -96,7 +96,7 @@ void ChangeViewpoint::changeToNewViewpoint(int index)
         m_mapView->setViewpointGeometry(envBeijing);
         break;
     case 3: // "Geometry and padding"
-        m_mapView->setViewpointGeometry(envBeijing, 200);
+        m_mapView->setViewpointGeometry(envBeijing, 200 * screenRatio());
         break;
     case 4: // "Rotation"
         m_rotationValue = (m_rotationValue + 45) % 360;
@@ -112,4 +112,11 @@ void ChangeViewpoint::changeToNewViewpoint(int index)
         m_mapView->setViewpointAnimated(vpSpring, 4.0, AnimationCurve::EaseInOutCubic);
         break;
     }
+}
+
+double ChangeViewpoint::screenRatio() const
+{
+    const double width = static_cast<double>(m_mapView->width());
+    const double height = static_cast<double>(m_mapView->height());
+    return height > width ? width / height : height / width;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.h
@@ -40,6 +40,8 @@ private slots:
   void changeToNewViewpoint(int);
 
 private:
+  double screenRatio() const;
+
   Esri::ArcGISRuntime::Map* m_map;
   Esri::ArcGISRuntime::MapGraphicsView* m_mapView;
   QComboBox* m_viewpointCombo;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -90,7 +90,7 @@ Rectangle {
                 break;
             case "Geometry and padding":
                 envBuilder.setXY(116.380, 39.920, 116.400, 39.940); // Beijing
-                mv.setViewpointGeometryAndPadding(envBuilder.geometry, 200);
+                mv.setViewpointGeometryAndPadding(envBuilder.geometry, 200 * screenRatio());
                 break;
             case "Rotation":
                 rotationValue = (rotationValue + 45.0) % 360.0;
@@ -107,6 +107,12 @@ Rectangle {
                 break;
             }
         }
+    }
+
+    function screenRatio() {
+        var width = mv.mapWidth;
+        var height = mv.mapHeight;
+        return height > width ? width / height : height / width;
     }
 
     // Neatline rectangle


### PR DESCRIPTION
Assign to @michael-tims. Please review.

This wasn't working on iPhone. It's because as the screen dimensions become more rectangular than square (either way) the padding is amplified. This is a quick a dirty formula to scale the padding value so the "Geometry and Padding" option will always work no matter the screen dimensions.