### PR TITLE
Use safe assignment.

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/FeatureLayer_Geodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/FeatureLayer_Geodatabase.qml
@@ -58,7 +58,9 @@ Rectangle {
             // create a feature layer
             FeatureLayer {
                 // obtain the feature table from the geodatabase by name
-                featureTable: gdb.geodatabaseFeatureTablesByTableName["Trailheads"]
+                featureTable: gdb.geodatabaseFeatureTablesByTableName["Trailheads"] ?
+                                  gdb.geodatabaseFeatureTablesByTableName["Trailheads"] :
+                                  null
 
                 // create the geodatabase
                 Geodatabase {


### PR DESCRIPTION
Use a ternary to avoid an initial error message when this property
isn't valid yet being assigned.

Assigned to @ldanzinger. Please review and merge.

This avoids this message from the sample app:
```
Unable to assign [undefined] to QmlFeatureTable*
```

Merging to v.next branch.

cc: @khajra 