### PR TITLE
fixing android specific issue and adding create new button

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
@@ -106,7 +106,9 @@ void CreateAndSaveMap::loadPortal()
   if (!m_portal)
     return;
 
-  if (m_portal->loadStatus() != LoadStatus::Loaded)
+  if (m_portal->loadStatus() == LoadStatus::Loaded)
+    emit portalLoaded();
+  else
     m_portal->load();
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -30,6 +30,7 @@ CreateAndSaveMapSample {
 
     onPortalLoaded: {
         options.visible = true;
+        options.reset();
         stackView.push(options);
     }
 
@@ -48,6 +49,7 @@ CreateAndSaveMapSample {
         anchors.fill: parent
 
         initialItem: LayerWindow {
+            id: layerWindow
             onCreateMapSelected: {
                 mapView.visible = true;
                 stackView.push(mapView)
@@ -104,6 +106,19 @@ CreateAndSaveMapSample {
             textFormat: Text.RichText
             horizontalAlignment: Text.AlignHCenter
             onLinkActivated: Qt.openUrlExternally(webmapUrl)
+        }
+
+        Button {
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                bottom: parent.bottom
+                margins: 10 * scaleFactor
+            }
+            text: "Create New Map"
+            onClicked: {
+                stackView.clear();
+                stackView.push(layerWindow)
+            }
         }
     }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -122,4 +122,10 @@ Rectangle {
             onClicked: cancelClicked()
         }
     }
+
+    function reset() {
+        titleText.text = "";
+        descriptionText.text = "";
+        tagsText.text = "";
+    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -33,6 +33,7 @@ Rectangle {
         anchors.fill: parent
 
         initialItem: LayerWindow {
+            id: layerWindow
             onCreateMapSelected: {
                 mapView.visible = true;
                 stackView.push(mapView)
@@ -60,22 +61,9 @@ Rectangle {
                     portal.load();
                 else {
                     options.visible = true;
+                    options.reset();
                     stackView.push(options);
                 }
-            }
-        }
-
-        Connections {
-            target: mapView.map
-            onSaveStatusChanged: {
-                if (mapView.map.saveStatus === Enums.TaskStatusCompleted) {
-                    completeText.webmapUrl = "https://www.arcgis.com/home/item.html?id=%1".arg(mapView.map.item.itemId);
-                    completeText.text = 'Map saved successfully.<br>View in <a href="%1">ArcGIS Online</a>'.arg(completeText.webmapUrl);
-                    stackView.push(completionRect);
-                } else if (mapView.map.saveStatus === Enums.TaskStatusErrored) {
-                    completeText.text = 'An error occurred while saving the map.\nPlease restart the sample and try again.\nDetails:'.arg(mapView.map.error.message);
-                    stackView.push(completionRect);
-                }                
             }
         }
     }
@@ -112,6 +100,19 @@ Rectangle {
             textFormat: Text.RichText
             horizontalAlignment: Text.AlignHCenter
             onLinkActivated: Qt.openUrlExternally(webmapUrl)
+        }
+
+        Button {
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                bottom: parent.bottom
+                margins: 10 * scaleFactor
+            }
+            text: "Create New Map"
+            onClicked: {
+                stackView.clear();
+                stackView.push(layerWindow)
+            }
         }
     }
 
@@ -150,7 +151,18 @@ Rectangle {
             selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapOceans");
 
         // Create the Map with the basemap
-        var map = ArcGISRuntimeEnvironment.createObject("Map", { basemap: selectedBasemap });
+        var map = ArcGISRuntimeEnvironment.createObject("Map", { basemap: selectedBasemap }, mapView);
+
+        map.saveStatusChanged.connect(function() {
+            if (mapView.map.saveStatus === Enums.TaskStatusCompleted) {
+                completeText.webmapUrl = "https://www.arcgis.com/home/item.html?id=%1".arg(mapView.map.item.itemId);
+                completeText.text = 'Map saved successfully.<br>View in <a href="%1">ArcGIS Online</a>'.arg(completeText.webmapUrl);
+                stackView.push(completionRect);
+            } else if (mapView.map.saveStatus === Enums.TaskStatusErrored) {
+                completeText.text = 'An error occurred while saving the map.\nPlease restart the sample and try again.\nDetails:'.arg(mapView.map.error.message);
+                stackView.push(completionRect);
+            }
+        });
 
         // Add Operational Layers
         for (var i = 0; i < layerList.length; i++) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -122,4 +122,10 @@ Rectangle {
             onClicked: cancelClicked()
         }
     }
+
+    function reset() {
+        titleText.text = "";
+        descriptionText.text = "";
+        tagsText.text = "";
+    }
 }


### PR DESCRIPTION
@lsmallwood please review merge. Fixing/adding 2 things:
1) Android has an issue with Connections QML type not working in the stack view. I haven't tracked down why, but this connect syntax works, so I am switching to that.
2) Adding a Create New Map button for the last page so that the user can easily restart the process and create a new map without having to restart the sample