### PR TITLE
fixing grid label

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.cpp
@@ -144,8 +144,6 @@ void DisplayGrid::changeLabelColor(const QString& color)
     for (int level = 0; level < gridLevels; level++)
     {
       TextSymbol* textSym = new TextSymbol("text", QColor(color), 14, HorizontalAlignment::Left, VerticalAlignment::Bottom, this);
-      textSym->setOutlineColor(QColor("black"));
-      textSym->setOutlineWidth(2.0 + level);
       textSym->setHaloColor(QColor("white"));
       textSym->setHaloWidth(2.0 + level);
       m_mapView->grid()->setTextSymbol(level, textSym);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -102,10 +102,6 @@ Rectangle {
                                                                         horizontalAlignment: Enums.HorizontalAlignmentLeft,
                                                                         verticalAlignment: Enums.VerticalAlignmentBottom
                                                                     });
-
-                textSym.outlineColor = "black";
-                textSym.outlineWidth = 2;
-
                 textSym.haloColor = "white";
                 textSym.haloWidth = 2 + level;
 


### PR DESCRIPTION
Removing outline width and color. This was overwriting the text color and causing the text to not change color. I spoke with Ralf, and this is expected, so we just need to update the sample.

@michael-tims please review and merge