### PR TITLE
changing order so the zoom happens before query executes

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -121,8 +121,10 @@ void ListRelatedFeatures::connectSignals()
               }
 
               emit showAttributeTable();
-              m_mapView->setViewpointGeometry(arcGISFeature->geometry(), 100);
             });
+
+            // zoom to the selected feature
+            m_mapView->setViewpointGeometry(arcGISFeature->geometry().extent(), 100);
 
             // query related features
             selectedTable->queryRelatedFeatures(arcGISFeature);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
@@ -130,8 +130,10 @@ Rectangle {
 
                         // show the attribute view
                         attributeView.height = 200 * scaleFactor
-                        mapView.setViewpointGeometryAndPadding(arcGISFeature.geometry, 100)
                     });
+
+                    // zoom to the feature
+                    mapView.setViewpointGeometryAndPadding(arcGISFeature.geometry, 100)
 
                     // query related features
                     selectedTable.queryRelatedFeatures(arcGISFeature);


### PR DESCRIPTION
@michael-tims please review/merge. There is a strange conflict where if the viewpoint animation and the attribute view slides up simulatenously, the map zooms to the wrong location. To avoid this, we can zoom before we show the attribute view