### PR TITLE
Fixed binding loop model crash.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -109,8 +109,11 @@ ChangeSublayerVisibilitySample {
                             }
 
                             Switch {
-                                checked: sublayerVisible
-
+                                // Careful not to cause a  binding loop here
+                                // by binding checked to sublayerVisible.
+                                Component.onCompleted: {
+                                    checked = sublayerVisible;
+                                }
                                 onCheckedChanged: {
                                     sublayerVisible = checked;
                                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -127,8 +127,11 @@ Rectangle {
                             }
 
                             Switch {
-                                checked: sublayerVisible
-
+                                // Careful not to cause a  binding loop here
+                                // by binding checked to sublayerVisible.
+                                Component.onCompleted: {
+                                    checked = sublayerVisible;
+                                }
                                 onCheckedChanged: {
                                     sublayerVisible = checked;
                                 }


### PR DESCRIPTION
``subLayerVisibility`` and checked were feeding off each other in a binding loop that crashed the QML app. Seems to have only manifested with the introduction of QuickControls 2.