### PR TITLE
Nand6028/use layer view state status flags

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.cpp
@@ -118,15 +118,15 @@ void DisplayLayerViewDrawStatus::connectSignals()
     m_layerNames[rIndex] = layer->name();
 
     // use insert to replace values mapped to layer name
-    if (viewState.status() == Esri::ArcGISRuntime::LayerViewStatus::Active)
+    if (viewState.statusFlags() & Esri::ArcGISRuntime::LayerViewStatus::Active)
       m_layerViewStates[rIndex] = QString("Active");
-    else if (viewState.status() == Esri::ArcGISRuntime::LayerViewStatus::NotVisible)
+    else if (viewState.statusFlags() & Esri::ArcGISRuntime::LayerViewStatus::NotVisible)
       m_layerViewStates[rIndex] = QString("Not Visible");
-    else if (viewState.status() == Esri::ArcGISRuntime::LayerViewStatus::OutOfScale)
+    else if (viewState.statusFlags() & Esri::ArcGISRuntime::LayerViewStatus::OutOfScale)
       m_layerViewStates[rIndex] = QString("Out of Scale");
-    else if (viewState.status() == Esri::ArcGISRuntime::LayerViewStatus::Loading)
+    else if (viewState.statusFlags() & Esri::ArcGISRuntime::LayerViewStatus::Loading)
       m_layerViewStates[rIndex] = QString("Loading");
-    else if (viewState.status() == Esri::ArcGISRuntime::LayerViewStatus::Error)
+    else if (viewState.statusFlags() & Esri::ArcGISRuntime::LayerViewStatus::Error)
       m_layerViewStates[rIndex] = QString("Error");
     else
       m_layerViewStates[rIndex] = QString("Unknown");

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.qml
@@ -85,20 +85,19 @@ Rectangle {
         }
 
         function viewStatusString(layerViewState) {
-            switch(layerViewState.status) {
-            case Enums.LayerViewStatusActive:
+            var stateFlag = layerViewState.statusFlags;
+            if (stateFlag & Enums.LayerViewStatusActive)
                 return "Active";
-            case Enums.LayerViewStatusNotVisible:
+            if (stateFlag & Enums.LayerViewStatusNotVisible)
                 return "Not Visible";
-            case Enums.LayerViewStatusOutOfScale:
-                return "Out of Scale";
-            case Enums.LayerViewStatusLoading:
+            if (stateFlag & Enums.LayerViewStatusOutOfScale)
+                return "Out of scale";
+            if (stateFlag & Enums.LayerViewStatusLoading)
                 return "Loading";
-            case Enums.LayerViewStatusError:
+            if (stateFlag & Enums.LayerViewStatusError)
                 return "Error";
-            default:
-                return "Unknown";
-            }
+
+            return "Unknown";
         }
 
         function getindex(layer) {


### PR DESCRIPTION
Assigned to @ldanzinger 

Updating the sample to use statusFlags instead of the obsolete status property.