### PR TITLE
Use new AsInt properties

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -137,7 +137,7 @@ Rectangle {
             if (identifyLayerStatus === Enums.TaskStatusCompleted) {
                 if (identifyLayerResult.geoElements.length > 0) {
                     // get the objectid of the identifed object
-                    params.objectIds = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
+                    params.objectIdsAsInts = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
                     // query for the feature using the objectid
                     featureLayer.selectFeaturesWithQuery(params, Enums.SelectionModeNew);
                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -118,7 +118,7 @@ Rectangle {
             if (identifyLayerStatus === Enums.TaskStatusCompleted) {
                 if (identifyLayerResult.geoElements.length > 0) {
                     // get the objectid of the identifed object
-                    params.objectIds = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
+                    params.objectIdsAsInts = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
                     // query for the feature using the objectid
                     featureLayer.selectFeaturesWithQuery(params, Enums.SelectionModeNew);
                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -126,7 +126,7 @@ Rectangle {
             if (identifyLayerStatus === Enums.TaskStatusCompleted) {
                 if (identifyLayerResult.geoElements.length > 0) {
                     // get the objectid of the identifed object
-                    params.objectIds = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
+                    params.objectIdsAsInts = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
                     // query for the feature using the objectid
                     featureLayer.selectFeaturesWithQuery(params, Enums.SelectionModeNew);
                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -136,7 +136,7 @@ Rectangle {
             if (identifyLayerStatus === Enums.TaskStatusCompleted) {
                 if (identifyLayerResult.geoElements.length > 0) {
                     // get the objectid of the identifed object
-                    params.objectIds = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
+                    params.objectIdsAsInts = [identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")];
                     // query for the feature using the objectid
                     featureLayer.selectFeaturesWithQuery(params, Enums.SelectionModeNew);
                 }


### PR DESCRIPTION
Assign to @lsmallwood 

Updating some samples to use the new "AsInt" properties for assignments. I tested and found no issues. This is the correct thing to do since `typeof identifyLayerResult.geoElements[0].attributes.attributeValue("objectid")` returns "number" and not "string". 

Merging to v.next.