### PR TITLE
A couple sample changes for anchoring to the attributionTop property

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
@@ -78,8 +78,8 @@ FindRouteSample {
             property bool pressed: false
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                bottom: parent.bottom
-                bottomMargin: 25 * scaleFactor
+                bottom: parent.attributionTop
+                bottomMargin: 5 * scaleFactor
             }
 
             width: 130 * scaleFactor

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
@@ -62,6 +62,7 @@ FindRouteSample {
 
     // add a mapView component
     MapView {
+        id: mapView
         anchors.fill: parent
         objectName: "mapView"
 
@@ -78,7 +79,7 @@ FindRouteSample {
             property bool pressed: false
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                bottom: parent.attributionTop
+                bottom: mapView.attributionTop
                 bottomMargin: 5 * scaleFactor
             }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -33,6 +33,43 @@ ServiceAreaSample {
     MapView {
         anchors.fill: parent
         objectName: "mapView"
+
+        Rectangle {
+            anchors.centerIn: solveRow
+            radius: 8 * scaleFactor
+            height: solveRow.height + (16 * scaleFactor)
+            width: solveRow.width + (16 * scaleFactor)
+            color: "lightgrey"
+            border.color: "darkgrey"
+            border.width: 2 * scaleFactor
+            opacity: 0.75
+        }
+
+        Row {
+            id: solveRow
+            anchors {
+                bottom: parent.attributionTop
+                horizontalCenter: parent.horizontalCenter
+                margins: 15 * scaleFactor
+            }
+            spacing: 8 * scaleFactor
+
+            Button {
+                id: serviceAreasButton
+                text: "Solve"
+                enabled: !busy
+
+                onClicked: solveServiceArea();
+            }
+
+            Button {
+                text: "Reset"
+                enabled: !busy
+                onClicked: {
+                    reset();
+                }
+            }
+        }
     }
 
     Rectangle {
@@ -76,43 +113,6 @@ ServiceAreaSample {
 
             onClicked: {
                 newBarrier();
-            }
-        }
-    }
-
-    Rectangle {
-        anchors.centerIn: solveRow
-        radius: 8 * scaleFactor
-        height: solveRow.height + (16 * scaleFactor)
-        width: solveRow.width + (16 * scaleFactor)
-        color: "lightgrey"
-        border.color: "darkgrey"
-        border.width: 2 * scaleFactor
-        opacity: 0.75
-    }
-
-    Row {
-        id: solveRow
-        anchors {
-            bottom: parent.bottom
-            horizontalCenter: parent.horizontalCenter
-            margins: 32 * scaleFactor
-        }
-        spacing: 8 * scaleFactor
-
-        Button {
-            id: serviceAreasButton
-            text: "Solve"
-            enabled: !busy
-
-            onClicked: solveServiceArea();
-        }
-
-        Button {
-            text: "Reset"
-            enabled: !busy
-            onClicked: {
-                reset();
             }
         }
     }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -31,6 +31,7 @@ ServiceAreaSample {
 
     // add a mapView component
     MapView {
+        id: mapView
         anchors.fill: parent
         objectName: "mapView"
 
@@ -48,7 +49,7 @@ ServiceAreaSample {
         Row {
             id: solveRow
             anchors {
-                bottom: parent.attributionTop
+                bottom: mapView.attributionTop
                 horizontalCenter: parent.horizontalCenter
                 margins: 15 * scaleFactor
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
@@ -64,6 +64,7 @@ Rectangle {
 
     // Create MapView that contains a Map with the Topographic Basemap
     MapView {
+        id: mapView
         anchors.fill: parent
 
         // set the transform to animate showing the direction window
@@ -116,7 +117,7 @@ Rectangle {
             property bool pressed: false
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                bottom: parent.attributionTop
+                bottom: mapView.attributionTop
                 bottomMargin: 5 * scaleFactor
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
@@ -116,8 +116,8 @@ Rectangle {
             property bool pressed: false
             anchors {
                 horizontalCenter: parent.horizontalCenter
-                bottom: parent.bottom
-                bottomMargin: 25 * scaleFactor
+                bottom: parent.attributionTop
+                bottomMargin: 5 * scaleFactor
             }
 
             width: 130 * scaleFactor

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -107,6 +107,47 @@ Rectangle {
                 handleBarrierPoint(mouse.mapPoint);
             }
         }
+
+        Rectangle {
+            anchors.centerIn: solveRow
+            radius: 8 * scaleFactor
+            height: solveRow.height + (16 * scaleFactor)
+            width: solveRow.width + (16 * scaleFactor)
+            color: "lightgrey"
+            border.color: "darkgrey"
+            border.width: 2 * scaleFactor
+            opacity: 0.75
+        }
+
+        Row {
+            id: solveRow
+            anchors {
+                bottom: parent.attributionTop
+                horizontalCenter: parent.horizontalCenter
+                margins: 15 * scaleFactor
+            }
+
+            spacing: 8 * scaleFactor
+
+            Button {
+                id: serviceAreasButton
+                text: "Solve"
+                enabled: !busy
+
+                onClicked: startSolveTask();
+            }
+
+            Button {
+                text: "Reset"
+                enabled: !busy
+                onClicked: {
+                    facilitiesOverlay.graphics.clear();
+                    barriersOverlay.graphics.clear();
+                    areasOverlay.graphics.clear();
+                    barrierBuilder = null;
+                }
+            }
+        }
     }
 
     ServiceAreaTask {
@@ -197,47 +238,6 @@ Rectangle {
                 barrierBuilder = null;
                 createBarrierBuilder();
                 addBarrierGraphic();
-            }
-        }
-    }
-
-    Rectangle {
-        anchors.centerIn: solveRow
-        radius: 8 * scaleFactor
-        height: solveRow.height + (16 * scaleFactor)
-        width: solveRow.width + (16 * scaleFactor)
-        color: "lightgrey"
-        border.color: "darkgrey"
-        border.width: 2 * scaleFactor
-        opacity: 0.75
-    }
-
-    Row {
-        id: solveRow
-        anchors {
-            bottom: parent.bottom
-            horizontalCenter: parent.horizontalCenter
-            margins: 32 * scaleFactor
-        }
-
-        spacing: 8 * scaleFactor
-
-        Button {
-            id: serviceAreasButton
-            text: "Solve"
-            enabled: !busy
-
-            onClicked: startSolveTask();
-        }
-
-        Button {
-            text: "Reset"
-            enabled: !busy
-            onClicked: {
-                facilitiesOverlay.graphics.clear();
-                barriersOverlay.graphics.clear();
-                areasOverlay.graphics.clear();
-                barrierBuilder = null;
             }
         }
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -122,7 +122,7 @@ Rectangle {
         Row {
             id: solveRow
             anchors {
-                bottom: parent.attributionTop
+                bottom: mapView.attributionTop
                 horizontalCenter: parent.horizontalCenter
                 margins: 15 * scaleFactor
             }


### PR DESCRIPTION
Assign to @JamesMBallard 

Updating a couple samples to take advantage of the attributionTop anchor line property so that controls are always anchored appropriately to the bottom of the Geo View, never overlapping the attribution text.