### PR TITLE
Use sync version of setViewpointCamera

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.cpp
@@ -33,7 +33,6 @@
 #include "SimpleMarkerSceneSymbol.h"
 #include "SimpleRenderer.h"
 #include "SpatialReference.h"
-#include "TaskWatcher.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -52,19 +51,16 @@ struct Animate3DSymbols::CameraHandler
 
   void setZoomDist(double zoomDist)
   {
-    m_camWatcher.cancel();
     m_zoomDist = zoomDist;
   }
 
   void setAngle(double angle)
   {
-    m_camWatcher.cancel();
     m_angle = angle;
   }
 
   void setIntervalMs(int intervalMs)
   {
-    m_camWatcher.cancel();
     m_intervalMs = intervalMs;
   }
 
@@ -85,7 +81,6 @@ struct Animate3DSymbols::CameraHandler
     return res;
   }
 
-  TaskWatcher m_camWatcher;
   float m_intervalMs = 0.0;
   double m_zoomDist = 0.0;
   double m_angle = 90.0;
@@ -191,19 +186,10 @@ void Animate3DSymbols::animate()
 
     if (m_following)
     {
-      if (!m_camHandler->m_camWatcher.isDone())
-        m_sceneView->update();
-      else
-      {
-        // move the camera to follow the 3d model
-        Camera camera(dp.m_pos, m_camHandler->m_zoomDist, dp.m_heading, m_camHandler->m_angle, dp.m_roll);
-        m_camHandler->m_camWatcher = m_sceneView->setViewpointCamera(camera, m_camHandler->animationDurationSeconds());
-      }
+      // move the camera to follow the 3d model
+      Camera camera(dp.m_pos, m_camHandler->m_zoomDist, dp.m_heading, m_camHandler->m_angle, dp.m_roll);
+      m_sceneView->setViewpointCameraAndWait(camera);
 
-    }
-    else
-    {
-      m_sceneView->update();
     }
 
     // move 3D graphic to the new position
@@ -221,7 +207,6 @@ void Animate3DSymbols::animate()
 void Animate3DSymbols::changeMission(const QString &missionNameStr)
 {
   setMissionFrame(0);
-  m_camHandler->m_camWatcher.cancel();
 
   // read the mission data from the samples .csv files
   QString formattedname = missionNameStr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.cpp
@@ -64,23 +64,6 @@ struct Animate3DSymbols::CameraHandler
     m_intervalMs = intervalMs;
   }
 
-  float animationDurationSeconds() const
-  {
-    // the faster the animation, the shorter duration we want for our camera animations (range 10-200)
-    float res = (220 - m_intervalMs) / 200.0f;
-    res *= 10.0f;
-
-    // slow down camera animation when the camera is zoomed right in (range 10-500)
-    float zoomFactor = (520 - m_zoomDist) / 500.0f;
-    res += zoomFactor;
-
-    // for very steep angles the camera needs to be quick enough to keep the model in view
-    if( m_angle > 135 || m_angle < 45)
-       res = 0.0f;
-
-    return res;
-  }
-
   float m_intervalMs = 0.0;
   double m_zoomDist = 0.0;
   double m_angle = 90.0;

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.h
@@ -28,7 +28,6 @@ namespace Esri
     class MapQuickView;
     class ModelSceneSymbol;
     class SceneQuickView;
-    class TaskWatcher;
   }
 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GraphicsOverlay_DictionaryRenderer_3D/GraphicsOverlay_DictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GraphicsOverlay_DictionaryRenderer_3D/GraphicsOverlay_DictionaryRenderer_3D.qml
@@ -145,7 +145,7 @@ Rectangle {
                         distance: 15000
                     });
                     camera = camera.rotateAround(bbox.extent.center, 0, 70, 0);
-                    sceneView.setViewpointCameraAndSeconds(camera, 0);
+                    sceneView.setViewpointCameraAndWait(camera);
                 }
                 progressBar_loading.visible = false;
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -40,7 +40,6 @@ Rectangle {
     property string attrFormat: "[%1]"
 
     property var graphic3d;
-    property bool camReady: true;
 
     /**
      * Create SceneView that contains a Scene with the Imagery Basemap
@@ -97,8 +96,6 @@ Rectangle {
             onPressed: mouse.accepted = followButton.checked
             onWheel: wheel.accepted = followButton.checked
         }
-
-        onSetViewpointCameraCompleted: camReady = true;
     }
 
     ListModel {
@@ -389,8 +386,6 @@ Rectangle {
 
             if (followButton.checked)
                 setCamera(newPos, missionData.heading);
-            else
-                sceneView.update();
         }
 
         nextFrameRequested();
@@ -431,13 +426,10 @@ Rectangle {
             });
 
         if (!playButton.checked)
-            sceneView.setViewpointCameraAndSeconds(cam, 0);
-        else if (camReady) {
-            camReady = false;
-            sceneView.setViewpointCameraAndSeconds(cam, getCameraDuration());
+            sceneView.setViewpointCameraAndWait(cam);
+        else {
+            sceneView.setViewpointCameraAndWait(cam);
         }
-        else
-            sceneView.update();
     }
 
     function getCameraDuration() {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -431,20 +431,4 @@ Rectangle {
             sceneView.setViewpointCameraAndWait(cam);
         }
     }
-
-    function getCameraDuration() {
-        // the faster the animation, the shorter duration we want for our camera animations (range 10-200)
-        var res = ((animationSpeed.maximumValue + animationSpeed.maximumValue) - animationSpeed.value) / animationSpeed.maximumValue;
-        res *= 5.0;
-
-        // slow down camera animation when the camera is zoomed right in (range 10-500)
-        var zoomFactor = (cameraDistance.value) / cameraDistance.maximumValue;
-        res += zoomFactor;
-
-        // for very steep angles the camera needs to be quick enough to keep the model in view
-        if( cameraAngle.value > 135 || cameraAngle.value < 45)
-           res = 0.0;
-
-        return res;
-    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
@@ -46,7 +46,7 @@ Rectangle {
 
         Component.onCompleted: {
             // set viewpoint to the specified camera
-            setViewpointCameraAndSeconds(camera, 0);
+            setViewpointCameraAndWait(camera);
         }
     }
     //! [create the scene with a basemap and surface]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
@@ -61,7 +61,7 @@ Rectangle {
 
         Component.onCompleted: {
             // set viewpoint to the specified camera
-            setViewpointCameraAndSeconds(camera, 0)
+            setViewpointCameraAndWait(camera)
         }
 
         GraphicsOverlay {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
@@ -66,7 +66,7 @@ Rectangle {
 
         Component.onCompleted: {
             // set viewpoint to the specified camera
-            setViewpointCameraAndSeconds(camera, 0);
+            setViewpointCameraAndWait(camera);
             createGraphics();
         }
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
@@ -57,7 +57,7 @@ Rectangle {
 
         Component.onCompleted: {
             // set viewpoint to the specified camera
-            setViewpointCameraAndSeconds(camera, 0);
+            setViewpointCameraAndWait(camera);
             addSymbols();
         }
     }


### PR DESCRIPTION
Assign to @JamesMBallard 

Call the synchronous method setViewpointCameraAndWait for 3D samples when appropriate.  Changed up the "Animate 3D Symbols" sample to use the sync method instead of the async method.