### PR TITLE
Michael tims/remove mac os deployment ver

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.pro
@@ -29,6 +29,24 @@ TARGET = ViewshedLocation
 ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
+#  message("building against the local dev build")
+#  include ($$PWD/../../../common/qt_api_config.pri)
+
+#  # when defined, the QML ArcGISRuntimePlugin will not be linked or copied
+#  CONFIG += CPP_API_APP
+
+#  # comment out if you do not want QML plugins to be linked/recopied
+#  include (/Users/mich5148/applications/qt/common/arcgis_qml_imports.pri)
+
+#  LIBS += \
+#    -L$${DESTDIR} \
+#    -L$${LIB_FOLDER_STATICLIB} \
+#    -lEsriRuntimeQt$${LIB_SUFFIX} \
+#    -lEsriCommonQt$${LIB_SUFFIX}
+
+#  INCLUDEPATH += /Users/mich5148/applications/qt/api/qt_cpp/Include \
+#                 /Users/mich5148/applications/qt/api/qt_cpp/Include/LocalServer
+
 #-------------------------------------------------------------------------------
 
 HEADERS += \
@@ -62,6 +80,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.pro
@@ -29,24 +29,6 @@ TARGET = ViewshedLocation
 ARCGIS_RUNTIME_VERSION = 100.2
 include($$PWD/arcgisruntime.pri)
 
-#  message("building against the local dev build")
-#  include ($$PWD/../../../common/qt_api_config.pri)
-
-#  # when defined, the QML ArcGISRuntimePlugin will not be linked or copied
-#  CONFIG += CPP_API_APP
-
-#  # comment out if you do not want QML plugins to be linked/recopied
-#  include (/Users/mich5148/applications/qt/common/arcgis_qml_imports.pri)
-
-#  LIBS += \
-#    -L$${DESTDIR} \
-#    -L$${LIB_FOLDER_STATICLIB} \
-#    -lEsriRuntimeQt$${LIB_SUFFIX} \
-#    -lEsriCommonQt$${LIB_SUFFIX}
-
-#  INCLUDEPATH += /Users/mich5148/applications/qt/api/qt_cpp/Include \
-#                 /Users/mich5148/applications/qt/api/qt_cpp/Include/LocalServer
-
 #-------------------------------------------------------------------------------
 
 HEADERS += \

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.pro
@@ -22,6 +22,8 @@ win32 {
     include (Win/Win.pri)
 }
 
