### PR TITLE
Fixed ListRelatedFeatures crash.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -36,6 +36,17 @@
 
 using namespace Esri::ArcGISRuntime;
 
+namespace
+{
+  // Convenience RAII struct that deletes all pointers in given container.
+  struct FeatureQueryListResultLock
+  {
+    FeatureQueryListResultLock(const QList<RelatedFeatureQueryResult*>& list) : results(list) { }
+    ~FeatureQueryListResultLock() { qDeleteAll(results); }
+    const QList<RelatedFeatureQueryResult*>& results;
+  };
+}
+
 ListRelatedFeatures::ListRelatedFeatures(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent)
 {
@@ -80,58 +91,56 @@ void ListRelatedFeatures::connectSignals()
   {
     if (!loadError.isEmpty())
       return;
-    for (int i = 0; i < m_map->operationalLayers()->size(); i++)
+
+    for (int i = 0; i < m_map->operationalLayers()->size(); ++i)
     {
       // get the Alaska National Parks layer
-      if (m_map->operationalLayers()->at(i)->name().contains(QString("- Alaska National Parks")))
+      if (m_map->operationalLayers()->at(i)->name().contains(QStringLiteral("- Alaska National Parks")))
       {
         m_alaskaNationalParks = static_cast<FeatureLayer*>(m_map->operationalLayers()->at(i));
+        m_alaskaFeatureTable = static_cast<ArcGISFeatureTable*>(m_alaskaNationalParks->featureTable());
+
+        // connect to queryRelatedFeaturesCompleted signal
+        connect(m_alaskaFeatureTable, &ArcGISFeatureTable::queryRelatedFeaturesCompleted,
+                this, [this](QUuid, QList<RelatedFeatureQueryResult*> rawRelatedResults)
+                {
+                  FeatureQueryListResultLock lock(rawRelatedResults);
+                  for (const RelatedFeatureQueryResult* relatedResult : lock.results)
+                  {
+                    while (relatedResult->iterator().hasNext())
+                    {
+                      // get the related feature
+                      ArcGISFeature* feature = static_cast<ArcGISFeature*>(relatedResult->iterator().next());
+                      ArcGISFeatureTable* relatedTable = static_cast<ArcGISFeatureTable*>(feature->featureTable());
+                      QString displayFieldName = relatedTable->layerInfo().displayFieldName();
+                      QString serviceLayerName = relatedTable->layerInfo().serviceLayerName();
+                      QString displayFieldValue = feature->attributes()->attributeValue(displayFieldName).toString();
+
+                      // add the related feature to the list model
+                      RelatedFeature relatedFeature = RelatedFeature(displayFieldName,
+                                                                     displayFieldValue,
+                                                                     serviceLayerName);
+                      m_relatedFeaturesModel->addRelatedFeature(relatedFeature);
+                      emit relatedFeaturesModelChanged();
+                    }
+                  }
+                  emit showAttributeTable();
+                });
 
         // connect to selectFeaturesCompleted signal
         connect(m_alaskaNationalParks, &FeatureLayer::selectFeaturesCompleted, this, [this](QUuid, FeatureQueryResult* rawResult)
         {
-          QPointer<FeatureQueryResult> result(rawResult);
+          QScopedPointer<FeatureQueryResult> result(rawResult);
           // iterate over features returned
           while (result->iterator().hasNext())
           {
-            ArcGISFeature* arcGISFeature = static_cast<ArcGISFeature*>(result->iterator().next(this));
-            ArcGISFeatureTable* selectedTable = static_cast<ArcGISFeatureTable*>(arcGISFeature->featureTable());
-
-            // connect to queryRelatedFeaturesCompleted signal
-            connect(selectedTable, &ArcGISFeatureTable::queryRelatedFeaturesCompleted, this, [this, arcGISFeature](QUuid, QList<RelatedFeatureQueryResult*> relatedResults)
-            {
-              // Delete feature on completion. We need to do this as we've
-              // re-parented it from the initial FeatureQueryResult.
-              QScopedPointer<ArcGISFeature> arcGISFeatureLock(arcGISFeature);
-
-              for (const RelatedFeatureQueryResult* relatedResult : relatedResults)
-              {
-                while (relatedResult->iterator().hasNext())
-                {
-                  // get the related feature
-                  ArcGISFeature* feature = static_cast<ArcGISFeature*>(relatedResult->iterator().next());
-                  ArcGISFeatureTable* relatedTable = static_cast<ArcGISFeatureTable*>(feature->featureTable());
-                  QString displayFieldName = relatedTable->layerInfo().displayFieldName();
-                  QString serviceLayerName = relatedTable->layerInfo().serviceLayerName();
-                  QString displayFieldValue = feature->attributes()->attributeValue(displayFieldName).toString();
-
-                  // add the related feature to the list model
-                  RelatedFeature relatedFeature = RelatedFeature(displayFieldName,
-                                                                 displayFieldValue,
-                                                                 serviceLayerName);
-                  m_relatedFeaturesModel->addRelatedFeature(relatedFeature);
-                  emit relatedFeaturesModelChanged();
-                }
-              }
-
-              emit showAttributeTable();
-            });
+            ArcGISFeature* arcGISFeature = static_cast<ArcGISFeature*>(result->iterator().next());
 
             // zoom to the selected feature
             m_mapView->setViewpointGeometry(arcGISFeature->geometry().extent(), 100);
 
             // query related features
-            selectedTable->queryRelatedFeatures(arcGISFeature);
+            m_alaskaFeatureTable->queryRelatedFeatures(arcGISFeature);
           }
         });
       }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -92,11 +92,13 @@ void ListRelatedFeatures::connectSignals()
     if (!loadError.isEmpty())
       return;
 
-    for (int i = 0; i < m_map->operationalLayers()->size(); ++i)
+    bool foundLayer = false; // Found the Alaska National Parks layer.
+    for (int i = 0; i < m_map->operationalLayers()->size() || !foundLayer; ++i)
     {
       // get the Alaska National Parks layer
       if (m_map->operationalLayers()->at(i)->name().contains(QStringLiteral("- Alaska National Parks")))
       {
+        foundLayer = true;
         m_alaskaNationalParks = static_cast<FeatureLayer*>(m_map->operationalLayers()->at(i));
         m_alaskaFeatureTable = static_cast<ArcGISFeatureTable*>(m_alaskaNationalParks->featureTable());
 
@@ -131,8 +133,10 @@ void ListRelatedFeatures::connectSignals()
         connect(m_alaskaNationalParks, &FeatureLayer::selectFeaturesCompleted, this, [this](QUuid, FeatureQueryResult* rawResult)
         {
           QScopedPointer<FeatureQueryResult> result(rawResult);
-          // iterate over features returned
-          while (result->iterator().hasNext())
+          // The result could contain more than 1 feature, but we assume that
+          // there is only ever 1. If more are given they are ignored. We
+          // are only interested in the first (and only) feature.
+          if (result->iterator().hasNext())
           {
             ArcGISFeature* arcGISFeature = static_cast<ArcGISFeature*>(result->iterator().next());
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -112,11 +112,11 @@ void ListRelatedFeatures::connectSignals()
                     while (relatedResult->iterator().hasNext())
                     {
                       // get the related feature
-                      ArcGISFeature* feature = static_cast<ArcGISFeature*>(relatedResult->iterator().next());
-                      ArcGISFeatureTable* relatedTable = static_cast<ArcGISFeatureTable*>(feature->featureTable());
-                      QString displayFieldName = relatedTable->layerInfo().displayFieldName();
-                      QString serviceLayerName = relatedTable->layerInfo().serviceLayerName();
-                      QString displayFieldValue = feature->attributes()->attributeValue(displayFieldName).toString();
+                      const ArcGISFeature* feature = static_cast<ArcGISFeature*>(relatedResult->iterator().next());
+                      const ArcGISFeatureTable* relatedTable = static_cast<ArcGISFeatureTable*>(feature->featureTable());
+                      const QString displayFieldName = relatedTable->layerInfo().displayFieldName();
+                      const QString serviceLayerName = relatedTable->layerInfo().serviceLayerName();
+                      const QString displayFieldValue = feature->attributes()->attributeValue(displayFieldName).toString();
 
                       // add the related feature to the list model
                       RelatedFeature relatedFeature = RelatedFeature(displayFieldName,

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
@@ -21,9 +21,10 @@ namespace Esri
 {
   namespace ArcGISRuntime
   {
+    class ArcGISFeatureTable;
+    class FeatureLayer;
     class Map;
     class MapQuickView;
-    class FeatureLayer;
   }
 }
 class RelatedFeatureListModel;
@@ -56,6 +57,7 @@ private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_alaskaNationalParks = nullptr;  
+  Esri::ArcGISRuntime::ArcGISFeatureTable* m_alaskaFeatureTable = nullptr;
   RelatedFeatureListModel* m_relatedFeaturesModel = nullptr;
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListRelatedFeatures- C++"); 
   
-  // Initialize the sample≥÷.;
+  // Initialize the sample.
   ListRelatedFeatures::init();
 
   // Initialize application view


### PR DESCRIPTION
A more correct version of the previous commit, based on feedback from lsmallwood.

Conceptual relationship model had issues.
Duplicate connections were made to the
same table for each layer. One connection
would clean up the contents,
and the remaining connections would attempt to
act upon the corrputed memory.