### PR TITLE
updating scale factor to not use extras

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import QtGraphicalEffects 1.0
-import Esri.ArcGISExtras 1.1
 import Esri.Samples 1.0
 
 AnalyzeHotspotsSample {
@@ -27,7 +27,7 @@ AnalyzeHotspotsSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // Declare the MapView
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 AnalyzeViewshedSample {
     id: rootRectangle
@@ -26,7 +26,7 @@ AnalyzeViewshedSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     MapView {
         anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 DistanceMeasurementAnalysisSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ DistanceMeasurementAnalysisSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     SceneView {
         objectName: "sceneView"

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 StatisticalQuerySample {
     id: rootRectangle
@@ -26,7 +26,7 @@ StatisticalQuerySample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property alias extentOnly: extentCheckbox.checked
     property alias bigCitiesOnly: bigCitiesCheckbox.checked
     property string resultsText: ""

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 StatisticalQueryGroupSortSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ StatisticalQueryGroupSortSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     StackView {
         id: stackView

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ViewshedCameraSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ ViewshedCameraSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     SceneView {
         objectName: "sceneView"

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ViewshedLocationSample {
     id: viewshedSample
@@ -26,7 +26,7 @@ ViewshedLocationSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     SceneView {
         id: sceneView

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Dialogs 100.4
 
 TokenAuthenticationSample {
@@ -26,7 +26,7 @@ TokenAuthenticationSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 BuildLegendSample {
     id: showLegendSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Layouts 1.1
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 DisplayGridSample {
     id: displayGrid
@@ -26,7 +26,7 @@ DisplayGridSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property real centerWindowY: (displayGrid.height / 2) - (styleWindow.height / 2)
 
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.ArcGISExtras 1.1
 import Esri.Samples 1.0
 
@@ -24,7 +25,7 @@ GODictionaryRendererSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data"
 
     // Create MapView here, and create its Map and GraphicsOverlay in C++ code

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.ArcGISExtras 1.1
 import Esri.Samples 1.0
 
@@ -25,7 +26,7 @@ GODictionaryRenderer_3DSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data"
 
     onGraphicsLoaded: progressBar_loading.visible = false;

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -25,7 +26,7 @@ SymbolizeShapefileSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 DeleteFeaturesFeatureServiceSample {
     id: deleteFeaturesSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ EditAndSyncFeaturesSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/"
     property string outputGdb: System.temporaryFolder.path + "/WildfireCpp_%1.geodatabase".arg(new Date().getTime().toString())
     property string statusText: ""

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -18,15 +18,15 @@ import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 EditFeatureAttachmentsSample {
     id: editAttachmentsSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property var featAttributes: ["Destroyed", "Major", "Minor", "Affected", "Inaccessible"]
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -17,15 +17,15 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 UpdateAttributesFeatureServiceSample {
     id: updateFeaturesSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property var featAttributes: ["Destroyed", "Major", "Minor", "Affected", "Inaccessible"]
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FeatureLayerChangeRendererSample {
     id: changeRendererSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.qml
@@ -16,17 +16,17 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 //! [Import the namespace that has QML type that was registered in Cpp]
 import Esri.Samples 1.0
 //! [Import the namespace that has QML type that was registered in Cpp]
-import Esri.ArcGISExtras 1.1
 
 FeatureLayerDefinitionExpressionSample {
     id: definitionExpressionSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     //! [Declare map view in QML that will be accessed from Cpp]
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.ArcGISExtras 1.1
 import Esri.Samples 1.0
 
@@ -24,7 +25,7 @@ FeatureLayerDictionaryRendererSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data"
 
     // Create MapView here, and create its Map in C++ code

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.qml
@@ -17,15 +17,15 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FeatureLayerSelectionSample {
     id: featureLayerSelectionSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.3
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -25,7 +26,7 @@ GenerateGeodatabaseSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string statusText: ""
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/"
     property string outputGdb: System.temporaryFolder.path + "/WildfireCpp_%1.geodatabase".arg(new Date().getTime().toString())

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
-import Esri.ArcGISExtras 1.1
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 
 ListRelatedFeaturesSample {
@@ -26,7 +26,7 @@ ListRelatedFeaturesSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     onHideAttributeTable: attributeView.height = 0;
     onShowAttributeTable: attributeView.height = 200 * scaleFactor;

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ServiceFeatureTableManualCacheSample {
     id: manualCacheSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 BufferSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ BufferSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 CutGeometrySample {
     id: rootRectangle
@@ -25,7 +25,7 @@ CutGeometrySample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FormatCoordinatesSample {
     id: formatCoordinates
@@ -25,7 +25,7 @@ FormatCoordinatesSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property int labelWidth: 100 * scaleFactor
     property int coordinateTextWidth: 200 * scaleFactor
     property int fontPixelSize: 14 * scaleFactor

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 GeodesicOperationsSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ GeodesicOperationsSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -25,7 +26,7 @@ ListTransformationsSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/PEDataRuntime"
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 SpatialOperationsSample {
     id: rootRectangle
@@ -27,7 +27,7 @@ SpatialOperationsSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ BlendRasterLayerSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster"
     property bool editingRenderer: false
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/TextWithComboBox.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/TextWithComboBox.qml
@@ -16,10 +16,10 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
-import Esri.ArcGISExtras 1.1
+import QtQuick.Window 2.2
 
 Row {
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property alias label: labelText.text
     property alias model: combo.model
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/TextWithSlider.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/TextWithSlider.qml
@@ -16,10 +16,10 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
-import Esri.ArcGISExtras 1.1
+import QtQuick.Window 2.2
 
 Row {
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property alias label: labelText.text
     property alias sliderValue: slider.value
     property alias min: slider.minimumValue

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ChangeSublayerVisibilitySample {
     id: changeSublayerVisibilitySample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -25,7 +26,7 @@ ExportTilesSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string outputTileCache: System.temporaryFolder.path + "/TileCacheQml_%1.tpk".arg(new Date().getTime().toString())
     property string statusText: ""
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FeatureLayerRenderingModeMapSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ FeatureLayerRenderingModeMapSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     MapView {
         anchors {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -25,7 +26,7 @@ FeatureLayerRenderingModeSceneSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     SceneView {
         anchors {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ FeatureLayerShapefileSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/shp/"
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ Hillshade_RendererSample {
     height: 600
 
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster"
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ RasterColormapRendererSample {
     width: 800
     height: 800
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster"
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ RasterFunctionServiceSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster/"
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ RasterLayerFileSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster/"
     property var supportedFormats: ["img","I12","dt0","dt1","dt2","tc2","geotiff","tif", "tiff", "hr1","jpg","jpeg","jp2","ntf","png","i21","ovr"]
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 RasterRenderingRuleSample {
     id: rootRectangle
@@ -26,7 +26,7 @@ RasterRenderingRuleSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ RasterRgbRendererSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster"
     property string minMax: "Min Max"
     property string percentClip: "Percent Clip"

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ RasterStretchRendererSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster"
     property string minMax: "Min Max"
     property string percentClip: "Percent Clip"

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 VectorTiledLayerUrlSample {
     id: vectorTiledLayerUrlSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ChangeBasemapSample {
     id: changeBasemapSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -24,7 +25,7 @@ ChangeViewpointSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Dialogs 100.4
 
 CreateAndSaveMapSample {
@@ -26,7 +26,7 @@ CreateAndSaveMapSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     onPortalLoaded: {
         options.visible = true;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 DisplayDeviceLocationSample {
     id: deviceLocationSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string currentModeText: deviceLocationSample.stopMode
     property string currentModeImage: "qrc:/Samples/Maps/DisplayDeviceLocation/Stop.png"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 DisplayDrawingStatusSample {
     id: displayDrawingStatusSample
@@ -26,7 +26,7 @@ DisplayDrawingStatusSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
-import Esri.ArcGISExtras 1.1
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 
 DisplayLayerViewDrawStatusSample {
@@ -25,7 +25,7 @@ DisplayLayerViewDrawStatusSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Dialogs 100.4
@@ -27,7 +28,7 @@ GenerateOfflineMapSample {
     width: 800
     height: 600
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string outputMapPackage: System.temporaryFolder.path + "/OfflineMap_%1.mmpk".arg(new Date().getTime().toString())
 
     onUpdateStatus: generateWindow.statusText = status;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ManageBookmarksSample {
     id: manageBookmarksSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 MapLoadedSample {
     id: mapLoadedSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.qml
@@ -17,15 +17,15 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 MapRotationSample {
     id: mapRotationSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Controls 100.4
@@ -26,7 +27,7 @@ MobileMap_SearchAndRouteSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.userHomeFolder.path + "/ArcGIS/Runtime/Data/mmpk"
     property bool isMapOpen: false
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -17,15 +17,15 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 OpenMapUrlSample {
     id: openMapUrlSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 TakeScreenshotSample {
     id: rootRectangle
@@ -26,7 +26,7 @@ TakeScreenshotSample {
     width: 800
     height: 600    
 
-    property real scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // Declare a MapView
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
@@ -16,15 +16,15 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FindRouteSample {
     id: findRouteSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     onSolveRouteComplete: solveButton.visible = false
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 ServiceAreaSample {
     id: rootRectangle
@@ -27,7 +27,7 @@ ServiceAreaSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     // add a mapView component
     MapView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -16,6 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
 import Esri.ArcGISExtras 1.1
 
@@ -26,7 +27,7 @@ Animate3DSymbolsSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/3D"
     property bool following: followButton.checked
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -16,8 +16,8 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FeatureLayerExtrusionSample {
     id: rootRectangle
@@ -25,7 +25,7 @@ FeatureLayerExtrusionSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
 
     SceneView {
         id: sceneView

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.qml
@@ -17,15 +17,15 @@
 import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
+import QtQuick.Window 2.2
 import Esri.Samples 1.0
-import Esri.ArcGISExtras 1.1
 
 FindAddressSample {
     id: findAddressSample
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property double mousePointX
     property double mousePointY
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.qml
@@ -18,6 +18,7 @@ import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick 2.6
 import QtQuick.Controls 1.4
+import QtQuick.Window 2.2
 import QtPositioning 5.6
 import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Controls 100.4
@@ -29,7 +30,7 @@ FindPlaceSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property bool isSearchingLocation: false
     property bool searchByExtent: false
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.qml
@@ -18,6 +18,7 @@ import QtQuick 2.6
 import Esri.Samples 1.0
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
+import QtQuick.Window 2.2
 import QtQuick.Dialogs 1.2
 import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Controls 100.4
@@ -29,7 +30,7 @@ OfflineGeocodeSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property string dataPath: System.resolvedPath(System.userHomePath) + "/ArcGIS/Runtime/Data/"
 
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -28,7 +28,7 @@ SearchDictionarySymbolStyleSample {
     width: 800
     height: 600
 
-    property double scaleFactor: System.displayScaleFactor
+    property real scaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property double fontSize: 16 * scaleFactor
     property var repeaterModel: ["Names", "Tags", "Symbol Classes", "Categories", "Keys"]
     property var hintsModel: ["Fire", "Sustainment Points", "3", "Control Measure", "25212300_6"]


### PR DESCRIPTION
@michael-tims please review/merge. Removing the extras scale factor from C++. This removes Extras from many samples. Samples that still use local data have Extras imported. We have another issue for changing that.