+macx {
+    include (Mac/Mac.pri)
 }
 
 ios {
@@ -38,6 +40,9 @@ DEFINES +="CLIENT_ID=\"enter client id\""
 # and registered for the Operating System
 DEFINES +="URL_SCHEME=\"exampleapp\""
 
+win32|unix:!macx {
+    message("Using QtSingleApplication")
+    # Update QT_SINGLEAPP_DIR to the location where you cloned the qt-solutions repository
     QT_SINGLEAPP_DIR = "$$PWD/../../../../../../../qt-solutions/qtsingleapplication"
     include("$$QT_SINGLEAPP_DIR/src/qtsingleapplication.pri")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.pro
@@ -22,9 +22,6 @@ win32 {
     include (Win/Win.pri)
 }
 
-macx {
-    include (Mac/Mac.pri)
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
 }
 
 ios {
@@ -41,9 +38,6 @@ DEFINES +="CLIENT_ID=\"enter client id\""
 # and registered for the Operating System
 DEFINES +="URL_SCHEME=\"exampleapp\""
 
-win32|unix:!macx {
-    message("Using QtSingleApplication")
-    # Update QT_SINGLEAPP_DIR to the location where you cloned the qt-solutions repository
     QT_SINGLEAPP_DIR = "$$PWD/../../../../../../../qt-solutions/qtsingleapplication"
     include("$$QT_SINGLEAPP_DIR/src/qtsingleapplication.pri")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
@@ -65,6 +65,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
@@ -61,6 +61,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLegend/ShowLegend.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLegend/ShowLegend.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
@@ -61,6 +61,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
@@ -61,6 +61,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.pro
@@ -62,8 +62,5 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
@@ -62,8 +62,5 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.pro
@@ -62,8 +62,5 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.pro
@@ -62,8 +62,5 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/FeatureLayer_GeoPackage.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/FeatureLayer_GeoPackage.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
@@ -66,6 +66,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.pro
@@ -62,8 +62,5 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.pro
@@ -62,8 +62,5 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 
 DISTFILES +=

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.pro
@@ -47,3 +47,6 @@ win32 {
         Ole32.lib
 }
 
+ios:android:macx {		
+    message("Local Server not supported on this platform")		
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.pro
@@ -47,6 +47,3 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {
-    message("Local Server not supported on this platform")
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.pro
@@ -47,6 +47,6 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {		
-    message("Local Server not supported on this platform")		
+ios:android:macx {
+    message("Local Server not supported on this platform")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.pro
@@ -47,3 +47,6 @@ win32 {
         Ole32.lib
 }
 
+ios:android:macx {		
+    message("Local Server not supported on this platform")		
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.pro
@@ -47,6 +47,3 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {
-    message("Local Server not supported on this platform")
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.pro
@@ -47,6 +47,6 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {		
-    message("Local Server not supported on this platform")		
+ios:android:macx {
+    message("Local Server not supported on this platform")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
@@ -47,3 +47,6 @@ win32 {
         Ole32.lib
 }
 
+ios:android:macx {		
+    message("Local Server not supported on this platform")		
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
@@ -47,6 +47,3 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {
-    message("Local Server not supported on this platform")
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
@@ -47,6 +47,6 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {		
-    message("Local Server not supported on this platform")		
+ios:android:macx {
+    message("Local Server not supported on this platform")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
@@ -47,3 +47,6 @@ win32 {
         Ole32.lib
 }
 
+ios:android:macx {		
+    message("Local Server not supported on this platform")		
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
@@ -47,6 +47,3 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {
-    message("Local Server not supported on this platform")
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
@@ -47,6 +47,6 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {		
-    message("Local Server not supported on this platform")		
+ios:android:macx {
+    message("Local Server not supported on this platform")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
@@ -47,3 +47,6 @@ win32 {
         Ole32.lib
 }
 
+ios:android:macx {		
+    message("Local Server not supported on this platform")		
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
@@ -47,6 +47,3 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {
-    message("Local Server not supported on this platform")
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
@@ -47,6 +47,6 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {		
-    message("Local Server not supported on this platform")		
+ios:android:macx {
+    message("Local Server not supported on this platform")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
@@ -47,3 +47,6 @@ win32 {
         Ole32.lib
 }
 
+ios:android:macx {		
+    message("Local Server not supported on this platform")		
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
@@ -47,6 +47,3 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {
-    message("Local Server not supported on this platform")
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
@@ -47,6 +47,6 @@ win32 {
         Ole32.lib
 }
 
-ios:android:macx {		
-    message("Local Server not supported on this platform")		
+ios:android:macx {
+    message("Local Server not supported on this platform")
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
@@ -59,6 +59,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
@@ -58,6 +58,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/SurfacePlacement.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/SurfacePlacement.pro
@@ -58,6 +58,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.pro
@@ -62,6 +62,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.pro
@@ -57,6 +57,3 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
@@ -62,7 +62,4 @@ android {
     DEPENDPATH += $$PWD
 }
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}
 

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/GORenderers.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/GORenderers.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     GORenderers.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     GOSymbols.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     ArcGISTiledLayerUrl.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     ChangeBasemap.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     ChangeViewpoint.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/DisplayMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/DisplayMap.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     DisplayMap.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     ManageBookmarks.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/MapLoaded.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/MapLoaded.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     MapLoaded.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/MapRotation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/MapRotation.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     MapRotation.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     OpenExistingMap.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     SetInitialMapArea.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     SetInitialMapLocation.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     SetMapSpatialReference.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.pro
@@ -37,6 +37,3 @@ SOURCES += \
 HEADERS  += \
     BasicSceneView.h
 
-macx {
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
@@ -35,4 +35,3 @@ ios {
 QML_IMPORT_PATH =
 
 # Default rules for deployment.
-include(deployment.pri)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
@@ -35,3 +35,4 @@ ios {
 QML_IMPORT_PATH =
 
 # Default rules for deployment.
+include(deployment.pri)


### PR DESCRIPTION
Assign to @JamesMBallard 

`QMAKE_MACOSX_DEPLOYMENT_TARGET` is now located in the shared pri files.  Not needed in the individual sample pro files anymore