### PR TITLE
Update to 100.2

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.pro
@@ -4,7 +4,7 @@ QT += core gui opengl xml network positioning sensors
 QT += qml quick
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 HEADERS += OAuthRedirectExample.h \

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.md
@@ -95,7 +95,7 @@ You may need to adjust the Qt Postlink step created by QtCreator to point to the
 E.g. Go to Build Phases/Qt PostLink and edit the script to look something like:
 
 `
-install_name_tool -change libEsriCommonQt.dylib "~/ArcGIS_SDKs/Qt100.1/sdk/macOS/x64/lib/libEsriCommonQt.dylib" Release/OAuthRedirectExample.app/Contents/MacOS/OAuthRedirectExample
+install_name_tool -change libEsriCommonQt.dylib "~/ArcGIS_SDKs/Qt100.2/sdk/macOS/x64/lib/libEsriCommonQt.dylib" Release/OAuthRedirectExample.app/Contents/MacOS/OAuthRedirectExample
 `
 
 Next go to Info/URL Types and add a new URL type with Identifier and URL Schemes set to the custom URL scheme you set up for your App.

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/windows_deployment.bat
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/windows_deployment.bat
@@ -6,7 +6,7 @@ SET "QT_KIT=C:\Qt\5.6\msvc2015_64"
 SET "DIR=%~dp0"
 SET "BUILD_TYPE=release"
 SET "BUILD_DIR=%DIR%..\build-OAuthRedirectExample-Desktop_Qt_5_6_2_MSVC2015_64bit-Release\%BUILD_TYPE%"
-SET "ARCGIS_SDK_DIR=C:\Program Files (x86)\ArcGIS SDKs\Qt100.1\sdk\windows\%ARCH%\bin\%BUILD_TYPE%"
+SET "ARCGIS_SDK_DIR=C:\Program Files (x86)\ArcGIS SDKs\Qt100.2\sdk\windows\%ARCH%\bin\%BUILD_TYPE%"
 
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %VC_ARCH%
 call %QT_KIT%\bin\windeployqt.exe %BUILD_DIR%\OAuthRedirectExample.exe --qmldir %DIR% -sensors -positioning

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLegend/ShowLegend.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLegend/ShowLegend.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = ListRelatedFeatures
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = BlendRasterLayer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = FeatureCollectionLayerQuery
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = OSM_Layer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RasterColormapRenderer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RasterFunctionFile
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RasterFunctionService
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RasterLayerService
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RasterRenderingRule
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RgbRenderer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = RasterStretchRenderer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = WMTS_Layer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = Web_Tiled_Layer
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenExistingMap/OpenExistingMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenExistingMap/OpenExistingMap.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = ClosestFacility
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.pro
@@ -26,7 +26,7 @@ QT += opengl qml quick positioning sensors
 TEMPLATE = app
 TARGET = ServiceArea
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/SurfacePlacement.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/SurfacePlacement.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
@@ -23,7 +23,7 @@ CONFIG += c++11
 
 QT += opengl qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/GORenderers.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/GORenderers.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/DisplayMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/DisplayMap.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/MapLoaded.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/MapLoaded.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/MapRotation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/MapRotation.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.pro
@@ -21,7 +21,7 @@ CONFIG += c++11
 
 QT += core gui opengl xml network positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 win32:CONFIG += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 qtHaveModule(webengine) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GORenderers/GORenderers.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GORenderers/GORenderers.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GO_DictionaryRenderer/GO_DictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GO_DictionaryRenderer/GO_DictionaryRenderer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GO_DictionaryRenderer_3D/GO_DictionaryRenderer_3D.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GO_DictionaryRenderer_3D/GO_DictionaryRenderer_3D.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/ShowCallout.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/ShowCallout.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLegend/ShowLegend.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLegend/ShowLegend.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/FeatureLayer_DefinitionExpression.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/FeatureLayer_DefinitionExpression.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/FeatureLayer_DictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/FeatureLayer_DictionaryRenderer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/FeatureLayer_FeatureService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/FeatureLayer_FeatureService.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/FeatureLayer_Geodatabase.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/FeatureLayer_Geodatabase.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/GenerateGeodatabase.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/GenerateGeodatabase.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/ServiceFeatureTable_Cache.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/ServiceFeatureTable_Cache.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/ServiceFeatureTable_NoCache.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/ServiceFeatureTable_NoCache.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/RasterLayerFile.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/RasterLayerFile.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/RasterLayerService.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/RasterLayerService.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/WMTS_Layer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/WMTS_Layer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/DisplayMap.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/DisplayMap.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/MapLoaded.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/MapLoaded.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/MapRotation.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/MapRotation.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenExistingMap/OpenExistingMap.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenExistingMap/OpenExistingMap.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/ShowMagnifier.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/ShowMagnifier.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/ClosestFacility.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/ClosestFacility.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.pro
@@ -19,7 +19,7 @@ QT += qml quick positioning sensors
 
 CONFIG += c++11
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/SurfacePlacement.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/SurfacePlacement.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/FindAddress.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/FindAddress.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick sensors positioning
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
@@ -18,7 +18,7 @@ TEMPLATE = app
 
 QT += qml quick positioning sensors
 
-ARCGIS_RUNTIME_VERSION = 100.1
+ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++11


### PR DESCRIPTION
Assign to @lsmallwood 

Pretty much just updating the `ARCGIS_RUNTIME_VERSION` variable.  The QML imports were already updated to 100.2 in a prior PR.

Toolkit will remain 100.1 until we update it later.

**Please do not merge.  Just review and leave the assignee to me.  I will merge when ready.**