### PR TITLE
adding element to allow box to resize

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
@@ -76,6 +76,11 @@ LocalServerServicesSample {
                         modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
+
+                TextMetrics {
+                    id: metrics
+                    font: servicesCombo.font
+                }
             }
 
             TextField {


### PR DESCRIPTION
@anmacdonald please review/merge. This combo box wasn't resizing. Looks like the TextMetric were failing so the Component.onCompleted handler was failing to run because it references the non-existent TextMetric