### PR TITLE
fixing a timing issue with the error display

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.cpp
@@ -62,9 +62,6 @@ void ListTransformations::componentComplete()
     emit showStatusBar(QString("Error setting projection engine directory: %1. %2").arg(e.message()).arg(e.additionalMessage()));
   });
 
-  // Set the TransformationCatalog path
-  TransformationCatalog::setProjectionEngineDirectory(dataPath.toString());
-  showStatusBar();
 
   // Create a geometry located in the Greenwich observatory courtyard in London, UK, the location of the
   // Greenwich prime meridian. This will be projected using the selected transformation.
@@ -84,6 +81,11 @@ void ListTransformations::componentComplete()
   // connect to map loaded signal
   connect(m_map, &Map::doneLoading, this, [this, dataPath]
   {
+    // Set the TransformationCatalog path
+    TransformationCatalog::setProjectionEngineDirectory(dataPath.toString());
+    if (TransformationCatalog::projectionEngineDirectory().length() > 0)
+      showStatusBar();
+
     // get the initial list of transformations
     refreshTransformationList(true);
   });


### PR DESCRIPTION
@michael-tims there is a timing issue with the error status bar, where it doesn't have the height calculated yet. Waiting for the map to load resolves the issue. 