### PR TITLE
making error reporting consistent with QML sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.cpp
@@ -80,16 +80,14 @@ void StatisticalQueryGroupSort::connectSignals()
     if (error.isEmpty())
       return;
 
+    m_resultsModel->clear();
     addResultToModel("", QString("Error. %1").arg(error.message()));
   });
 
   connect(m_featureTable, &ServiceFeatureTable::queryStatisticsCompleted, this, [this](QUuid, StatisticsQueryResult* result)
   {
-    if (!result)
-    {
-      addResultToModel("", "An unknown error occurred.");
-      return;
-    }
+    if (!result)    
+      return;    
 
     // clear previous results
     m_resultsModel->clear();


### PR DESCRIPTION
@michael-tims please review/merge. Fixing up the C++ sample so the error reporting is the same as QML