### PR TITLE
dian9181/RemoveAuthenticationView

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -262,9 +262,11 @@ AddItemsToPortalSample {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         authenticationManager: authManager
     }
+    */
 
     BusyIndicator {
         anchors.centerIn: parent

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
@@ -155,8 +155,10 @@ PortalUserInfoSample {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         id: authView
         authenticationManager: authManager
     }
+    */
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
@@ -189,9 +189,11 @@ SearchForWebmapSample {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         authenticationManager: authManager
     }
+    */
 
     MessageDialog {
         id: webMapMsg

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -219,7 +219,9 @@ ShowOrgBasemapsSample {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         authenticationManager: authManager
     }
+    */
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
@@ -35,8 +35,10 @@ TokenAuthenticationSample {
     }
 
     // Declare an AuthenticationView
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         anchors.fill: parent
         authenticationManager: authSample.authenticationManager // set the authenticationManager property (this needs to be registered)
     }
+    */
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -355,9 +355,11 @@ Rectangle {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         authenticationManager: AuthenticationManager
     }
+    */
 
     BusyIndicator {
         anchors.centerIn: parent

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
@@ -191,9 +191,11 @@ Rectangle {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         id: authView
         authenticationManager: AuthenticationManager
     }
+    */
     //! [PortalUserInfo create portal]
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
@@ -281,9 +281,11 @@ Rectangle {
         anchors {top: searchBox.bottom; bottom: parent.bottom; left: parent.left; right: parent.right; margins: 10 * scaleFactor}
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         authenticationManager: AuthenticationManager
     }
+    */
 
     MessageDialog {
         id: webMapMsg

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -266,7 +266,9 @@ Rectangle {
         }
     }
 
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         authenticationManager: AuthenticationManager
     }
+    */
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
@@ -51,8 +51,10 @@ Rectangle {
     }
 
     // Declare an AuthenticationView
+    /* Uncomment this section when running as standalone application
     AuthenticationView {
         anchors.fill: parent
         authenticationManager: AuthenticationManager // set the authenticationManager property
     }
+    */
 }


### PR DESCRIPTION
Assign to @mich5148, @kous3106

Issue:  https://devtopia.esri.com/runtime/qt-sdk/issues/4037

Removes `AuthenticationView` from standalone apps after it was added to the sample viewer in issue https://devtopia.esri.com/runtime/qt-sdk/issues/4037 (this is a temporary fix for commit [bc2edcd](https://devtopia.esri.com/dian9181/qt-sdk/commit/bc2edcd82d58b014a4ba9be6e5fbb5c6756b4a86), and a new issue will be created to resolve it)
- comment out `AuthenticationView` from samples when running with sample viewer
     - sample viewer application will crash if two instances of `AuthenticationViewer` are used to handle an `AuthenticationChallenge`
- uncomment `AuthenticationView` from samples when running as standalone app

Sprint 3-Quartz Update 2