### PR TITLE
Callouts now correctly parented.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
@@ -33,16 +33,16 @@ ProjectGeometrySample {
         id: mapView
         anchors.fill: parent
         objectName: "mapView"
-    }
 
-    // Declare a callout
-    Callout {
-        id: callout
-        calloutData: parent.calloutData
-        accessoryButtonHidden: true
-        autoAdjustWidth: true
-        maxWidth: 350 * scaleFactor
-        leaderPosition: leaderPositionEnum.Automatic
+        // Declare a callout
+        Callout {
+            id: callout
+            calloutData: rootRectangle.calloutData
+            accessoryButtonHidden: true
+            autoAdjustWidth: true
+            maxWidth: 350 * scaleFactor
+            leaderPosition: leaderPositionEnum.Automatic
+        }
     }
 
     onCalloutDataChanged: callout.showCallout();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
@@ -46,6 +46,16 @@ Rectangle {
             }
         }
 
+        // Declare a callout
+        Callout {
+            id: callout
+            calloutData: parent.calloutData
+            accessoryButtonHidden: true
+            autoAdjustWidth: true
+            maxWidth: 350 * scaleFactor
+            leaderPosition: leaderPositionEnum.Automatic
+        }
+
         // create a graphics to show the input location
         GraphicsOverlay {
 
@@ -89,15 +99,5 @@ Rectangle {
             // show the callout
             callout.showCallout();
         }
-    }
-
-    // Declare a callout
-    Callout {
-        id: callout
-        calloutData: mapView.calloutData
-        accessoryButtonHidden: true
-        autoAdjustWidth: true
-        maxWidth: 350 * scaleFactor
-        leaderPosition: leaderPositionEnum.Automatic
     }
 }


### PR DESCRIPTION
Callouts weren't parented correctly. Was not noticed before as ``leaderPosition: leaderPositionEnum.Automatic`` was not invoked before. 