### PR TITLE
Anmacdonald/update to https

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.cpp
@@ -53,7 +53,7 @@ void AnalyzeHotspots::componentComplete()
   m_mapView->setMap(m_map);
 
   // Create the Geoprocessing Task
-  m_hotspotTask = new GeoprocessingTask(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot"), this);
+  m_hotspotTask = new GeoprocessingTask(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot"), this);
 
   // Connect to the GP Task's errorOccurred signal
   connect(m_hotspotTask, &GeoprocessingTask::errorOccurred, this, [this](Error error)

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
@@ -51,14 +51,14 @@ void DistanceMeasurementAnalysis::componentComplete()
   Scene* scene = new Scene(Basemap::imagery(this), this);
 
   // Add a Scene Layer
-  ArcGISSceneLayer* sceneLayer = new ArcGISSceneLayer(QUrl("http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
+  ArcGISSceneLayer* sceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
   scene->operationalLayers()->append(sceneLayer);
 
   // Create a list of elevation sources
   const QList<ElevationSource*> sources
   {
     new ArcGISTiledElevationSource(
-          QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+          QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
           this),
         new ArcGISTiledElevationSource(
           QUrl("https://tiles.arcgis.com/tiles/d3voDfTFbHOCRwVR/arcgis/rest/services/MNT_IDF/ImageServer"),

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
@@ -48,7 +48,7 @@ void LineOfSightLocation::componentComplete()
   Surface* surface = new Surface(this);
   surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+          QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
           this));
   scene->setBaseSurface(surface);
   m_sceneView->setArcGISScene(scene);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.cpp
@@ -52,12 +52,12 @@ void ViewshedCamera::componentComplete()
   Surface* surface = new Surface(this);
   surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"),
+          QUrl("https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"),
           this));
   m_scene->setBaseSurface(surface);
 
   // Add a Scene Layer
-  ArcGISSceneLayer* sceneLayer = new ArcGISSceneLayer(QUrl("http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
+  ArcGISSceneLayer* sceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
   m_scene->operationalLayers()->append(sceneLayer);
 
   // Add an AnalysisOverlay

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
@@ -62,12 +62,12 @@ void ViewshedGeoElement::componentComplete()
   Surface* surface = new Surface(this);
   surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"),
+          QUrl("https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"),
           this));
   scene->setBaseSurface(surface);
 
   // Add a SceneLayer
-  ArcGISSceneLayer* sceneLayer = new ArcGISSceneLayer(QUrl("http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
+  ArcGISSceneLayer* sceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
   scene->operationalLayers()->append(sceneLayer);
 
   // Add an AnalysisOverlay

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
@@ -50,7 +50,7 @@ void ViewshedLocation::componentComplete()
   Surface* surface = new Surface(this);
   surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+          QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
           this));
   scene->setBaseSurface(surface);
   m_sceneView->setArcGISScene(scene);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.cpp
@@ -72,13 +72,13 @@ void BuildLegend::componentComplete()
 
 void BuildLegend::addLayers()
 {
-  ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(QUrl("http://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer"), this);
+  ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(QUrl("https://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer"), this);
   m_map->operationalLayers()->append(tiledLayer);
 
-  ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
+  ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
   m_map->operationalLayers()->append(mapImageLayer);
 
-  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"), this);
+  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"), this);
   FeatureLayer* featureLayer = new FeatureLayer(featureTable, this);
   m_map->operationalLayers()->append(featureLayer);
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp
@@ -85,7 +85,7 @@ void GODictionaryRenderer_3D::componentComplete()
   connect(surface, &Surface::errorOccurred, this, &GODictionaryRenderer_3D::logError);
   surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+          QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
           this));
   scene->setBaseSurface(surface);
   m_sceneView->setArcGISScene(scene);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.cpp
@@ -68,7 +68,7 @@ void Picture_Marker_Symbol::componentComplete()
   m_graphicsOverlay = new GraphicsOverlay(this);
 
   // create a campsite symbol from a URL
-  PictureMarkerSymbol* campSymbol = new PictureMarkerSymbol(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae"), this);
+  PictureMarkerSymbol* campSymbol = new PictureMarkerSymbol(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae"), this);
   setWidthAndHeight(campSymbol, 38.0f);
   Point campPoint(-228835, 6550763, SpatialReference::webMercator());
   addGraphic(campPoint, campSymbol);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.cpp
@@ -61,7 +61,7 @@ void Unique_Value_Renderer::componentComplete()
   m_map = new Map(basemap, this);
 
   // create featureLayer with URL
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"), this);
   m_featureLayer = new FeatureLayer(m_featureTable, this);
   m_map->operationalLayers()->append(m_featureLayer);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -74,7 +74,7 @@ void AddFeaturesFeatureService::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the ServiceFeatureTable
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -66,7 +66,7 @@ void DeleteFeaturesFeatureService::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the ServiceFeatureTable
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.h
@@ -72,7 +72,7 @@ private:
   Esri::ArcGISRuntime::ArcGISFeature* m_selectedFeature = nullptr;
   QString m_dataPath;
   qint64 m_featureLayerId = 0;
-  QString m_featureServiceUrl = QStringLiteral("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer/");
+  QString m_featureServiceUrl = QStringLiteral("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer/");
   bool m_isOffline = false;
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -78,7 +78,7 @@ void EditFeatureAttachments::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the ServiceFeatureTable
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -75,7 +75,7 @@ void UpdateAttributesFeatureService::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the ServiceFeatureTable
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -73,7 +73,7 @@ void UpdateGeometryFeatureService::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the ServiceFeatureTable
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
 
   // create the FeatureLayer with the ServiceFeatureTable and add it to the Map
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
@@ -60,7 +60,7 @@ void FeatureLayerChangeRenderer::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the feature table
-  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"), this);
+  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"), this);
   // create the feature layer using the feature table
   m_featureLayer = new FeatureLayer(featureTable, this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.cpp
@@ -61,7 +61,7 @@ void FeatureLayerDefinitionExpression::componentComplete()
   //! [Obtain the instantiated map view in Cpp]
 
   // create the feature table
-  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"), this);
+  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"), this);
   // create the feature layer using the feature table
   m_featureLayer = new FeatureLayer(featureTable, this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.cpp
@@ -57,7 +57,7 @@ void FeatureLayerFeatureService::componentComplete()
 
   //! [Display Feature Service]
   // create the feature table
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9"), this);
 
   // create the feature layer using the feature table
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.cpp
@@ -66,7 +66,7 @@ void FeatureLayerQuery::componentComplete()
     m_mapView->setMap(m_map);
 
     // create the feature table
-    m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"), this);
+    m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"), this);
     // create the feature layer using the feature table
     m_featureLayer = new FeatureLayer(m_featureTable, this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -63,7 +63,7 @@ void FeatureLayerSelection::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the feature table
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
   // create the feature layer using the feature table
   m_featureLayer = new FeatureLayer(m_featureTable, this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.h
@@ -60,7 +60,7 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::GeodatabaseSyncTask* m_syncTask = nullptr;
   QString m_dataPath;
-  QString m_featureServiceUrl = QStringLiteral("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer/");
+  QString m_featureServiceUrl = QStringLiteral("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer/");
   QStringList m_serviceIds;
   Esri::ArcGISRuntime::ArcGISFeatureServiceInfo m_featureServiceInfo;
 };

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.cpp
@@ -57,7 +57,7 @@ void ServiceFeatureTableCache::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the feature table
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"), this);
 
   // create the feature layer using the feature table
   m_featureLayer = new FeatureLayer(m_featureTable, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.cpp
@@ -59,7 +59,7 @@ void ServiceFeatureTableManualCache::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the feature table
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"), this);
   m_featureTable->setFeatureRequestMode(FeatureRequestMode::ManualCache);
 
   // create the feature layer using the feature table

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.cpp
@@ -57,7 +57,7 @@ void ServiceFeatureTableNoCache::componentComplete()
   m_mapView->setMap(m_map);
 
   // create the feature table
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"), this);
 
   // set the feature request mode
   m_featureTable->setFeatureRequestMode(FeatureRequestMode::OnInteractionNoCache);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.cpp
@@ -45,7 +45,7 @@ void ArcGISMapImageLayerUrl::componentComplete()
   m_mapView = findChild<MapQuickView*>("mapView");
 
   // create a new map image layer
-  ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("http://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer"), this);
+  ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer"), this);
 
   // create a new basemap from the layer
   Basemap* basemap = new Basemap(mapImageLayer, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.cpp
@@ -46,7 +46,7 @@ void ArcGISTiledLayerUrl::componentComplete()
 
   //! [display tiled layer from tiled map service]
   // create a new tiled layer
-  ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(QUrl("http://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer"), this);
+  ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(QUrl("https://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer"), this);
   // create a new basemap instance with the tiled layer
   Basemap* basemap = new Basemap(tiledLayer, this);
   // create a new map instance

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.cpp
@@ -50,7 +50,7 @@ void ChangeSublayerRenderer::componentComplete()
   m_map = new Map(Basemap::streets(this), this);
 
   // Add the map image layer
-  ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
+  ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
 
   // Get the sublayer
   connect(mapImageLayer, &ArcGISMapImageLayer::doneLoading, this, [this, mapImageLayer](Error e)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.cpp
@@ -54,7 +54,7 @@ void ChangeSublayerVisibility::componentComplete()
   m_map->setInitialViewpoint(Viewpoint(Point(-11e6, 6e6, SpatialReference(102100)), 9e7));
 
   // add the map image layer
-  m_mapImageLayer = new ArcGISMapImageLayer(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"), this);
+  m_mapImageLayer = new ArcGISMapImageLayer(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"), this);
   m_map->operationalLayers()->append(m_mapImageLayer);
 
   // set map on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.h
@@ -56,7 +56,7 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::ExportTileCacheTask* m_exportTileCacheTask = nullptr;
   Esri::ArcGISRuntime::ExportTileCacheParameters m_parameters;
-  QUrl m_serviceUrl = QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
+  QUrl m_serviceUrl = QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
 };
 
 #endif // EXPORT_TILES

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.cpp
@@ -67,7 +67,7 @@ void FeatureCollectionLayerQuery::componentComplete()
   m_mapView->setMap(m_map);
 
   //initialize service feature table to be queried
-  m_featureTable = new ServiceFeatureTable(QUrl(QStringLiteral("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0")), this);
+  m_featureTable = new ServiceFeatureTable(QUrl(QStringLiteral("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0")), this);
 
   //create query parameters
   QueryParameters queryParams;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.cpp
@@ -54,7 +54,7 @@ void RasterFunctionService::componentComplete()
   m_mapView->setMap(m_map);
 
   // create an image service raster
-  m_imageServiceRaster = new ImageServiceRaster(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer"), this);
+  m_imageServiceRaster = new ImageServiceRaster(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer"), this);
   // zoom to the raster's extent once it's loaded
   connect(m_imageServiceRaster, &ImageServiceRaster::doneLoading, this, [this]()
   {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.cpp
@@ -51,14 +51,14 @@ void RasterLayerService::componentComplete()
 
   // create a new tiled layer to add a basemap
   ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(
-        QUrl(QStringLiteral("http://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer")), this);
+        QUrl(QStringLiteral("https://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer")), this);
   m_map = new Map(new Basemap(tiledLayer, this));
   m_mapView->setMap(m_map);
 
   //! [ImageServiceRaster Create a new image service raster]
   // create an image service raster
   ImageServiceRaster* imageServiceRaster = new ImageServiceRaster(
-        QUrl(QStringLiteral("http://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer")), this);
+        QUrl(QStringLiteral("https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer")), this);
   // zoom to the center of the raster once it's loaded
   connect(imageServiceRaster, &ImageServiceRaster::doneLoading, this, [this, imageServiceRaster]()
   {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.cpp
@@ -47,7 +47,7 @@ void StyleWmsLayer::componentComplete()
   m_map = new Map(Basemap::imagery(this), this);
 
   // Add a WMS Layer
-  WmsLayer* wmsLayer = new WmsLayer(QUrl("http://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"), QStringList{"fsa2017"}, this);
+  WmsLayer* wmsLayer = new WmsLayer(QUrl("https://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"), QStringList{"fsa2017"}, this);
   m_map->operationalLayers()->append(wmsLayer);
 
   // connect to the doneLoading signal of the WMS Layer

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.cpp
@@ -47,7 +47,7 @@ void StyleWmsLayer::componentComplete()
   m_map = new Map(Basemap::imagery(this), this);
 
   // Add a WMS Layer
-  WmsLayer* wmsLayer = new WmsLayer(QUrl("https://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"), QStringList{"fsa2017"}, this);
+  WmsLayer* wmsLayer = new WmsLayer(QUrl("http://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"), QStringList{"fsa2017"}, this);
   m_map->operationalLayers()->append(wmsLayer);
 
   // connect to the doneLoading signal of the WMS Layer

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.cpp
@@ -49,7 +49,7 @@ void VectorTiledLayerUrl::componentComplete()
 
   //! [display vector tiled layer]
   // create a vector tiled basemap
-  ArcGISVectorTiledLayer* vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"), this);
+  ArcGISVectorTiledLayer* vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"), this);
   Basemap* basemap = new Basemap(vectorTiledLayer, this);
   // create a new map instance
   m_map = new Map(basemap, this);
@@ -68,17 +68,17 @@ void VectorTiledLayerUrl::changeBasemap(const QString& basemap)
   {
     ArcGISVectorTiledLayer* vectorTiledLayer = nullptr;
     if (basemap == "Mid-Century")
-      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"), this);
+      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"), this);
     else if (basemap == "Colored Pencil")
-      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=4cf7e1fb9f254dcda9c8fbadb15cf0f8"), this);
+      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=4cf7e1fb9f254dcda9c8fbadb15cf0f8"), this);
     else if (basemap == "Newspaper")
-      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=dfb04de5f3144a80bc3f9f336228d24a"), this);
+      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=dfb04de5f3144a80bc3f9f336228d24a"), this);
     else if (basemap == "Nova")
-      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=75f4dfdff19e445395653121a95a85db"), this);
+      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=75f4dfdff19e445395653121a95a85db"), this);
     else if (basemap == "World Street Map (Night)")
-      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f"), this);
+      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f"), this);
     else
-      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("http://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"), this);
+      vectorTiledLayer = new ArcGISVectorTiledLayer(QUrl("https://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"), this);
     Basemap* basemap = new Basemap(vectorTiledLayer, this);
     m_map->setBasemap(basemap);
   }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.h
@@ -45,7 +45,7 @@ private:
 private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::WmtsService* m_service = nullptr;
-  const QUrl m_wmtsServiceUrl = QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS");
+  const QUrl m_wmtsServiceUrl = QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS");
 };
 
 #endif // WMTS_LAYER_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.cpp
@@ -48,7 +48,7 @@ void Web_Tiled_Layer::componentComplete()
   m_mapView = findChild<MapQuickView*>("mapView");
 
   // Set up the tiled layer parameters
-  const QString templateUrl = "https://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png";
+  const QString templateUrl = "http://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png";
   const QStringList subDomains { "a", "b", "c", "d" };
   const QString attributionText = "Map tiles by <a href=\"https://stamen.com\">Stamen Design</a>, "
                                   "under <a href=\"https://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. "

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.cpp
@@ -48,12 +48,12 @@ void Web_Tiled_Layer::componentComplete()
   m_mapView = findChild<MapQuickView*>("mapView");
 
   // Set up the tiled layer parameters
-  const QString templateUrl = "http://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png";
+  const QString templateUrl = "https://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png";
   const QStringList subDomains { "a", "b", "c", "d" };
-  const QString attributionText = "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, "
-                                  "under <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. "
-                                  "Data by <a href=\"http://openstreetmap.org\">OpenStreetMap</a>, "
-                                  "under <a href=\"http://www.openstreetmap.org/copyright\">ODbL</a>.";
+  const QString attributionText = "Map tiles by <a href=\"https://stamen.com\">Stamen Design</a>, "
+                                  "under <a href=\"https://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. "
+                                  "Data by <a href=\"https://openstreetmap.org\">OpenStreetMap</a>, "
+                                  "under <a href=\"https://www.openstreetmap.org/copyright\">ODbL</a>.";
 
   // Create the WebTiledLayer with a template URL, sub domains, and copyright information
   WebTiledLayer* webTiledLayer = new WebTiledLayer(templateUrl, subDomains, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.cpp
@@ -51,7 +51,7 @@ void DisplayDrawingStatus::componentComplete()
   m_map->setInitialViewpoint(Viewpoint(Envelope(-13639984, 4537387, -13606734, 4558866, SpatialReference::webMercator())));
 
   // create feature layer
-  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
+  ServiceFeatureTable* featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"), this);
   m_featureLayer = new FeatureLayer(featureTable, this);
 
   // add the layer to the map

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.cpp
@@ -79,19 +79,19 @@ void DisplayLayerViewDrawStatus::componentComplete()
 void DisplayLayerViewDrawStatus::addLayers()
 {
   // create tiled layer using a url
-  m_tiledLayer = new ArcGISTiledLayer(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer"), this);
+  m_tiledLayer = new ArcGISTiledLayer(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer"), this);
   // add to map
   m_map->operationalLayers()->append(m_tiledLayer);
 
   // create map image using url
-  m_imageLayer = new ArcGISMapImageLayer(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
+  m_imageLayer = new ArcGISMapImageLayer(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
   m_imageLayer->setMinScale(40000000);
   m_imageLayer->setMaxScale(2000000);
   // add to map
   m_map->operationalLayers()->append(m_imageLayer);
 
   // create feature table using url
-  m_featureTable = new ServiceFeatureTable(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"), this);
+  m_featureTable = new ServiceFeatureTable(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"), this);
   // create feature layer using table
   m_featureLayer = new FeatureLayer(m_featureTable, this);
   // add feature layer to map

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
@@ -52,7 +52,7 @@ void IdentifyLayers::componentComplete()
   m_map = new Map(Basemap::topographic(this), this);
 
   // add a map image layer
-  QUrl mapServiceUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
+  QUrl mapServiceUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
   ArcGISMapImageLayer* imageLayer = new ArcGISMapImageLayer(mapServiceUrl, this);
   m_map->operationalLayers()->append(imageLayer);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.cpp
@@ -54,7 +54,7 @@ void OpenMapUrl::openMap(const QString& itemId)
 {
   //! [Construct map from a webmap Url]
   // create a QUrl using the item id QString
-  QString organizationPortalUrl(QStringLiteral("http://arcgis.com"));
+  QString organizationPortalUrl(QStringLiteral("https://arcgis.com"));
   const QUrl webmapUrl(QString(organizationPortalUrl + "/sharing/rest/content/items/" + itemId));
   // create a new map from the webmap Url
   Map* map = new Map(webmapUrl, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.cpp
@@ -50,7 +50,7 @@ void SetMapSpatialReference::componentComplete()
   m_map = new Map(SpatialReference(54024), this);
 
   // create the URL pointing to the map image layer
-  QUrl imageLayerUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
+  QUrl imageLayerUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
 
   // construct the ArcGISMapImageLayer using the URL
   m_imageLayer = new ArcGISMapImageLayer(imageLayerUrl, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
@@ -28,10 +28,10 @@
 using namespace Esri::ArcGISRuntime;
 
 const QUrl ClosestFacility::facilityImageUrl(
-    QStringLiteral("http://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png"));
+    QStringLiteral("https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png"));
 
 const QUrl ClosestFacility::sanDiegoRegion(
-    QStringLiteral("http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ClosestFacility"));
+    QStringLiteral("https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ClosestFacility"));
 
 ClosestFacility::ClosestFacility(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent),

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.cpp
@@ -119,7 +119,7 @@ void FindRoute::setupRouteTask()
 {
   //! [FindRoute new RouteTask]
   // create the route task pointing to an online service
-  m_routeTask = new RouteTask(QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route"), this);
+  m_routeTask = new RouteTask(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route"), this);
 
   // connect to loadStatusChanged signal
   connect(m_routeTask, &RouteTask::loadStatusChanged, this, [this](LoadStatus loadStatus)

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
@@ -30,7 +30,7 @@ using namespace Esri::ArcGISRuntime;
 ServiceArea::ServiceArea(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent),
   m_task(new ServiceAreaTask(
-           QUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ServiceArea"), this))
+           QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ServiceArea"), this))
 {
 }
 
@@ -189,7 +189,7 @@ void ServiceArea::setupGraphics()
 {
   // create a symbol for the incidents
   PictureMarkerSymbol* facilitySymbol = new PictureMarkerSymbol(
-        QUrl(QStringLiteral("http://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png")), this);
+        QUrl(QStringLiteral("https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png")), this);
   facilitySymbol->setHeight(30);
   facilitySymbol->setWidth(30);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.cpp
@@ -89,7 +89,7 @@ void Animate3DSymbols::componentComplete()
 
   // create a new elevation source
   ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(
-    QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
+    QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
 
   // add the elevation source to the scene to display elevation
   scene->baseSurface()->elevationSources()->append(elevationSource);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.cpp
@@ -51,7 +51,7 @@ void BasicSceneView::componentComplete()
   m_sceneView->setArcGISScene(m_scene);
 
   //! [create a new elevation source]
-  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
+  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
   // add the elevation source to the scene to display elevation
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
   //! [create a new elevation source]

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.cpp
@@ -52,12 +52,12 @@ void DisplaySceneLayer::componentComplete()
   m_scene = new Scene(basemap, this);
 
   //! [add a scene service with ArcGISSceneLayer]
-  m_sceneLayer = new ArcGISSceneLayer(QUrl("http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
+  m_sceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
   m_scene->operationalLayers()->append(m_sceneLayer);
   //! [add a scene service with ArcGISSceneLayer]
 
   // create a new elevation source and add to scene
-  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
+  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
 
   // create a camera and set the initial viewpoint

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.cpp
@@ -62,7 +62,7 @@ void DistanceCompositeSymbol::componentComplete()
   m_sceneView->setArcGISScene(m_scene);
 
   // create a new elevation source
-  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
+  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
   // add the elevation source to the scene to display elevation
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.h
@@ -45,7 +45,7 @@ private:
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
-  QUrl m_elevationSourceUrl = QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
+  QUrl m_elevationSourceUrl = QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer");
   int m_maxZ = 1000;
   double m_size = 0.01;
 };

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
@@ -54,12 +54,12 @@ void SceneLayerSelection::componentComplete()
   Surface* surface = new Surface(this);
   surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+          QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
           this));
   scene->setBaseSurface(surface);
 
   // add a scene layer
-  m_sceneLayer = new ArcGISSceneLayer(QUrl("http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
+  m_sceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"), this);
   scene->operationalLayers()->append(m_sceneLayer);
 
   // Set an initial viewpoint

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/Surface_Placement.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/Surface_Placement.cpp
@@ -53,7 +53,7 @@ void Surface_Placement::componentComplete()
   m_sceneView = findChild<SceneQuickView*>("sceneView");
   Scene* scene = new Scene(Basemap::imagery(this), this);
   Surface* surface = new Surface(this);
-  surface->elevationSources()->append(new ArcGISTiledElevationSource(QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this));
+  surface->elevationSources()->append(new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this));
   scene->setBaseSurface(surface);
   //! [Create Scene API snippet]
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.cpp
@@ -52,7 +52,7 @@ void Symbols::componentComplete()
   m_sceneView->setArcGISScene(m_scene);
 
   // create a new elevation source
-  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
+  ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
   // add the elevation source to the scene to display elevation
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.cpp
@@ -46,7 +46,7 @@ void TerrainExaggeration::componentComplete()
   m_surface = new Surface(this);
   m_surface->elevationSources()->append(
         new ArcGISTiledElevationSource(
-          QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+          QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
           this));
 
   // Create the camera object at our initial viewpoint

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
@@ -74,7 +74,7 @@ void FindAddress::componentComplete()
 
   // create locator task and parameters
   //! [FindAddress create LocatorTask]
-  m_locatorTask = new LocatorTask(QUrl("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"), this);
+  m_locatorTask = new LocatorTask(QUrl("https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"), this);
   //! [FindAddress create LocatorTask]
   m_geocodeParameters.setMinScore(75);
   m_geocodeParameters.setResultAttributeNames(QStringList { "Place_addr", "Match_addr" });

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.cpp
@@ -28,7 +28,7 @@ ArcGISTiledLayerUrl::ArcGISTiledLayerUrl(QWidget* parent) :
   QWidget(parent)
 {
     // create the URL pointing to the tiled map service
-    QUrl tiledLayerUrl("http://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer");
+    QUrl tiledLayerUrl("https://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer");
 
     // construct the ArcGISTiledLayer using the URL
     m_tiledLayer = new ArcGISTiledLayer(tiledLayerUrl, this);

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.cpp
@@ -60,7 +60,7 @@ OpenExistingMap::OpenExistingMap(QWidget* parent) :
         if(portalId.isEmpty())
             return;
 
-        PortalItem* portalItem = new PortalItem(QUrl("http://arcgis.com/sharing/rest/content/items/" + portalId), this);
+        PortalItem* portalItem = new PortalItem(QUrl("https://arcgis.com/sharing/rest/content/items/" + portalId), this);
 
         // create a new map from the portal item
         Map* map = new Map(portalItem, this);

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.cpp
@@ -32,7 +32,7 @@ SetMapSpatialReference::SetMapSpatialReference(QWidget* parent) :
     m_map = new Map(SpatialReference(54024), this);
 
     // create the URL pointing to the map image layer
-    QUrl imageLayerUrl("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
+    QUrl imageLayerUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
 
     // construct the ArcGISMapImageLayer using the URL
     m_imageLayer = new ArcGISMapImageLayer(imageLayerUrl, this);

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.cpp
@@ -33,7 +33,7 @@ BasicSceneView::BasicSceneView(QWidget* parent) :
     m_sceneView = new SceneGraphicsView(m_scene, this);
 
     // create an elevation source
-    ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
+    ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this);
     m_scene->baseSurface()->elevationSources()->append(elevationSource);
 
     // create a camera

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -45,7 +45,7 @@ Rectangle {
     // Declare the GeoprocessingTask and set the URL
     GeoprocessingTask {
         id: hotspotTask
-        url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot"
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/GPServer/911%20Calls%20Hotspot"
 
         onErrorChanged: {
             if (error)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
@@ -42,13 +42,13 @@ Rectangle {
 
             // Add a Scene Layer
             ArcGISSceneLayer {
-                url: "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
+                url: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
             }
 
             // Set the Surface
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
                 ArcGISTiledElevationSource {
                     url: "https://tiles.arcgis.com/tiles/d3voDfTFbHOCRwVR/arcgis/rest/services/MNT_IDF/ImageServer"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/LineOfSightLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/LineOfSightLocation.qml
@@ -39,7 +39,7 @@ Rectangle {
 
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
@@ -38,13 +38,13 @@ Rectangle {
             // Set the Scene's Surface
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"
+                    url: "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"
                 }
             }
 
             // Add a Scene Layer
             ArcGISSceneLayer {
-                url: "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
+                url: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
             }
 
             // Set an initial viewpoint

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.qml
@@ -42,13 +42,13 @@ Rectangle {
             // Set the Scene's Surface
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"
+                    url: "https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer"
                 }
             }
 
             // Add a Scene Layer
             ArcGISSceneLayer {
-                url: "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
+                url: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
             }
 
             onLoadStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
@@ -40,7 +40,7 @@ Rectangle {
 
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -40,20 +40,20 @@ Rectangle {
             // Add a tiled layer as an operational layer
             ArcGISTiledLayer {
                 id: tiledLayer
-                url: "http://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer"
+                url: "https://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer"
             }
 
             // Add a map image layer as an operational layer
             ArcGISMapImageLayer {
                 id: mapImageLayer
-                url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
+                url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
             }
 
             // Add a feature layer as an operational layer
             FeatureLayer {
                 id: featureLayer
                 featureTable: ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -39,7 +39,7 @@ Rectangle {
             BasemapImagery {}
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
@@ -60,7 +60,7 @@ Rectangle {
                 }
 
                 PictureMarkerSymbol {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae"
                     width: 38.0
                     height: 38.0
                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.qml
@@ -36,7 +36,7 @@ Rectangle {
             // create feature layer using service feature table
             FeatureLayer {
                 ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"
                 }
 
                 // override the renderer of the feature layer with a new unique value renderer

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
@@ -51,7 +51,7 @@ Rectangle {
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
 
                     // make sure edits are successfully applied to the service
                     onApplyEditsStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -57,7 +57,7 @@ Rectangle {
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
 
                     // make sure edits are successfully applied to the service
                     onApplyEditsStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -28,7 +28,7 @@ Rectangle {
     property real scaleFactor: System.displayScaleFactor
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/"
     property url outputGdb: System.temporaryFolder.url + "/WildfireQml_%1.geodatabase".arg(new Date().getTime().toString())
-    property string featureServiceUrl: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer"
+    property string featureServiceUrl: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer"
     property Envelope generateExtent: null
     property string statusText: ""
     property string featureLayerId: "0"

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -57,7 +57,7 @@ Rectangle {
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
 
                     onApplyEditsStatusChanged: {
                         if (applyEditsStatus === Enums.TaskStatusCompleted) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -58,7 +58,7 @@ Rectangle {
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
 
                     // make sure edits are successfully applied to the service
                     onApplyEditsStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -54,7 +54,7 @@ Rectangle {
                 // declare as child of feature layer, as featureTable is the default property
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
 
                     // make sure edits are successfully applied to the service
                     onApplyEditsStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.qml
@@ -44,7 +44,7 @@ Rectangle {
                 // feature table
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/FeatureLayer_DefinitionExpression.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/FeatureLayer_DefinitionExpression.qml
@@ -43,7 +43,7 @@ Rectangle {
 
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/FeatureLayer_FeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/FeatureLayer_FeatureService.qml
@@ -36,7 +36,7 @@ Rectangle {
 
             FeatureLayer {
                 ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
@@ -62,7 +62,7 @@ Rectangle {
                 // feature table
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2"
 
                     onQueryFeaturesStatusChanged: {
                         if (queryFeaturesStatus === Enums.TaskStatusCompleted) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
@@ -50,7 +50,7 @@ Rectangle {
                 // feature table
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/GenerateGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/GenerateGeodatabase.qml
@@ -28,7 +28,7 @@ Rectangle {
     property real scaleFactor: System.displayScaleFactor
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/"
     property url outputGdb: System.temporaryFolder.url + "/WildfireQml_%1.geodatabase".arg(new Date().getTime().toString())
-    property string featureServiceUrl: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer"
+    property string featureServiceUrl: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer"
     property Envelope generateExtent: null
     property var generateLayerOptions: []
     property string statusText: ""

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/ServiceFeatureTable_Cache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/ServiceFeatureTable_Cache.qml
@@ -35,7 +35,7 @@ Rectangle {
 
             FeatureLayer {
                 ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
                     featureRequestMode: Enums.FeatureRequestModeOnInteractionCache
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.qml
@@ -42,7 +42,7 @@ Rectangle {
 
                 ServiceFeatureTable {
                     id: featureTable
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0"
                     featureRequestMode: Enums.FeatureRequestModeManualCache
 
                     onPopulateFromServiceStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/ServiceFeatureTable_NoCache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/ServiceFeatureTable_NoCache.qml
@@ -35,7 +35,7 @@ Rectangle {
 
             FeatureLayer {
                 ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0"
                     featureRequestMode: Enums.FeatureRequestModeOnInteractionNoCache
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.qml
@@ -30,7 +30,7 @@ Rectangle {
             Basemap {
                 // Nest an ArcGISMapImage Layer in the Basemap
                 ArcGISMapImageLayer {
-                    url: "http://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer"
+                    url: "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.qml
@@ -31,7 +31,7 @@ Rectangle {
             Basemap {
                 // Nest the ArcGISTiledLayer to add it as one of the Basemap's baseLayers
                 ArcGISTiledLayer {
-                    url: "http://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer"
+                    url: "https://services.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer"
                 }
             }
             //! [display tiled layer from tiled map service]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.qml
@@ -37,7 +37,7 @@ Rectangle {
             BasemapStreets {}
 
             ArcGISMapImageLayer {
-                url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
+                url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
 
                 onLoadStatusChanged: {
                     if (loadStatus !== Enums.LoadStatusLoaded)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -36,7 +36,7 @@ Rectangle {
             // Nest an ArcGISMapImage Layer in the Map to add it as an operational layer
             ArcGISMapImageLayer {
                 id: mapImageLayer
-                url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"
+                url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"
             }
 
             initialViewpoint: ViewpointCenter {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
@@ -28,7 +28,7 @@ Rectangle {
     property Envelope tileCacheExtent: null
     property url outputTileCache: System.temporaryFolder.url + "/TileCacheQml_%1.tpk".arg(new Date().getTime().toString())
     property string statusText: ""
-    property string tiledServiceUrl: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+    property string tiledServiceUrl: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
 
     property ExportTileCacheParameters params
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.qml
@@ -38,7 +38,7 @@ Rectangle {
 
     ServiceFeatureTable {
         id: featureTable
-        url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0"
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0"
 
         onQueryFeaturesStatusChanged: {
             if (queryFeaturesStatus !== Enums.TaskStatusCompleted)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.qml
@@ -42,7 +42,7 @@ Rectangle {
                 // create the raster layer from an image service raster
                 ImageServiceRaster {
                     id: imageServiceRaster
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer"
 
                     // zoom to the extent of the raster once it's loaded
                     onLoadStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/RasterLayerService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/RasterLayerService.qml
@@ -33,7 +33,7 @@ Rectangle {
             // create a basemap from a tiled layer and add to the map
             Basemap {
                 ArcGISTiledLayer {
-                    url: "http://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer"
+                    url: "https://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer"
                 }
             }
 
@@ -43,7 +43,7 @@ Rectangle {
                 // create the raster layer from an image service raster
                 ImageServiceRaster {
                     id: imageServiceRaster
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer"
 
                     // zoom to the center of the raster once it's loaded
                     onLoadStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
@@ -38,7 +38,7 @@ Rectangle {
 
             WmsLayer {
                 id: wmsLayer
-                url: "http://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"
+                url: "https://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"
                 layerNames: ["fsa2017"]
 
                 onLoadStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
@@ -38,7 +38,7 @@ Rectangle {
 
             WmsLayer {
                 id: wmsLayer
-                url: "https://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"
+                url: "http://geoint.lmic.state.mn.us/cgi-bin/wms?VERSION=1.3.0&SERVICE=WMS&REQUEST=GetCapabilities"
                 layerNames: ["fsa2017"]
 
                 onLoadStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -35,7 +35,7 @@ Rectangle {
             Basemap {
                 // Nest an ArcGISVectorTiledLayer Layer in the Basemap
                 ArcGISVectorTiledLayer {
-                    url: "http://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"
+                    url: "https://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"
                 }
             }
             initialViewpoint: ViewpointCenter {
@@ -67,19 +67,19 @@ Rectangle {
             switch (comboBoxBasemap.currentText) {
             case "Mid-Century":
             default:
-                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"http://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"});
+                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"https://www.arcgis.com/home/item.html?id=7675d44bb1e4428aa2c30a9b68f97822"});
                 break;
             case "Colored Pencil":
-                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"http://www.arcgis.com/home/item.html?id=4cf7e1fb9f254dcda9c8fbadb15cf0f8"});
+                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"https://www.arcgis.com/home/item.html?id=4cf7e1fb9f254dcda9c8fbadb15cf0f8"});
                 break;
             case "Newspaper":
-                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"http://www.arcgis.com/home/item.html?id=dfb04de5f3144a80bc3f9f336228d24a"});
+                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"https://www.arcgis.com/home/item.html?id=dfb04de5f3144a80bc3f9f336228d24a"});
                 break;
             case "Nova":
-                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"http://www.arcgis.com/home/item.html?id=75f4dfdff19e445395653121a95a85db"});
+                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"https://www.arcgis.com/home/item.html?id=75f4dfdff19e445395653121a95a85db"});
                 break;
             case "World Street Map (Night)":
-                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"http://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f"});
+                layer = ArcGISRuntimeEnvironment.createObject("ArcGISVectorTiledLayer", {url:"https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f"});
                 break;
             }
             var newBasemap = ArcGISRuntimeEnvironment.createObject("Basemap");

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/WMTS_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/WMTS_Layer.qml
@@ -23,7 +23,7 @@ Rectangle {
     width: 800
     height: 600
 
-    property url wmtsServiceUrl: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS"
+    property url wmtsServiceUrl: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/WMTS"
     property WmtsService service;
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
@@ -33,7 +33,7 @@ Rectangle {
             Basemap {
                 // Create a WebTiledLayer with a template URL, sub domains, and copyright information
                 WebTiledLayer {
-                    templateUrl: "https://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png"
+                    templateUrl: "http://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png"
                     subDomains: ["a", "b", "c", "d"]
                     attribution: "Map tiles by <a href=\"https://stamen.com\">Stamen Design</a>, " +
                                  "under <a href=\"https://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. " +

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
@@ -33,12 +33,12 @@ Rectangle {
             Basemap {
                 // Create a WebTiledLayer with a template URL, sub domains, and copyright information
                 WebTiledLayer {
-                    templateUrl: "http://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png"
+                    templateUrl: "https://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png"
                     subDomains: ["a", "b", "c", "d"]
-                    attribution: "Map tiles by <a href=\"http://stamen.com\">Stamen Design</a>, " +
-                                 "under <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. " +
-                                 "Data by <a href=\"http://openstreetmap.org\">OpenStreetMap</a>, " +
-                                 "under <a href=\"http://www.openstreetmap.org/copyright\">ODbL</a>."
+                    attribution: "Map tiles by <a href=\"https://stamen.com\">Stamen Design</a>, " +
+                                 "under <a href=\"https://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. " +
+                                 "Data by <a href=\"https://openstreetmap.org\">OpenStreetMap</a>, " +
+                                 "under <a href=\"https://www.openstreetmap.org/copyright\">ODbL</a>."
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -38,7 +38,7 @@ Rectangle {
             // create FeatureLayer using a service URL
             FeatureLayer {
                 ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawStatus/DisplayLayerViewDrawStatus.qml
@@ -36,12 +36,12 @@ Rectangle {
 
             // create tiled layer using url
             ArcGISTiledLayer {
-                url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer"
+                url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer"
             }
 
             // create a map image layer using a url
             ArcGISMapImageLayer {
-                url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
+                url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
                 minScale: 40000000
                 maxScale: 2000000
             }
@@ -49,7 +49,7 @@ Rectangle {
             //create a feature layer using a url
             FeatureLayer {
                 ServiceFeatureTable {
-                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"
+                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/IdentifyLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/IdentifyLayers.qml
@@ -35,7 +35,7 @@ Rectangle {
 
             // add a map image layer and hide 2 of the sublayers
             ArcGISMapImageLayer {
-                url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"
+                url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"
                 onLoadStatusChanged: {
                     if (error) {
                         console.log("error:", error.message, error.additionalMessage)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -74,7 +74,7 @@ Rectangle {
 
                     //! [Construct map from a webmap url]
                     // construct the webmap Url using the itemId
-                    var organizationPortalUrl = "http://arcgis.com/sharing/rest/content/items/";
+                    var organizationPortalUrl = "https://arcgis.com/sharing/rest/content/items/";
                     var webmapUrl = organizationPortalUrl + itemId;
                     // Create a new map and assign it the initUrl
                     var newMap = ArcGISRuntimeEnvironment.createObject("Map", {initUrl: webmapUrl});

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.qml
@@ -35,7 +35,7 @@ Rectangle {
     Basemap {
         id: basemap
         ArcGISMapImageLayer {
-            url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"
+            url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"
         }
     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/ClosestFacility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/ClosestFacility.qml
@@ -62,7 +62,7 @@ Rectangle {
 
             SimpleRenderer {
                 PictureMarkerSymbol {
-                    url: "http://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png"
+                    url: "https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png"
                     height: 30
                     width: 30
                 }
@@ -170,7 +170,7 @@ Rectangle {
 
     ClosestFacilityTask {
         id: task
-        url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ClosestFacility"
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ClosestFacility"
 
         onLoadStatusChanged: {
             if (loadStatus !== Enums.LoadStatusLoaded)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
@@ -215,7 +215,7 @@ Rectangle {
     // Create a RouteTask pointing to an online service
     RouteTask {
         id: routeTask
-        url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route"
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/Route"
 
         // Request default parameters once the task is loaded
         onLoadStatusChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -74,7 +74,7 @@ Rectangle {
 
             renderer: SimpleRenderer {
                 symbol: PictureMarkerSymbol {
-                    url: "http://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png"
+                    url: "https://static.arcgis.com/images/Symbols/SafetyHealth/Hospital.png"
                     height: 30
                     width: 30
                 }
@@ -152,7 +152,7 @@ Rectangle {
 
     ServiceAreaTask {
         id: task
-        url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ServiceArea"
+        url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/NetworkAnalysis/SanDiego/NAServer/ServiceArea"
 
         onLoadStatusChanged: {
             if (loadStatus !== Enums.LoadStatusLoaded)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -62,7 +62,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }     
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
@@ -38,7 +38,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.qml
@@ -34,7 +34,7 @@ Rectangle {
 
             //! [add a scene service with ArcGISSceneLayer]
             ArcGISSceneLayer {
-                url: "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
+                url: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
             }
             //! [add a scene service with ArcGISSceneLayer]
 
@@ -42,7 +42,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
@@ -42,7 +42,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
@@ -42,7 +42,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
@@ -34,7 +34,7 @@ Rectangle {
             // add a scene layer
             ArcGISSceneLayer {
                 id: sceneLayer
-                url: "http://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
+                url: "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0"
             }
 
             // set an initial viewpoint
@@ -60,7 +60,7 @@ Rectangle {
             // add an elevation surface
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/Surface_Placement.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/Surface_Placement.qml
@@ -32,7 +32,7 @@ Rectangle {
 
             Surface {
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
@@ -41,7 +41,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
@@ -41,7 +41,7 @@ Rectangle {
             Surface {
                 // add an arcgis tiled elevation source...elevation source is a default property of surface
                 ArcGISTiledElevationSource {
-                    url: "http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+                    url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
                 // elevationExaggeration is bound to the value of the slider
                 elevationExaggeration: slider.value

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/FindAddress.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/FindAddress.qml
@@ -104,7 +104,7 @@ Rectangle {
     // Create a locator task using the World Geocoding Service
     LocatorTask {
         id: locatorTask
-        url: "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"
+        url: "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer"
 
         // handle the result once the geocode status is complete
         onGeocodeStatusChanged: {


### PR DESCRIPTION
Updated `http` to `https` for all resources that can be safely upgraded. Some `http` remains.

As of Android level 28, plain http links can no longer
be accessed from an app. All http resources must be
upgraded to https.