### PR TITLE
only show the dialog if features were identified

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.qml
@@ -35,5 +35,8 @@ IdentifyLayersSample {
         text: message
     }
 
-    onShowMessage: msgDialog.open();
+    onShowMessage: {
+        if (message.length > 0)
+            msgDialog.open();
+    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/IdentifyLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/IdentifyLayers.qml
@@ -100,7 +100,8 @@ Rectangle {
             }
 
             // show the message box
-            msgDialog.open();
+            if (msgText.length > 0)
+                msgDialog.open();
         }
 
         // handle any errors on the map view


### PR DESCRIPTION
@michael-tims please review and merge. Fix for issue @kathleen1 found, where the dialog should not display if no features were identified