### PR TITLE
No need to check if GeoElement is a feature

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
@@ -76,11 +76,8 @@ Rectangle {
 
             // get the first GeoElement
             if (geoElements.length > 0) {
-                var geoElement = geoElements[0];
-                if (geoElement instanceof Feature) {
-                    // select the feature
-                    sceneLayer.selectFeature(geoElement);
-                }
+                // select the feature
+                sceneLayer.selectFeature(geoElements[0]);
             }
         }
 


### PR DESCRIPTION
@khajra please review and merge

I don't believe `instanceof` works with Qt 5.9.2.  Seems like it does work with Qt 5.11 though.  In any case, there's no need to use it here.  All we ever get from Scene Layer identify is features anyway.