### PR TITLE
Anmacdonald/change viewpoint combobox

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -67,8 +67,8 @@ Rectangle {
         width: modelWidth + leftPadding + rightPadding + indicator.width
 
         model: ["Center","Center and scale","Geometry","Geometry and padding","Rotation","Scale 1:5,000,000","Scale 1:10,000,000","Animation"]
-        onCurrentIndexChanged: {
-            changeCurrentViewpoint();
+        onCurrentTextChanged: {
+            changeCurrentViewpoint(currentText);
         }
 
         Component.onCompleted: {
@@ -83,8 +83,8 @@ Rectangle {
             font: comboBoxViewpoint.font
         }
 
-        function changeCurrentViewpoint() {
-            switch (comboBoxViewpoint.currentText) {
+        function changeCurrentViewpoint(text) {
+            switch (text) {
             case "Center":
                 ptBuilder.setXY(-117.195681, 34.056218); // Esri Headquarters
                 mv.setViewpointCenter(ptBuilder.geometry);


### PR DESCRIPTION
Part of the QML QuickControls-2 upgrade looks like there
is some delay between the currentTextChanged and currentIndexChanged
signals in a combo-box. Functions were reading old cached values
from Comboboxes as opposed to the correct values.