### PR TITLE
changing symbol swatch size

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -123,14 +123,17 @@ BuildLegendSample {
                     clip: true
 
                     Row {
-                        spacing: 5
+                        spacing: 5 * scaleFactor
                         anchors.verticalCenter: parent.verticalCenter
+
                         Image {
-                            width: symbolWidth
-                            height: symbolHeight
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 24 * scaleFactor
+                            height: width
                             source: symbolUrl
                         }
                         Text {
+                            anchors.verticalCenter: parent.verticalCenter
                             width: 125 * scaleFactor
                             text: name
                             wrapMode: Text.WordWrap

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -160,14 +160,17 @@ Rectangle {
                     clip: true
 
                     Row {
-                        spacing: 5
+                        spacing: 5 * scaleFactor
                         anchors.verticalCenter: parent.verticalCenter
+
                         Image {
-                            width: symbolWidth
-                            height: symbolHeight
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: 24 * scaleFactor
+                            height: width
                             source: symbolUrl
                         }
                         Text {
+                            anchors.verticalCenter: parent.verticalCenter
                             width: 125 * scaleFactor
                             text: name
                             wrapMode: Text.WordWrap


### PR DESCRIPTION
@michael-tims please review/merge. Changing symbol swatch size to use hardcoded value. I realized that once I started using the role * scale factor that they symbols could come back in different sizes, resulting in an odd looking legend. It is better instead to set a size to scale them to