### PR TITLE
Do not recreate graphics when mission changes

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.h
@@ -88,11 +88,9 @@ signals:
   void nextFrameRequested();
 
 private:
-  void createModel3d();
   void createModel2d(Esri::ArcGISRuntime::GraphicsOverlay* mapOverlay);
   void createRoute2d(Esri::ArcGISRuntime::GraphicsOverlay* mapOverlay);
   void createGraphic3D();
-  void clearGraphic3D();
 
   static const QString HEADING;
   static const QString ROLL;


### PR DESCRIPTION
Assign to @ldanzinger 

Updated sample so it doesn't recreate graphics each time the mission changes.  Instead it just updates the graphics' geometries and attributes.  Also cleaned up some code a bit in the process and got the 2D symbol on the overview map working.