### PR TITLE
Create and Save Map 'Create a new Map' button working

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -29,8 +29,6 @@ CreateAndSaveMapSample {
     property real scaleFactor: 1
 
     onPortalLoaded: {
-        options.visible = true;
-        options.reset();
         stackView.push(options);
     }
 
@@ -38,35 +36,23 @@ CreateAndSaveMapSample {
         if (stackView.currentItem === completionRect)
             return;
 
-        if (success) {
-            completeText.webmapUrl = "https://www.arcgis.com/home/item.html?id=%1".arg(itemId);
-            completeText.text = 'Map saved successfully.<br>View in <a href="%1">ArcGIS Online</a>'.arg(completeText.webmapUrl);
-        } else {
-            completeText.text = "An error occurred while saving the map. Details: %1".arg(error);
-        }
-        stackView.push(completionRect);
+        var url =  "https://www.arcgis.com/home/item.html?id=%1".arg(itemId);
+        stackView.push(completionRect,
+                       { text: success ? 'Map saved successfully.<br>View in <a href="%1">ArcGIS Online</a>'.arg(url)
+                                       : "An error occurred while saving the map. Details: %1".arg(error)
+                       });
     }
 
     StackView {
         id: stackView
         anchors.fill: parent
-
-        initialItem: LayerWindow {
-            id: layerWindow
-            onCreateMapSelected: {
-                mapView.visible = true;
-                stackView.push(mapView)
-                createMap(basemap, layerList);
-            }
-        }
+        initialItem: layerWindow
     }
 
     // add a mapView component
     MapView {
         id: mapView
         objectName: "mapView"
-        visible: false
-
         Button {
             anchors {
                 horizontalCenter: parent.horizontalCenter
@@ -81,48 +67,61 @@ CreateAndSaveMapSample {
         }
     }
 
-    // Window to display options for setting title, tags, and description
-    SaveOptionsWindow {
-        id: options
-        visible: false
-
-        onCancelClicked: {
-            mapView.visible = true;
-            stackView.pop(mapView)
+    Component {
+        id: layerWindow
+        LayerWindow {
+            onCreateMapSelected: {
+                stackView.push(mapView);
+                createMap(basemap, layerList);
+            }
         }
+    }
 
-        onSaveMapClicked: {
-            saveMap(title, tags, description);
+    // Window to display options for setting title, tags, and description
+    Component {
+        id: options
+        SaveOptionsWindow {
+            onCancelClicked: {
+                stackView.pop();
+            }
+
+            onSaveMapClicked: {
+                saveMap(title, tags, description);
+            }
         }
     }
 
     // Rectangle to display completion text
-    Rectangle {
+    Component {
         id: completionRect
+        Rectangle {
+            property alias text: completeText.text
 
-        Text {
-            id: completeText
-            anchors.centerIn: parent
-            width: 200 * scaleFactor
-            wrapMode: Text.Wrap
+            Text {
+                id: completeText
+                anchors.centerIn: parent
 
-            property string webmapUrl
-
-            textFormat: Text.RichText
-            horizontalAlignment: Text.AlignHCenter
-            onLinkActivated: Qt.openUrlExternally(webmapUrl)
-        }
-
-        Button {
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-                bottom: parent.bottom
-                margins: 10 * scaleFactor
+                textFormat: Text.RichText
+                horizontalAlignment: Text.AlignHCenter
+                onLinkActivated: Qt.openUrlExternally(link)
             }
-            text: "Create New Map"
-            onClicked: {
-                stackView.clear();
-                stackView.push(layerWindow)
+
+            Button {
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    bottom: parent.bottom
+                    margins: 5 * scaleFactor
+                }
+                text: "Create New Map"
+                onClicked: {
+                    // We need a local ref to the stackView and layerWindow
+                    // object as our object references will have been deleted
+                    // once "clear" cleans up this object.
+                    var sv = stackView;
+                    var lWindow = layerWindow;
+                    sv.clear();
+                    sv.push(lWindow);
+                }
             }
         }
     }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.4
 import QtGraphicalEffects 1.0
 
 Rectangle {
@@ -28,80 +29,79 @@ Rectangle {
     signal createMapSelected(var basemap, var layerList)
 
     Rectangle {
-        anchors {
-            fill: layerColumn
-            margins: -15 * scaleFactor
-        }
-
         color: "#edeeef"
         radius: 5 * scaleFactor
+        width: childrenRect.width
+        height: childrenRect.height
+        anchors.centerIn: parent
         border {
             color: "#77787a"
             width: 1 * scaleFactor
         }
-    }
 
-    Column {
-        id: layerColumn
-        anchors.centerIn: parent
-        width: 200 * scaleFactor
-
-        spacing: 10 * scaleFactor
-
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            text: "Select Layers"
-            font {
-                pixelSize: 18 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        Text {
-            text: "Select Basemap:"
-            font {
-                pixelSize: 14 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        ComboBox {
-            id: basemapComboBox
-            width: parent.width
-            model: ["Streets", "Imagery", "Topographic", "Oceans"]
-        }
-
-        Text {
-            text: "Select Operational Layers:"
-            font {
-                pixelSize: 14 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        Repeater {
-            id: operationalLayerRepeater
-            width: parent.width
-            model: ["WorldElevations", "Census"]
-
-            CheckBox {
-                text: modelData
-                checked: true
-            }
-        }
-
-        Button {
-            width: parent.width
-            text: "Create Map"
-            onClicked: {
-                var layerList = [];
-                for (var i = 0; i < operationalLayerRepeater.count; i++) {
-                    var currentCheckbox = operationalLayerRepeater.itemAt(i);
-                    if (currentCheckbox.checked) {
-                        layerList.push(currentCheckbox.text)
-                    }
+        ColumnLayout {
+            id: layerColumn
+            Text {
+                Layout.margins: 5
+                Layout.alignment: Qt.AlignHCenter
+                text: "Select Layers"
+                font {
+                    pixelSize: 18 * scaleFactor
+                    family: "helvetica"
                 }
-                createMapSelected(basemapComboBox.currentText, layerList);
+            }
+
+            Text {
+                Layout.margins: 5
+                text: "Select Basemap:"
+                font {
+                    pixelSize: 14 * scaleFactor
+                    family: "helvetica"
+                }
+            }
+
+            ComboBox {
+                id: basemapComboBox
+                Layout.margins: 5
+                Layout.fillWidth: true
+                model: ["Streets", "Imagery", "Topographic", "Oceans"]
+            }
+
+            Text {
+                Layout.margins: 5
+                text: "Select Operational Layers:"
+                font {
+                    pixelSize: 14 * scaleFactor
+                    family: "helvetica"
+                }
+            }
+
+            Repeater {
+                id: operationalLayerRepeater
+                Layout.margins: 5
+                Layout.fillWidth: true
+                model: ["WorldElevations", "Census"]
+
+                CheckBox {
+                    text: modelData
+                    checked: true
+                }
+            }
+
+            Button {
+                Layout.margins: 5
+                Layout.fillWidth: true
+                text: "Create Map"
+                onClicked: {
+                    var layerList = [];
+                    for (var i = 0; i < operationalLayerRepeater.count; i++) {
+                        var currentCheckbox = operationalLayerRepeater.itemAt(i);
+                        if (currentCheckbox.checked) {
+                            layerList.push(currentCheckbox.text)
+                        }
+                    }
+                    createMapSelected(basemapComboBox.currentText, layerList);
+                }
             }
         }
     }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
 
 Rectangle {
@@ -29,103 +30,107 @@ Rectangle {
     signal cancelClicked()
 
     Rectangle {
-        anchors {
-            fill: layerColumn
-            margins: -15 * scaleFactor
-        }
-
         color: "#edeeef"
         radius: 5 * scaleFactor
+        anchors.centerIn: parent
+        width: childrenRect.width
+        height: childrenRect.height
         border {
             color: "#77787a"
             width: 1 * scaleFactor
         }
-    }
 
-    Column {
-        id: layerColumn
-        anchors.centerIn: parent
-        width: 200 * scaleFactor
+        GridLayout {
+            id: layerColumn
+            columns: 2
 
-        spacing: 10 * scaleFactor
-
-        Text {
-            id: title
-            text: "Title*:"
-            font {
-                pixelSize: 14 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        TextField {
-            id: titleText
-            width: parent.width
-            placeholderText: "ex: Sample Map"
-        }
-
-        Text {
-            id: tags
-            text: "Tags:"
-            font {
-                pixelSize: 14 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        TextField {
-            id: tagsText
-            width: parent.width
-            placeholderText: "ex: map, sample, elevation"
-        }
-
-        Text {
-            id: description
-            text: "Description:"
-            font {
-                pixelSize: 14 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        TextField {
-            id: descriptionText
-            width: parent.width
-            placeholderText: "ex: This map displays..."
-        }
-
-        Text {
-            text: "*Field is Required"
-            font {
-                pixelSize: 10 * scaleFactor
-                family: "helvetica"
-            }
-        }
-
-        Button {
-            width: parent.width
-            text: "Save"
-            onClicked: {
-                // Make sure a Title is supplied
-                if (titleText.text === "") {
-                    title.color = "red";
-                    return;
+            Text {
+                id: title
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                text: "Title*:"
+                font {
+                    pixelSize: 14 * scaleFactor
+                    family: "helvetica"
                 }
+            }
 
-                saveMapClicked(titleText.text, tagsText.text, descriptionText.text)
+            TextField {
+                id: titleText
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                Layout.fillWidth: true
+
+                placeholderText: "ex: Sample Map"
+            }
+
+            Text {
+                id: tags
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                text: "Tags:"
+                font {
+                    pixelSize: 14 * scaleFactor
+                    family: "helvetica"
+                }
+            }
+
+            TextField {
+                id: tagsText
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                Layout.fillWidth: true
+                placeholderText: "ex: map, sample, elevation"
+            }
+
+            Text {
+                id: description
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                text: "Description:"
+                font {
+                    pixelSize: 14 * scaleFactor
+                    family: "helvetica"
+                }
+            }
+
+            TextField {
+                id: descriptionText
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                Layout.fillWidth: true
+                placeholderText: "ex: This map displays..."
+            }
+
+            Text {
+                Layout.columnSpan: 2
+                Layout.margins: 5
+                text: "*Field is Required"
+                font {
+                    pixelSize: 10 * scaleFactor
+                    family: "helvetica"
+                }
+            }
+
+            Button {
+                Layout.margins: 5
+                text: "Save"
+                onClicked: {
+                    // Make sure a Title is supplied
+                    if (titleText.text === "") {
+                        title.color = "red";
+                        return;
+                    }
+
+                    saveMapClicked(titleText.text, tagsText.text, descriptionText.text)
+                }
+            }
+
+            Button {
+                Layout.margins: 5
+                text: "Cancel"
+                onClicked: cancelClicked()
             }
         }
-
-        Button {
-            width: parent.width
-            text: "Cancel"
-            onClicked: cancelClicked()
-        }
-    }
-
-    function reset() {
-        titleText.text = "";
-        descriptionText.text = "";
-        tagsText.text = "";
     }
 }


### PR DESCRIPTION
Garbage collection was unclear when using  StackView in its previous form. 

I think the QuickControls 2 StackView is less forgiving, so this bug never manifested itself before.

The StackView initialItem was being destroyed - and then pushed back onto the stack post-destruction. This seemed to work despite the docs suggesting that since the StackView was the owner then the initialItem should have been permanently deleted. 

Conversely, every other layer in the stack was parented to the rootRectangle, meaning that these stack items actually existed for the entire lifetime of the application. One component had reset functions attached because of this to get it back to initial state. Whole thing was a mess.

All stack layers are now components. Stack layers are created when pushed, and removed when destroyed. Everything resets to initial state. 

Also some hard-coded width/height cleanups. 

Removed reference to custom webmapUrl property, was not required.