### PR TITLE
Michael tims/selection properties

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -78,7 +78,6 @@ void AddFeaturesFeatureService::componentComplete()
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);
-  m_featureLayer->setSelectionWidth(3);
   m_map->operationalLayers()->append(m_featureLayer);
 
   connectSignals();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -70,7 +70,6 @@ void DeleteFeaturesFeatureService::componentComplete()
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);
-  m_featureLayer->setSelectionWidth(3);
   m_map->operationalLayers()->append(m_featureLayer);
 
   connectSignals();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -82,7 +82,6 @@ void EditFeatureAttachments::componentComplete()
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);
-  m_featureLayer->setSelectionWidth(3);
   m_map->operationalLayers()->append(m_featureLayer);
 
   connectSignals();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -79,7 +79,6 @@ void UpdateAttributesFeatureService::componentComplete()
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);
-  m_featureLayer->setSelectionWidth(3);
   m_map->operationalLayers()->append(m_featureLayer);
 
   connectSignals();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -77,7 +77,6 @@ void UpdateGeometryFeatureService::componentComplete()
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);
-  m_featureLayer->setSelectionWidth(3);
   m_map->operationalLayers()->append(m_featureLayer);
 
   connectSignals();

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -67,9 +67,6 @@ void FeatureLayerSelection::componentComplete()
   // create the feature layer using the feature table
   m_featureLayer = new FeatureLayer(m_featureTable, this);
 
-  // set a selection width on the feature layer
-  m_featureLayer->setSelectionWidth(3);
-
   // add the feature layer to the map
   m_map->operationalLayers()->append(m_featureLayer);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -72,6 +72,7 @@ void ListRelatedFeatures::componentComplete()
 
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
+  m_mapView->setSelectionProperties(SelectionProperties(QColor("yellow")));
 
   // Create a map using the URL of a web map
   m_map = new Map(QUrl("https://arcgis.com/home/item.html?id=dcc7466a91294c0ab8f7a094430ab437"), this);
@@ -96,8 +97,6 @@ void ListRelatedFeatures::connectSignals()
       if (m_map->operationalLayers()->at(i)->name().contains(QString("- Alaska National Parks")))
       {
         m_alaskaNationalParks = static_cast<FeatureLayer*>(m_map->operationalLayers()->at(i));
-        m_alaskaNationalParks->setSelectionColor(QColor("yellow"));
-        m_alaskaNationalParks->setSelectionWidth(5.0);
 
         // connect to selectFeaturesCompleted signal
         connect(m_alaskaNationalParks, &FeatureLayer::selectFeaturesCompleted, this, [this](QUuid, FeatureQueryResult* result)

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -72,7 +72,7 @@ void ListRelatedFeatures::componentComplete()
 
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
-  m_mapView->setSelectionProperties(SelectionProperties(QColor("yellow")));
+  m_mapView->setSelectionProperties(SelectionProperties(QColor(Qt::yellow)));
 
   // Create a map using the URL of a web map
   m_map = new Map(QUrl("https://arcgis.com/home/item.html?id=dcc7466a91294c0ab8f7a094430ab437"), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
@@ -52,7 +52,7 @@ void SpatialRelationships::componentComplete()
 
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
-  m_mapView->setSelectionProperties(SelectionProperties(QColor("yellow")));
+  m_mapView->setSelectionProperties(SelectionProperties(QColor(Qt::yellow)));
 
   // Create a map using the topographic basemap
   m_map = new Map(Basemap::topographic(this), this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
@@ -52,6 +52,7 @@ void SpatialRelationships::componentComplete()
 
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
+  m_mapView->setSelectionProperties(SelectionProperties(QColor("yellow")));
 
   // Create a map using the topographic basemap
   m_map = new Map(Basemap::topographic(this), this);
@@ -61,7 +62,6 @@ void SpatialRelationships::componentComplete()
 
   // Create GraphicsOverlay
   m_graphicsOverlay = new GraphicsOverlay(this);
-  m_graphicsOverlay->setSelectionColor(QColor("yellow"));
   m_mapView->graphicsOverlays()->append(m_graphicsOverlay);
 
   // Add Graphics

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
@@ -48,9 +48,6 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
 
-                selectionColor: "cyan"
-                selectionWidth: 3
-
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -54,9 +54,6 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
 
-                selectionColor: "cyan"
-                selectionWidth: 3
-
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -54,9 +54,6 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
 
-                selectionColor: "cyan"
-                selectionWidth: 3
-
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -55,9 +55,6 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
 
-                selectionColor: "cyan"
-                selectionWidth: 3
-
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -51,9 +51,6 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
 
-                selectionColor: "cyan"
-                selectionWidth: 3
-
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
@@ -47,9 +47,6 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
 
-                selectionColor: "cyan"
-                selectionWidth: 3
-
                 // feature table
                 ServiceFeatureTable {
                     id: featureTable

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
@@ -32,6 +32,10 @@ Rectangle {
         id: mapView
         anchors.fill: parent
 
+        SelectionProperties {
+            color: "yellow"
+        }
+
         // bind the insets to the attribute view so the attribution text shows when the view expands
         viewInsets.bottom: attributeView.height / scaleFactor
 
@@ -47,8 +51,6 @@ Rectangle {
                 map.operationalLayers.forEach(function(fl) {
                     if (fl.name.indexOf("- Alaska National Parks") !== -1) {
                         alaskaNationalParks = fl;
-                        alaskaNationalParks.selectionColor = "yellow";
-                        alaskaNationalParks.selectionWidth = 5;
                     }
                 });
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
@@ -30,6 +30,10 @@ Rectangle {
         id: mapView
         anchors.fill: parent
 
+        SelectionProperties {
+            color: "yellow"
+        }
+
         Map {
             BasemapTopographic {}
         }
@@ -37,7 +41,6 @@ Rectangle {
         // Add a GraphicsOverlay
         GraphicsOverlay {
             id: graphicsOverlay
-            selectionColor: "yellow"
 
             // Add Polygon Graphic
             Graphic {


### PR DESCRIPTION
Assign to @anmacdonald 
Please review and merge.

Remove usage of deprecated `GraphicsOverlay::setSelectionColor`, `FeatureLayer::setSelectionColor`, and `FeatureLayer::setSelectionWidth`.  Replace with `GeoView::setSelectionProperties`.