### PR TITLE
The additional message is more useful in these cases.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.cpp
@@ -78,7 +78,7 @@ void AnalyzeHotspots::executeTaskWithDates(const QString& fromDate, const QStrin
     switch (job->jobStatus())
     {
       case JobStatus::Failed:
-        emit displayErrorDialog("Geoprocessing Task failed", !job->error().isEmpty() ? job->error().message() : "Unknown error.");
+        emit displayErrorDialog("Geoprocessing Task failed", !job->error().isEmpty() ? job->error().additionalMessage() : "Unknown error.");
         m_jobInProgress = false;
         m_jobStatus = "Job failed";
         break;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -94,7 +94,7 @@ Rectangle {
         function showErrorDialog(error) {
             messageDialog.title = "Error";
             messageDialog.text = "Executing geoprocessing failed.";
-            messageDialog.detailedText = error ? error.message : "Unknown error";
+            messageDialog.detailedText = error ? error.additionalMessage : "Unknown error";
             messageDialog.open();
         }
     }


### PR DESCRIPTION
Use a more user-friendly error message in case the job fails.