### PR TITLE
Use the same identify and query approach used by the Cpp samples.

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -111,7 +111,6 @@ Rectangle {
 
         QueryParameters {
             id: params
-            maxFeatures: 1
         }
 
         // hide the callout after navigation
@@ -130,7 +129,7 @@ Rectangle {
             // call identify on the feature layer
             var tolerance = 10;
             var returnPopupsOnly = false;
-            mapView.identifyLayer(featureLayer, mouse.x, mouse.y, tolerance, returnPopupsOnly);
+            mapView.identifyLayerWithMaxResults(featureLayer, mouse.x, mouse.y, tolerance, returnPopupsOnly, 1);
             //! [DeleteFeaturesFeatureService identify feature]
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -93,7 +93,6 @@ Rectangle {
 
         QueryParameters {
             id: params
-            maxFeatures: 1
         }
 
         // hide the callout after navigation
@@ -112,7 +111,7 @@ Rectangle {
             mousePointY = mouse.y - callout.height;
 
             // call identify on the mapview
-            mapView.identifyLayer(featureLayer, mouse.x, mouse.y, 10, false);
+            mapView.identifyLayerWithMaxResults(featureLayer, mouse.x, mouse.y, 10, false, 1);
         }
 
         onIdentifyLayerStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -103,7 +103,6 @@ Rectangle {
 
         QueryParameters {
             id: params
-            maxFeatures: 1
         }
 
         // hide the callout after navigation

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -117,7 +117,6 @@ Rectangle {
 
         QueryParameters {
             id: params
-            maxFeatures: 1
         }
 
         onMouseClicked: {
@@ -129,7 +128,7 @@ Rectangle {
                 featureLayer.selectedFeatures();
             } else {
                 // call identify on the mapview
-                mapView.identifyLayer(featureLayer, mouse.x, mouse.y, 10, false);
+                mapView.identifyLayerWithMaxResults(featureLayer, mouse.x, mouse.y, 10, false, 1);
             }
         }
 


### PR DESCRIPTION
Assigned to @khajra. 

Backporting https://github.com/Esri/arcgis-runtime-samples-qt/pull/616 to 100.1 (current master branch).

I tested all these samples with 100.1 and they still work correctly.