### PR TITLE
Add missing closing Legal tag.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.h
@@ -10,7 +10,7 @@
 // notice and use restrictions.
 //
 // See the Sample code usage restrictions document for further information.
-//
+// [Legal]
 
 #ifndef ADDITEMSTOPORTAL_H
 #define ADDITEMSTOPORTAL_H


### PR DESCRIPTION
This missing was causing the snippet extraction output file to be empty. 

@ldanzinger - Please review and merge. Thank you. 