### PR TITLE
Guil8553/at common 4495 override

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.h
@@ -41,9 +41,9 @@ class AnalyzeHotspots : public QQuickItem
 
 public:
   explicit AnalyzeHotspots(QQuickItem* parent = nullptr);
-  ~AnalyzeHotspots();
+  ~AnalyzeHotspots() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void executeTaskWithDates(const QString& fromDate, const QString& toDate);
@@ -59,7 +59,7 @@ private:
   Esri::ArcGISRuntime::GeoprocessingTask* m_hotspotTask = nullptr;
   Esri::ArcGISRuntime::ArcGISMapImageLayer* m_layer = nullptr;
   bool m_jobInProgress = false;
-  QString m_jobStatus = QString("Not started.");
+  QString m_jobStatus = QStringLiteral("Not started.");
 
 private:
   bool jobInProgress() const { return m_jobInProgress; }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.h
@@ -41,9 +41,9 @@ class AnalyzeViewshed : public QQuickItem
 
 public:
   explicit AnalyzeViewshed(QQuickItem* parent = nullptr);
-  ~AnalyzeViewshed();
+  ~AnalyzeViewshed() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.h
@@ -37,9 +37,9 @@ class DistanceMeasurementAnalysis : public QQuickItem
 
 public:
   explicit DistanceMeasurementAnalysis(QQuickItem* parent = nullptr);
-  ~DistanceMeasurementAnalysis() = default;
+  ~DistanceMeasurementAnalysis() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();  
   Q_INVOKABLE void setUnits(const QString& unitName);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.h
@@ -40,7 +40,7 @@ class LineOfSightGeoElement : public QObject
 
 public:
     explicit LineOfSightGeoElement(QObject* parent = nullptr);
-    ~LineOfSightGeoElement();
+    ~LineOfSightGeoElement() override;
 
     static void init();
 
@@ -67,9 +67,9 @@ private:
     Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
 
     QTimer m_animation;
-    std::size_t m_waypointIndex { 0 };
-    Esri::ArcGISRuntime::Graphic* m_taxi { nullptr };
-    Esri::ArcGISRuntime::Graphic* m_observer { nullptr };
+    std::size_t m_waypointIndex = 0;
+    Esri::ArcGISRuntime::Graphic* m_taxi = nullptr;
+    Esri::ArcGISRuntime::Graphic* m_observer = nullptr;
 
     QString m_dataPath;
 };

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.h
@@ -35,9 +35,9 @@ class LineOfSightLocation : public QQuickItem
 
 public:
   explicit LineOfSightLocation(QQuickItem* parent = nullptr);
-  ~LineOfSightLocation() = default;
+  ~LineOfSightLocation() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.h
@@ -35,9 +35,9 @@ class StatisticalQuery : public QQuickItem
 
 public:
   explicit StatisticalQuery(QQuickItem* parent = nullptr);
-  ~StatisticalQuery() = default;
+  ~StatisticalQuery() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void queryStatistics(bool extentOnly, bool bigCitiesOnly);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticResultListModel.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticResultListModel.h
@@ -30,7 +30,7 @@ public:
   };
 
   explicit StatisticResultListModel(QObject* parent = nullptr);
-  ~StatisticResultListModel() = default;
+  ~StatisticResultListModel() override = default;
 
 public:
   void addStatisticResult(const QString& section, const QString& statistic);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.h
@@ -48,9 +48,9 @@ class StatisticalQueryGroupSort : public QQuickItem
 
 public:
   explicit StatisticalQueryGroupSort(QQuickItem* parent = nullptr);
-  ~StatisticalQueryGroupSort() = default;
+  ~StatisticalQueryGroupSort() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void queryStatistics();
   Q_INVOKABLE void addStatisticDefinition(const QString& field, const QString& statistic);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.h
@@ -36,9 +36,9 @@ class ViewshedCamera : public QQuickItem
 
 public:
   explicit ViewshedCamera(QQuickItem* parent = nullptr);
-  ~ViewshedCamera() = default;
+  ~ViewshedCamera() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void calculateViewshed();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.h
@@ -40,9 +40,9 @@ class ViewshedGeoElement : public QQuickItem
 
 public:
   explicit ViewshedGeoElement(QQuickItem* parent = nullptr);
-  ~ViewshedGeoElement() = default;
+  ~ViewshedGeoElement() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private slots:
@@ -62,7 +62,7 @@ private:
   Esri::ArcGISRuntime::AngularUnitId m_angularUnit = Esri::ArcGISRuntime::AngularUnitId::Degrees;
   Esri::ArcGISRuntime::GeodeticCurveType m_curveType = Esri::ArcGISRuntime::GeodeticCurveType::Geodesic;
 
-  const QString m_headingAttr = "HEADING";
+  const QString m_headingAttr = QStringLiteral("HEADING");
   QTimer* m_timer = nullptr;
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
@@ -300,22 +300,22 @@ double ViewshedLocation::heading() const
 void ViewshedLocation::setHeading(double heading)
 {
   if (m_locationViewshed)
-   {
-     if (m_locationViewshed->heading() == heading)
-       return;
+  {
+    if (m_locationViewshed->heading() == heading)
+      return;
 
-     m_heading = heading;
-     m_locationViewshed->setHeading(heading);
-   }
-   else
-   {
-     if (m_heading == heading)
-       return;
+    m_heading = heading;
+    m_locationViewshed->setHeading(heading);
+  }
+  else
+  {
+    if (m_heading == heading)
+      return;
 
-     m_heading = heading;
-   }
+    m_heading = heading;
+  }
 
-   emit headingChanged();
+  emit headingChanged();
 }
 
 double ViewshedLocation::pitch() const

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.h
@@ -36,9 +36,9 @@ class ViewshedLocation : public QQuickItem
 
 public:
   explicit ViewshedLocation(QQuickItem* parent = nullptr);
-  ~ViewshedLocation() = default;
+  ~ViewshedLocation() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_PROPERTY(bool viewshedVisible READ isViewshedVisible WRITE setViewshedVisible NOTIFY viewshedVisibleChanged)

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.h
@@ -44,9 +44,9 @@ class AddItemsToPortal : public QQuickItem
 
 public:
   explicit AddItemsToPortal(QQuickItem* parent = nullptr);
-  ~AddItemsToPortal();
+  ~AddItemsToPortal() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void authenticatePortal();

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/MyApplication.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/MyApplication.h
@@ -27,15 +27,14 @@ class MyApplication : public QtSingleApplication
 class MyApplication : public QApplication
 #endif
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
+  MyApplication(int& argc, char** argv, bool GUIenabled = true);
+  MyApplication(const QString& id, int& argc, char** argv);
+  ~MyApplication() override;
 
-    MyApplication(int& argc, char** argv, bool GUIenabled = true);
-    MyApplication(const QString& id, int& argc, char** argv);
-    ~MyApplication();
-
-    bool event(QEvent* event) override;
+  bool event(QEvent* event) override;
 };
 
 #endif // MYAPPLICATION_H

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectExample.h
@@ -16,10 +16,10 @@
 
 namespace Esri
 {
-    namespace ArcGISRuntime
-    {
-        class Portal;
-    }
+  namespace ArcGISRuntime
+  {
+    class Portal;
+  }
 }
 
 class OAuthRedirectHandler;
@@ -29,38 +29,38 @@ class OAuthRedirectHandler;
 
 class OAuthRedirectExample : public QQuickItem
 {
-    Q_OBJECT
+  Q_OBJECT
 
-    Q_PROPERTY(QString  clientId READ clientId WRITE setClientId NOTIFY clientIdChanged)
-    Q_PROPERTY(QString portalLoadStatus READ portalLoadStatus NOTIFY portalLoadStatusChanged)
-    Q_PROPERTY(QString status READ status NOTIFY statusChanged)
-    Q_PROPERTY(QString portalName READ portalName NOTIFY portalLoadStatusChanged)
+  Q_PROPERTY(QString  clientId READ clientId WRITE setClientId NOTIFY clientIdChanged)
+  Q_PROPERTY(QString portalLoadStatus READ portalLoadStatus NOTIFY portalLoadStatusChanged)
+  Q_PROPERTY(QString status READ status NOTIFY statusChanged)
+  Q_PROPERTY(QString portalName READ portalName NOTIFY portalLoadStatusChanged)
 
 public:
-    OAuthRedirectExample(QQuickItem* parent = nullptr);
-    ~OAuthRedirectExample();
+  OAuthRedirectExample(QQuickItem* parent = nullptr);
+  ~OAuthRedirectExample() override;
 
-    void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
-    Q_INVOKABLE void loadPortal();
-    Q_INVOKABLE void setClientId(const QString& clientId);
+  Q_INVOKABLE void loadPortal();
+  Q_INVOKABLE void setClientId(const QString& clientId);
 
-    static QString customUrlProtocol();
+  static QString customUrlProtocol();
 
 signals:
-    void clientIdChanged();
-    void portalLoadStatusChanged();
-    void statusChanged();
-    void portalNameChanged();
+  void clientIdChanged();
+  void portalLoadStatusChanged();
+  void statusChanged();
+  void portalNameChanged();
 
 private:
-    QString clientId() const;
-    QString portalLoadStatus() const;
-    QString status() const;
-    QString portalName() const;
+  QString clientId() const;
+  QString portalLoadStatus() const;
+  QString status() const;
+  QString portalName() const;
 
-    Esri::ArcGISRuntime::Portal* m_portal = nullptr;
-    OAuthRedirectHandler* m_handler = nullptr;
+  Esri::ArcGISRuntime::Portal* m_portal = nullptr;
+  OAuthRedirectHandler* m_handler = nullptr;
 };
 
 #endif // OAUTHREDIRECTEXAMPLE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectHandler.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/OAuthRedirectHandler.h
@@ -39,7 +39,7 @@ class OAuthRedirectHandler : public QObject
 public:
 
   OAuthRedirectHandler(const QString& urlScheme, QObject* parent = nullptr);
-  ~OAuthRedirectHandler();
+  ~OAuthRedirectHandler() override;
 
   OAuthRedirectHandlerStatus status() const;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.h
@@ -54,9 +54,9 @@ class PortalUserInfo : public QQuickItem
 
 public:
   explicit PortalUserInfo(QQuickItem* parent = nullptr);
-  ~PortalUserInfo();
+  ~PortalUserInfo() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.cpp
@@ -106,9 +106,7 @@ void SearchForWebmap::search(const QString keyword)
 
   PortalQueryParametersForItems query;
   query.setSearchString(QString("tags:\"%1\" AND +uploaded:[%2 TO %3]")
-                        .arg(keyword)
-                        .arg(fromDate)
-                        .arg(toDate));
+                        .arg(keyword, fromDate, toDate));
   query.setTypes(QList<PortalItemType>() << PortalItemType::WebMap);
 
   m_portal->findItems(query);

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.h
@@ -44,9 +44,9 @@ class SearchForWebmap : public QQuickItem
 
 public:
   explicit SearchForWebmap(QQuickItem* parent = nullptr);
-  ~SearchForWebmap();
+  ~SearchForWebmap() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Esri::ArcGISRuntime::AuthenticationManager* authManager() const;

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
@@ -44,9 +44,9 @@ class ShowOrgBasemaps : public QQuickItem
 
 public:
   explicit ShowOrgBasemaps(QQuickItem* parent = nullptr);
-  ~ShowOrgBasemaps();
+  ~ShowOrgBasemaps() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Esri::ArcGISRuntime::AuthenticationManager* authManager() const;

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.h
@@ -37,9 +37,9 @@ class TokenAuthentication : public QQuickItem
 
 public:
   explicit TokenAuthentication(QQuickItem* parent = nullptr);
-  ~TokenAuthentication();
+  ~TokenAuthentication() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void loadSecuredLayer();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.h
@@ -39,9 +39,9 @@ class BuildLegend : public QQuickItem
 
 public:
   explicit BuildLegend(QQuickItem* parent = nullptr);
-  ~BuildLegend();
+  ~BuildLegend() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.h
@@ -56,9 +56,9 @@ class DisplayGrid : public QQuickItem
 
 public:
   explicit DisplayGrid(QQuickItem* parent = nullptr);
-  ~DisplayGrid();
+  ~DisplayGrid() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void changeGrid(const QString& gridType);
   Q_INVOKABLE void changeGridColor(const QString& color);
@@ -133,8 +133,8 @@ private:
   static const QString s_topRightPosition;
   static const QString s_centerPosition;
   static const QString s_allSidesPosition;
-  QString m_currentGridColor = "red";
-  QString m_currentLabelColor = "black";
+  QString m_currentGridColor = QStringLiteral("red");
+  QString m_currentLabelColor = QStringLiteral("black");
   QString m_currentLabelFormat;
   QString m_currentLabelPosition;
   bool m_gridVisibility = true;

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.h
@@ -40,9 +40,9 @@ class GODictionaryRenderer : public QQuickItem
 
 public:
   explicit GODictionaryRenderer(QQuickItem* parent = nullptr);
-  ~GODictionaryRenderer();
+  ~GODictionaryRenderer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.h
@@ -41,9 +41,9 @@ class GODictionaryRenderer_3D : public QQuickItem
 
 public:
   explicit GODictionaryRenderer_3D(QQuickItem* parent = nullptr);
-  ~GODictionaryRenderer_3D();
+  ~GODictionaryRenderer_3D() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/GORenderers.h
@@ -34,9 +34,9 @@ class GORenderers : public QQuickItem
 
 public:
   explicit GORenderers(QQuickItem* parent = nullptr);
-  ~GORenderers();
+  ~GORenderers() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.h
@@ -36,9 +36,9 @@ class GOSymbols : public QQuickItem
 
 public:
   explicit GOSymbols(QQuickItem* parent = nullptr);
-  ~GOSymbols();
+  ~GOSymbols() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.h
@@ -37,9 +37,9 @@ class IdentifyGraphics : public QQuickItem
 
 public:
   explicit IdentifyGraphics(QQuickItem* parent = nullptr);
-  ~IdentifyGraphics();
+  ~IdentifyGraphics() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.h
@@ -38,9 +38,9 @@ class Picture_Marker_Symbol : public QQuickItem
 
 public:
   explicit Picture_Marker_Symbol(QQuickItem* parent = nullptr);
-  ~Picture_Marker_Symbol();
+  ~Picture_Marker_Symbol() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.h
@@ -38,9 +38,9 @@ class ShowCallout : public QQuickItem
 
 public:
   explicit ShowCallout(QQuickItem* parent = nullptr);
-  ~ShowCallout();
+  ~ShowCallout() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.h
@@ -34,9 +34,9 @@ class ShowLabelsOnLayers : public QQuickItem
 
 public:
   explicit ShowLabelsOnLayers(QQuickItem* parent = nullptr);
-  ~ShowLabelsOnLayers() = default;
+  ~ShowLabelsOnLayers() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.h
@@ -35,9 +35,9 @@ class Simple_Marker_Symbol : public QQuickItem
 
 public:
   explicit Simple_Marker_Symbol(QQuickItem* parent = nullptr);
-  ~Simple_Marker_Symbol();
+  ~Simple_Marker_Symbol() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.h
@@ -36,9 +36,9 @@ class Simple_Renderer : public QQuickItem
 
 public:
   explicit Simple_Renderer(QQuickItem* parent = nullptr);
-  ~Simple_Renderer();
+  ~Simple_Renderer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.h
@@ -35,9 +35,9 @@ class SymbolizeShapefile : public QQuickItem
 
 public:
   explicit SymbolizeShapefile(QQuickItem* parent = nullptr);
-  ~SymbolizeShapefile() = default;
+  ~SymbolizeShapefile() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void updateRenderer();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.h
@@ -38,9 +38,9 @@ class Unique_Value_Renderer : public QQuickItem
 
 public:
   explicit Unique_Value_Renderer(QQuickItem* parent = nullptr);
-  ~Unique_Value_Renderer();
+  ~Unique_Value_Renderer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.h
@@ -36,9 +36,9 @@ class AddFeaturesFeatureService : public QQuickItem
 
 public:
   explicit AddFeaturesFeatureService(QQuickItem* parent = nullptr);
-  ~AddFeaturesFeatureService();
+  ~AddFeaturesFeatureService() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.h
@@ -42,9 +42,9 @@ class DeleteFeaturesFeatureService : public QQuickItem
 
 public:
   explicit DeleteFeaturesFeatureService(QQuickItem* parent = nullptr);
-  ~DeleteFeaturesFeatureService();
+  ~DeleteFeaturesFeatureService() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void deleteSelectedFeature();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.h
@@ -43,9 +43,9 @@ class EditAndSyncFeatures : public QQuickItem
 
 public:
   explicit EditAndSyncFeatures(QQuickItem* parent = nullptr);
-  ~EditAndSyncFeatures();
+  ~EditAndSyncFeatures() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void generateGeodatabaseFromCorners(double xCorner1, double yCorner1, double xCorner2, double yCorner2);
   Q_INVOKABLE void executeSync();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
@@ -44,9 +44,9 @@ class EditFeatureAttachments : public QQuickItem
 
 public:
   explicit EditFeatureAttachments(QQuickItem* parent = nullptr);
-  ~EditFeatureAttachments();
+  ~EditFeatureAttachments() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void addAttachment(const QUrl& fileUrl, const QString& contentType);
   Q_INVOKABLE void deleteAttachment(int index);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.h
@@ -43,7 +43,7 @@ class UpdateAttributesFeatureService : public QQuickItem
 
 public:
   explicit UpdateAttributesFeatureService(QQuickItem* parent = nullptr);
-  ~UpdateAttributesFeatureService();
+  ~UpdateAttributesFeatureService() override;
 
   void componentComplete() override;
   static void init();

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.h
@@ -37,9 +37,9 @@ class UpdateGeometryFeatureService : public QQuickItem
 
 public:
   explicit UpdateGeometryFeatureService(QQuickItem* parent = nullptr);
-  ~UpdateGeometryFeatureService();
+  ~UpdateGeometryFeatureService() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.h
@@ -37,9 +37,9 @@ class FeatureLayerChangeRenderer : public QQuickItem
 
 public:
   explicit FeatureLayerChangeRenderer(QQuickItem* parent = nullptr);
-  ~FeatureLayerChangeRenderer();
+  ~FeatureLayerChangeRenderer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void changeRenderer();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.h
@@ -37,9 +37,9 @@ class FeatureLayerDefinitionExpression : public QQuickItem
 
 public:
   explicit FeatureLayerDefinitionExpression(QQuickItem* parent = nullptr);
-  ~FeatureLayerDefinitionExpression();
+  ~FeatureLayerDefinitionExpression() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void setDefExpression(QString whereClause);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.h
@@ -34,9 +34,9 @@ class FeatureLayerDictionaryRenderer : public QQuickItem
 
 public:
   explicit FeatureLayerDictionaryRenderer(QQuickItem* parent = nullptr);
-  ~FeatureLayerDictionaryRenderer();
+  ~FeatureLayerDictionaryRenderer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.h
@@ -36,9 +36,9 @@ class FeatureLayerFeatureService : public QQuickItem
 
 public:
   explicit FeatureLayerFeatureService(QQuickItem* parent = nullptr);
-  ~FeatureLayerFeatureService();
+  ~FeatureLayerFeatureService() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/FeatureLayer_GeoPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/FeatureLayer_GeoPackage.h
@@ -34,9 +34,9 @@ class FeatureLayer_GeoPackage : public QQuickItem
 
 public:
   explicit FeatureLayer_GeoPackage(QQuickItem* parent = nullptr);
-  ~FeatureLayer_GeoPackage() = default;
+  ~FeatureLayer_GeoPackage() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.h
@@ -39,9 +39,9 @@ class FeatureLayerGeodatabase : public QQuickItem
 
 public:
   explicit FeatureLayerGeodatabase(QQuickItem* parent = nullptr);
-  ~FeatureLayerGeodatabase();
+  ~FeatureLayerGeodatabase() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.h
@@ -39,9 +39,9 @@ class FeatureLayerQuery : public QQuickItem
 
 public:
   explicit FeatureLayerQuery(QQuickItem* parent = nullptr);
-  ~FeatureLayerQuery();
+  ~FeatureLayerQuery() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void runQuery(const QString& stateName);
 
@@ -66,4 +66,3 @@ private:
 };
 
 #endif // FEATURE_LAYER_QUERY_H
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.h
@@ -40,9 +40,9 @@ class FeatureLayerSelection : public QQuickItem
 
 public:
   explicit FeatureLayerSelection(QQuickItem* parent = nullptr);
-  ~FeatureLayerSelection();
+  ~FeatureLayerSelection() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:
@@ -57,8 +57,7 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
   Esri::ArcGISRuntime::ServiceFeatureTable* m_featureTable = nullptr;
-  QString m_selectedFeatureText = "Click or tap to select features.";
+  QString m_selectedFeatureText = QStringLiteral("Click or tap to select features.");
 };
 
 #endif // FEATURE_LAYER_SELECTION_H
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.h
@@ -40,9 +40,9 @@ class GenerateGeodatabase : public QQuickItem
 
 public:
   explicit GenerateGeodatabase(QQuickItem* parent = nullptr);
-  ~GenerateGeodatabase();
+  ~GenerateGeodatabase() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void generateGeodatabaseFromCorners(double xCorner1, double yCorner1, double xCorner2, double yCorner2);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
@@ -39,9 +39,9 @@ class ListRelatedFeatures : public QQuickItem
 
 public:
   explicit ListRelatedFeatures(QQuickItem* parent = nullptr);
-  ~ListRelatedFeatures() = default;
+  ~ListRelatedFeatures() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/RelatedFeatureListModel.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/RelatedFeatureListModel.h
@@ -35,17 +35,17 @@ public:
     ServiceLayerName
   };
 
-  explicit RelatedFeatureListModel(QObject* parent = 0);
-  ~RelatedFeatureListModel() = default;
+  explicit RelatedFeatureListModel(QObject* parent = nullptr);
+  ~RelatedFeatureListModel() override = default;
 
   void addRelatedFeature(RelatedFeature relatedFeature);
-  int rowCount(const QModelIndex& parent = QModelIndex()) const;
-  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+  int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
   void clear();
   int size() const { return m_relatedFeatures.size(); }
 
 protected:
-  QHash<int, QByteArray> roleNames() const;
+  QHash<int, QByteArray> roleNames() const override;
 
 private:
   QList<RelatedFeature> m_relatedFeatures;

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.h
@@ -36,9 +36,9 @@ class ServiceFeatureTableCache : public QQuickItem
 
 public:
   explicit ServiceFeatureTableCache(QQuickItem* parent = nullptr);
-  ~ServiceFeatureTableCache();
+  ~ServiceFeatureTableCache() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:
@@ -49,4 +49,3 @@ private:
 };
 
 #endif // SERVICE_FEATURE_TABLE_CACHE_H
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.h
@@ -36,9 +36,9 @@ class ServiceFeatureTableManualCache : public QQuickItem
 
 public:
   explicit ServiceFeatureTableManualCache(QQuickItem* parent = nullptr);
-  ~ServiceFeatureTableManualCache();
+  ~ServiceFeatureTableManualCache() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void populate();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.h
@@ -36,9 +36,9 @@ class ServiceFeatureTableNoCache : public QQuickItem
 
 public:
   explicit ServiceFeatureTableNoCache(QQuickItem* parent = nullptr);
-  ~ServiceFeatureTableNoCache();
+  ~ServiceFeatureTableNoCache() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/TimeBasedQuery/TimeBasedQuery.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/TimeBasedQuery/TimeBasedQuery.h
@@ -34,9 +34,9 @@ class TimeBasedQuery : public QQuickItem
 
 public:
   explicit TimeBasedQuery(QQuickItem* parent = nullptr);
-  ~TimeBasedQuery() = default;
+  ~TimeBasedQuery() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.h
@@ -38,11 +38,11 @@ class Buffer : public QQuickItem
 
 public:
   explicit Buffer(QQuickItem* parent = nullptr);
-  ~Buffer() = default;
+  ~Buffer() override = default;
 
   Q_PROPERTY(int bufferSize READ bufferSize WRITE setBufferSize NOTIFY bufferSizeChanged)
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void clear();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.h
@@ -39,9 +39,9 @@ class ClipGeometry : public QQuickItem
 
 public:
   explicit ClipGeometry(QQuickItem* parent = nullptr);
-  ~ClipGeometry() = default;
+  ~ClipGeometry() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void clipAreas();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/CreateGeometries.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/CreateGeometries.h
@@ -36,9 +36,9 @@ class CreateGeometries : public QQuickItem
 
 public:
   explicit CreateGeometries(QQuickItem* parent = nullptr);
-  ~CreateGeometries() = default;
+  ~CreateGeometries() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.h
@@ -38,9 +38,9 @@ class CutGeometry : public QQuickItem
 
 public:
   explicit CutGeometry(QQuickItem* parent = nullptr);
-  ~CutGeometry() = default;
+  ~CutGeometry() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void cutPolygon();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.h
@@ -38,9 +38,9 @@ class DensifyAndGeneralize : public QQuickItem
 
 public:
   explicit DensifyAndGeneralize(QQuickItem* parent = nullptr);
-  ~DensifyAndGeneralize() = default;
+  ~DensifyAndGeneralize() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void updateGeometry(bool densify, double maxSegmentLength, bool generalize, double maxDeviation);
   Q_INVOKABLE void showResults(bool show);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.h
@@ -45,7 +45,7 @@ class FormatCoordinates : public QObject
 
 public:
   explicit FormatCoordinates(QObject* parent = nullptr);
-  ~FormatCoordinates();
+  ~FormatCoordinates() override;
 
   static void init();
   Q_INVOKABLE void handleTextUpdate(QString textType, QString text);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.h
@@ -39,9 +39,9 @@ class GeodesicOperations : public QQuickItem
 
 public:
   explicit GeodesicOperations(QQuickItem* parent = nullptr);
-  ~GeodesicOperations() = default;
+  ~GeodesicOperations() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.cpp
@@ -59,7 +59,7 @@ void ListTransformations::componentComplete()
     if (e.isEmpty())
       return;
 
-    emit showStatusBar(QString("Error setting projection engine directory: %1. %2").arg(e.message()).arg(e.additionalMessage()));
+    emit showStatusBar(QString("Error setting projection engine directory: %1. %2").arg(e.message(), e.additionalMessage()));
   });
 
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.h
@@ -42,9 +42,9 @@ class ListTransformations : public QQuickItem
 
 public:
   explicit ListTransformations(QQuickItem* parent = nullptr);
-  ~ListTransformations() = default;
+  ~ListTransformations() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void refreshTransformationList(bool orderBySuitability);
   Q_INVOKABLE void updateGraphicTransformation(int index);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.h
@@ -37,11 +37,11 @@ class ProjectGeometry : public QQuickItem
 
 public:
   explicit ProjectGeometry(QQuickItem* parent = nullptr);
-  ~ProjectGeometry() = default;
+  ~ProjectGeometry() override = default;
 
   Q_PROPERTY(Esri::ArcGISRuntime::CalloutData* calloutData MEMBER m_calloutData NOTIFY calloutDataChanged)
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.h
@@ -38,10 +38,10 @@ class SpatialOperations : public QQuickItem
 
 public:
   explicit SpatialOperations(QQuickItem* parent = nullptr);
-  ~SpatialOperations() = default;
+  ~SpatialOperations() override = default;
 
   static void init();
-  void componentComplete() Q_DECL_OVERRIDE;  
+  void componentComplete() override;  
   Q_INVOKABLE void applyGeometryOperation(int index);
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.h
@@ -41,9 +41,9 @@ class SpatialRelationships : public QQuickItem
 
 public:
   explicit SpatialRelationships(QQuickItem* parent = nullptr);
-  ~SpatialRelationships() = default;
+  ~SpatialRelationships() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.h
@@ -34,9 +34,9 @@ class ArcGISMapImageLayerUrl : public QQuickItem
 
 public:
   explicit ArcGISMapImageLayerUrl(QQuickItem* parent = nullptr);
-  ~ArcGISMapImageLayerUrl();
+  ~ArcGISMapImageLayerUrl() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:
@@ -45,4 +45,3 @@ private:
 };
 
 #endif // ARCGIS_MAP_IMAGE_LAYER_URL_H
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.h
@@ -34,9 +34,9 @@ class ArcGISTiledLayerUrl : public QQuickItem
 
 public:
   explicit ArcGISTiledLayerUrl(QQuickItem* parent = nullptr);
-  ~ArcGISTiledLayerUrl();
+  ~ArcGISTiledLayerUrl() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:
@@ -45,4 +45,3 @@ private:
 };
 
 #endif // ARCGIS_TILED_LAYER_URL_H
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.h
@@ -37,11 +37,11 @@ class BlendRasterLayer : public QQuickItem
 
 public:
   explicit BlendRasterLayer(QQuickItem* parent = nullptr);
-  ~BlendRasterLayer();
+  ~BlendRasterLayer() override;
 
   static void init();
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
   Q_INVOKABLE void applyRenderSettings(double altitude, double azimuth, int slopeType, int colorRampType);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.h
@@ -38,9 +38,9 @@ class ChangeSublayerRenderer : public QQuickItem
 
 public:
   explicit ChangeSublayerRenderer(QQuickItem* parent = nullptr);
-  ~ChangeSublayerRenderer() = default;
+  ~ChangeSublayerRenderer() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void applyRenderer();
   Q_INVOKABLE void resetRenderer();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.h
@@ -38,9 +38,9 @@ class ChangeSublayerVisibility : public QQuickItem
 
 public:
   explicit ChangeSublayerVisibility(QQuickItem* parent = nullptr);
-  ~ChangeSublayerVisibility();
+  ~ChangeSublayerVisibility() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.h
@@ -38,7 +38,7 @@ class DisplayKml : public QQuickItem
 
 public:
   explicit DisplayKml(QQuickItem* parent = nullptr);
-  ~DisplayKml();
+  ~DisplayKml() override;
 
   void componentComplete() override;
   static void init();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.h
@@ -34,7 +34,7 @@ class DisplayKmlNetworkLinks : public QQuickItem
 
 public:
   explicit DisplayKmlNetworkLinks(QQuickItem* parent = nullptr);
-  ~DisplayKmlNetworkLinks();
+  ~DisplayKmlNetworkLinks() override;
 
   void componentComplete() override;
   static void init();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.h
@@ -38,9 +38,9 @@ class ExportTiles : public QQuickItem
 
 public:
   explicit ExportTiles(QQuickItem* parent = nullptr);
-  ~ExportTiles();
+  ~ExportTiles() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void exportTileCacheFromCorners(double xCorner1, double yCorner1, double xCorner2, double yCorner2, QString dataPath);
 
@@ -60,4 +60,3 @@ private:
 };
 
 #endif // EXPORT_TILES
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.h
@@ -37,9 +37,9 @@ class FeatureCollectionLayerQuery : public QQuickItem
 
 public:
   explicit FeatureCollectionLayerQuery(QQuickItem* parent = nullptr);
-  ~FeatureCollectionLayerQuery() = default;
+  ~FeatureCollectionLayerQuery() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.h
@@ -37,9 +37,9 @@ class FeatureLayerRenderingModeMap : public QQuickItem
 
 public:
   explicit FeatureLayerRenderingModeMap(QQuickItem* parent = nullptr);
-  ~FeatureLayerRenderingModeMap() = default;
+  ~FeatureLayerRenderingModeMap() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void startAnimation();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.h
@@ -37,9 +37,9 @@ class FeatureLayerRenderingModeScene : public QQuickItem
 
 public:
   explicit FeatureLayerRenderingModeScene(QQuickItem* parent = nullptr);
-  ~FeatureLayerRenderingModeScene() = default;
+  ~FeatureLayerRenderingModeScene() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void startAnimation();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.h
@@ -34,9 +34,9 @@ class FeatureLayerShapefile : public QQuickItem
 
 public:
     explicit FeatureLayerShapefile(QQuickItem* parent = nullptr);
-    ~FeatureLayerShapefile() = default;
+    ~FeatureLayerShapefile() override = default;
 
-    void componentComplete() Q_DECL_OVERRIDE;
+    void componentComplete() override;
     static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.h
@@ -39,9 +39,9 @@ class Feature_Collection_Layer : public QQuickItem
 
 public:
   explicit Feature_Collection_Layer(QQuickItem* parent = nullptr);
-  ~Feature_Collection_Layer();
+  ~Feature_Collection_Layer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.h
@@ -34,9 +34,9 @@ class Hillshade_Renderer : public QQuickItem
 
 public:
   explicit Hillshade_Renderer(QQuickItem* parent = nullptr);
-  ~Hillshade_Renderer();
+  ~Hillshade_Renderer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void applyHillshadeRenderer(double altitude, double azimuth, int slope);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.h
@@ -34,9 +34,9 @@ class OSM_Layer : public QQuickItem
 
 public:
   explicit OSM_Layer(QQuickItem* parent = nullptr);
-  ~OSM_Layer() = default;
+  ~OSM_Layer() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.h
@@ -41,9 +41,9 @@ class QueryMapImageSublayer : public QQuickItem
 
 public:
   explicit QueryMapImageSublayer(QQuickItem* parent = nullptr);
-  ~QueryMapImageSublayer() = default;
+  ~QueryMapImageSublayer() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void query(const QString& whereClause);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.h
@@ -36,11 +36,11 @@ class RasterColormapRenderer : public QQuickItem
 
 public:
   explicit RasterColormapRenderer(QQuickItem* parent = nullptr);
-  ~RasterColormapRenderer();
+  ~RasterColormapRenderer() override;
 
   static void init();
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
 private:
   Esri::ArcGISRuntime::ColormapRenderer* createRenderer();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.h
@@ -38,9 +38,9 @@ class RasterFunctionFile : public QQuickItem
 
 public:
   explicit RasterFunctionFile(QQuickItem* parent = nullptr);
-  ~RasterFunctionFile() = default;
+  ~RasterFunctionFile() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void applyRasterFunction();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.h
@@ -37,12 +37,12 @@ class RasterFunctionService : public QQuickItem
 
 public:
   explicit RasterFunctionService(QQuickItem* parent = nullptr);
-  ~RasterFunctionService() = default;
+  ~RasterFunctionService() override = default;
 
   static void init();
   Q_INVOKABLE void applyRasterFunction();
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
 private:
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.h
@@ -34,9 +34,9 @@ class RasterLayerFile : public QQuickItem
 
 public:
   explicit RasterLayerFile(QQuickItem* parent = nullptr);
-  ~RasterLayerFile();
+  ~RasterLayerFile() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void createAndAddRasterLayer(QUrl rasterUrl);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.h
@@ -34,9 +34,9 @@ class RasterLayerGeoPackage : public QQuickItem
 
 public:
   explicit RasterLayerGeoPackage(QQuickItem* parent = nullptr);
-  ~RasterLayerGeoPackage() = default;
+  ~RasterLayerGeoPackage() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.h
@@ -36,11 +36,11 @@ class RasterLayerService : public QQuickItem
 
 public:
   explicit RasterLayerService(QQuickItem* parent = nullptr);
-  ~RasterLayerService();
+  ~RasterLayerService() override;
 
   static void init();
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
 private:
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.h
@@ -38,10 +38,10 @@ class RasterRenderingRule : public QQuickItem
 
 public:
   explicit RasterRenderingRule(QQuickItem* parent = nullptr);
-  ~RasterRenderingRule() = default;
+  ~RasterRenderingRule() override = default;
 
   static void init();
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   Q_INVOKABLE void applyRenderingRule(int index);
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.h
@@ -35,11 +35,11 @@ class RasterRgbRenderer : public QQuickItem
 
 public:
   explicit RasterRgbRenderer(QQuickItem* parent = nullptr);
-  ~RasterRgbRenderer();
+  ~RasterRgbRenderer() override;
 
   static void init();
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
   Q_INVOKABLE void applyMinMax(double min0, double min1, double min2, double max0, double max1, double max2);
   Q_INVOKABLE void applyPercentClip(double min, double max);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.h
@@ -35,11 +35,11 @@ class RasterStretchRenderer : public QQuickItem
 
 public:
   explicit RasterStretchRenderer(QQuickItem* parent = nullptr);
-  ~RasterStretchRenderer();
+  ~RasterStretchRenderer() override;
 
   static void init();
 
-  void componentComplete() Q_DECL_OVERRIDE;  
+  void componentComplete() override;  
 
   Q_INVOKABLE void applyMinMax(double min, double max);
   Q_INVOKABLE void applyPercentClip(double min, double max);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.h
@@ -35,9 +35,9 @@ class StyleWmsLayer : public QQuickItem
 
 public:
   explicit StyleWmsLayer(QQuickItem* parent = nullptr);
-  ~StyleWmsLayer() = default;
+  ~StyleWmsLayer() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void setCurrentStyle(int index);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.h
@@ -34,9 +34,9 @@ class VectorTiledLayerUrl : public QQuickItem
 
 public:
   explicit VectorTiledLayerUrl(QQuickItem* parent = nullptr);
-  ~VectorTiledLayerUrl();
+  ~VectorTiledLayerUrl() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void changeBasemap(const QString& basemap);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.h
@@ -34,9 +34,9 @@ class WMTS_Layer : public QQuickItem
 
 public:
   explicit WMTS_Layer(QQuickItem* parent = nullptr);
-  ~WMTS_Layer() = default;
+  ~WMTS_Layer() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.h
@@ -34,9 +34,9 @@ class Web_Tiled_Layer : public QQuickItem
 
 public:
   explicit Web_Tiled_Layer(QQuickItem* parent = nullptr);
-  ~Web_Tiled_Layer();
+  ~Web_Tiled_Layer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.h
@@ -34,9 +34,9 @@ class WmsLayerUrl : public QQuickItem
 
 public:
   explicit WmsLayerUrl(QQuickItem* parent = nullptr);
-  ~WmsLayerUrl() = default;
+  ~WmsLayerUrl() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.h
@@ -35,9 +35,9 @@ class DynamicWorkspaceRaster : public QQuickItem
 
 public:
   explicit DynamicWorkspaceRaster(QQuickItem* parent = nullptr);
-  ~DynamicWorkspaceRaster() = default;
+  ~DynamicWorkspaceRaster() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void startLocalService(const QString& filePath, const QString& folder);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.h
@@ -35,9 +35,9 @@ class DynamicWorkspaceShapefile : public QQuickItem
 
 public:
   explicit DynamicWorkspaceShapefile(QQuickItem* parent = nullptr);
-  ~DynamicWorkspaceShapefile() = default;
+  ~DynamicWorkspaceShapefile() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void startLocalService(const QString& filePath, const QString& folder);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.h
@@ -38,9 +38,9 @@ class LocalServerFeatureLayer : public QQuickItem
 
 public:
   explicit LocalServerFeatureLayer(QQuickItem* parent = nullptr);
-  ~LocalServerFeatureLayer();
+  ~LocalServerFeatureLayer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
@@ -41,7 +41,7 @@ class LocalServerGeoprocessing : public QQuickItem
 
 public:
   explicit LocalServerGeoprocessing(QQuickItem* parent = nullptr);
-  ~LocalServerGeoprocessing();
+  ~LocalServerGeoprocessing() override;
 
   void componentComplete() override;
 
@@ -63,7 +63,7 @@ private:
   Esri::ArcGISRuntime::GeoprocessingTask* m_gpTask = nullptr;
 
   bool isReady() { return m_isReady; }
-  double m_isReady = false;
+  bool m_isReady = false;
 };
 
 #endif // LOCAL_SERVER_GEOPROCESSING_H

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.h
@@ -36,9 +36,9 @@ class LocalServerMapImageLayer : public QQuickItem
 
 public:
   explicit LocalServerMapImageLayer(QQuickItem* parent = nullptr);
-  ~LocalServerMapImageLayer();
+  ~LocalServerMapImageLayer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
@@ -42,9 +42,9 @@ class LocalServerServices : public QQuickItem
 
 public:
   explicit LocalServerServices(QQuickItem* parent = nullptr);
-  ~LocalServerServices();
+  ~LocalServerServices() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void startLocalServer();
   Q_INVOKABLE void stopLocalServer();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.h
@@ -34,9 +34,9 @@ class ChangeBasemap : public QQuickItem
 
 public:
   explicit ChangeBasemap(QQuickItem* parent = nullptr);
-  ~ChangeBasemap();
+  ~ChangeBasemap() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void changeBasemap(const QString& basemap);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.h
@@ -35,9 +35,9 @@ class ChangeViewpoint : public QQuickItem
 
 public:
   explicit ChangeViewpoint(QQuickItem* parent = nullptr);
-  ~ChangeViewpoint();
+  ~ChangeViewpoint() override = 0;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void changeViewpoint(QString viewpoint);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.h
@@ -38,9 +38,9 @@ class CreateAndSaveMap : public QQuickItem
 
 public:
   explicit CreateAndSaveMap(QQuickItem* parent = nullptr);
-  ~CreateAndSaveMap() = default;
+  ~CreateAndSaveMap() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void createMap(const QString& basemap, const QStringList& operationalLayers);
   Q_INVOKABLE void loadPortal();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.h
@@ -41,9 +41,9 @@ class DisplayDeviceLocation : public QQuickItem
 
 public:
   explicit DisplayDeviceLocation(QQuickItem* parent = nullptr);
-  ~DisplayDeviceLocation();
+  ~DisplayDeviceLocation() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void startLocationDisplay();
   Q_INVOKABLE void stopLocationDisplay();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.h
@@ -37,9 +37,9 @@ class DisplayDrawingStatus : public QQuickItem
 
 public:
   explicit DisplayDrawingStatus(QQuickItem* parent = nullptr);
-  ~DisplayDrawingStatus();
+  ~DisplayDrawingStatus() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.cpp
@@ -153,6 +153,8 @@ DisplayItem::DisplayItem(QObject* parent) :
 {
 }
 
+DisplayItem::~DisplayItem() = default;
+
 void DisplayItem::setName(const QString& name)
 {
   m_name = name;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.h
@@ -41,9 +41,9 @@ class DisplayLayerViewDrawState : public QQuickItem
 
 public:
   explicit DisplayLayerViewDrawState(QQuickItem* parent = nullptr);
-  ~DisplayLayerViewDrawState();
+  ~DisplayLayerViewDrawState() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:
@@ -69,10 +69,11 @@ class DisplayItem : public QObject
   Q_OBJECT
   Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
   Q_PROPERTY(QString status READ status WRITE setStatus NOTIFY statusChanged)
+
 public:
   DisplayItem(QObject* parent = nullptr);
-
   DisplayItem(const QString& name, const QString& status, QObject* parent = nullptr);
+  ~DisplayItem() override;
 
   void setName(const QString& name);
   QString name() const;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.h
@@ -34,9 +34,9 @@ class DisplayMap : public QQuickItem
 
 public:
   explicit DisplayMap(QQuickItem* parent = nullptr);
-  ~DisplayMap();
+  ~DisplayMap() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.h
@@ -40,9 +40,9 @@ class GenerateOfflineMap : public QQuickItem
 
 public:
   explicit GenerateOfflineMap(QQuickItem* parent = nullptr);
-  ~GenerateOfflineMap() = default;
+  ~GenerateOfflineMap() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 public:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.h
@@ -35,9 +35,9 @@ class IdentifyLayers : public QQuickItem
 
 public:
   explicit IdentifyLayers(QQuickItem* parent = nullptr);
-  ~IdentifyLayers() = default;
+  ~IdentifyLayers() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   QString message() const { return m_message; }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.h
@@ -42,9 +42,9 @@ class ManageBookmarks : public QQuickItem
 
 public:
   explicit ManageBookmarks(QQuickItem* parent = nullptr);
-  ~ManageBookmarks();
+  ~ManageBookmarks() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void goToBookmark(int bookmarkIndex);
   Q_INVOKABLE void addBookmark(QString newBookmarkName);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.h
@@ -38,9 +38,9 @@ class MapLoaded : public QQuickItem
 
 public:
   explicit MapLoaded(QQuickItem* parent = nullptr);
-  ~MapLoaded();
+  ~MapLoaded() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.h
@@ -34,9 +34,9 @@ class MapRotation : public QQuickItem
 
 public:
   explicit MapRotation(QQuickItem* parent = nullptr);
-  ~MapRotation();
+  ~MapRotation() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void setMapViewRotation(double degrees);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/MinMaxScale.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/MinMaxScale.h
@@ -34,9 +34,9 @@ class MinMaxScale : public QQuickItem
 
 public:
   explicit MinMaxScale(QQuickItem* parent = nullptr);
-  ~MinMaxScale() = default;
+  ~MinMaxScale() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.h
@@ -54,9 +54,9 @@ class MobileMap_SearchAndRoute : public QQuickItem
 
 public:
   explicit MobileMap_SearchAndRoute(QQuickItem* parent = nullptr);
-  ~MobileMap_SearchAndRoute();
+  ~MobileMap_SearchAndRoute() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void resetMapView();
   Q_INVOKABLE void createMapList(int index);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.h
@@ -35,9 +35,9 @@ class OpenMapUrl : public QQuickItem
 
 public:
   explicit OpenMapUrl(QQuickItem* parent = nullptr);
-  ~OpenMapUrl();
+  ~OpenMapUrl() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void openMap(const QString& itemId);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
@@ -34,9 +34,9 @@ class OpenMobileMap_MapPackage : public QQuickItem
 
 public:
   explicit OpenMobileMap_MapPackage(QQuickItem* parent = nullptr);
-  ~OpenMobileMap_MapPackage();
+  ~OpenMobileMap_MapPackage() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/ReadGeoPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/ReadGeoPackage.h
@@ -47,10 +47,10 @@ class ReadGeoPackage : public QQuickItem
 
 public:
   explicit ReadGeoPackage(QQuickItem* parent = nullptr);
-  ~ReadGeoPackage() = default;
+  ~ReadGeoPackage() override = default;
 
   void readGeoPackage();
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
 
   static void init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.h
@@ -34,9 +34,9 @@ class SetInitialMapArea : public QQuickItem
 
 public:
   explicit SetInitialMapArea(QQuickItem* parent = nullptr);
-  ~SetInitialMapArea();
+  ~SetInitialMapArea() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.h
@@ -34,9 +34,9 @@ class SetInitialMapLocation : public QQuickItem
 
 public:
   explicit SetInitialMapLocation(QQuickItem* parent = nullptr);
-  ~SetInitialMapLocation();
+  ~SetInitialMapLocation() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.h
@@ -36,9 +36,9 @@ class SetMapSpatialReference : public QQuickItem
 
 public:
   explicit SetMapSpatialReference(QQuickItem* parent = nullptr);
-  ~SetMapSpatialReference();
+  ~SetMapSpatialReference() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.h
@@ -34,9 +34,9 @@ class ShowMagnifier : public QQuickItem
 
 public:
   explicit ShowMagnifier(QQuickItem* parent = nullptr);
-  ~ShowMagnifier();
+  ~ShowMagnifier() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/MapImageProvider.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/MapImageProvider.h
@@ -23,7 +23,7 @@ class MapImageProvider : public QQuickImageProvider
 
 public:
   MapImageProvider();
-  ~MapImageProvider() = default;
+  ~MapImageProvider() override = default;
 
 public:
   QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.h
@@ -38,9 +38,9 @@ class TakeScreenshot : public QQuickItem
 
 public:
   explicit TakeScreenshot(QQuickItem* parent = nullptr);
-  ~TakeScreenshot() = default;
+  ~TakeScreenshot() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void captureScreenshot();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.h
@@ -46,9 +46,9 @@ class ClosestFacility : public QQuickItem
 
 public:
   explicit ClosestFacility(QQuickItem* parent = nullptr);
-  ~ClosestFacility();
+  ~ClosestFacility() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 signals:

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.h
@@ -41,9 +41,9 @@ class FindRoute : public QQuickItem
 
 public:
   explicit FindRoute(QQuickItem* parent = nullptr);
-  ~FindRoute();
+  ~FindRoute() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void solveRoute();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.h
@@ -44,9 +44,9 @@ class ServiceArea : public QQuickItem
 
 public:
   explicit ServiceArea(QQuickItem* parent = nullptr);
-  ~ServiceArea();
+  ~ServiceArea() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
   Q_INVOKABLE void setFacilityMode();
@@ -60,7 +60,6 @@ signals:
   void messageChanged();
 
 private:
-
   enum class SampleMode {
     Facility,
     Barrier

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
@@ -36,7 +36,7 @@ class AddIntegratedMeshLayer : public QObject
 
 public:
   explicit AddIntegratedMeshLayer(QObject* parent = nullptr);
-  ~AddIntegratedMeshLayer();
+  ~AddIntegratedMeshLayer() override;
 
   static void init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.h
@@ -55,7 +55,7 @@ class Animate3DSymbols : public QQuickItem
 
 public:
   Animate3DSymbols(QQuickItem* parent = nullptr);
-  ~Animate3DSymbols();
+  ~Animate3DSymbols() override;
 
   void componentComplete() override;
   static void init();

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.h
@@ -34,9 +34,9 @@ class BasicSceneView : public QQuickItem
 
 public:
   explicit BasicSceneView(QQuickItem* parent = nullptr);
-  ~BasicSceneView();
+  ~BasicSceneView() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.h
@@ -44,7 +44,7 @@ public:
   Q_ENUM(AtmosphereEnum)
 
   explicit ChangeAtmosphereEffect(QObject* parent = nullptr);
-  ~ChangeAtmosphereEffect();
+  ~ChangeAtmosphereEffect() override;
 
   static void init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.h
@@ -35,9 +35,9 @@ class DisplaySceneLayer : public QQuickItem
 
 public:
   explicit DisplaySceneLayer(QQuickItem* parent = nullptr);
-  ~DisplaySceneLayer();
+  ~DisplaySceneLayer() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.h
@@ -34,9 +34,9 @@ class DistanceCompositeSymbol : public QQuickItem
 
 public:
   explicit DistanceCompositeSymbol(QQuickItem* parent = nullptr);
-  ~DistanceCompositeSymbol();
+  ~DistanceCompositeSymbol() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.cpp
@@ -27,8 +27,8 @@
 #include "Polygon.h"
 #include "SimpleFillSymbol.h"
 
-#include "cmath"
-#include "time.h"
+#include <cmath>
+#include <ctime>
 
 using namespace Esri::ArcGISRuntime;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.h
@@ -35,9 +35,9 @@ class ExtrudeGraphics : public QQuickItem
 
 public:
   explicit ExtrudeGraphics(QQuickItem* parent = nullptr);
-  ~ExtrudeGraphics();
+  ~ExtrudeGraphics() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.h
@@ -42,9 +42,9 @@ class FeatureLayerExtrusion : public QQuickItem
 
 public:
   explicit FeatureLayerExtrusion(QQuickItem* parent = nullptr);
-  ~FeatureLayerExtrusion() = default;
+  ~FeatureLayerExtrusion() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void popDensity();
   Q_INVOKABLE void totalPopulation();

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/OpenScene.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/OpenScene.h
@@ -33,9 +33,9 @@ class OpenScene : public QQuickItem
 
 public:
   explicit OpenScene(QQuickItem* parent = nullptr);
-  ~OpenScene() = default;
+  ~OpenScene() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.h
@@ -34,9 +34,9 @@ class SceneLayerSelection : public QQuickItem
 
 public:
   explicit SceneLayerSelection(QQuickItem* parent = nullptr);
-  ~SceneLayerSelection() = default;
+  ~SceneLayerSelection() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/Surface_Placement.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/Surface_Placement.h
@@ -34,9 +34,9 @@ class Surface_Placement : public QQuickItem
 
 public:
   explicit Surface_Placement(QQuickItem* parent = nullptr);
-  ~Surface_Placement();
+  ~Surface_Placement() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.h
@@ -34,9 +34,9 @@ class Symbols : public QQuickItem
 
 public:
   explicit Symbols(QQuickItem* parent = nullptr);
-  ~Symbols();
+  ~Symbols() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
 
 private:

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.h
@@ -40,7 +40,7 @@ class SyncMapViewSceneView : public QObject
 
 public:
   explicit SyncMapViewSceneView(QObject* parent = nullptr);
-  ~SyncMapViewSceneView();
+  ~SyncMapViewSceneView() override;
 
   static void init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.h
@@ -34,9 +34,9 @@ class TerrainExaggeration : public QQuickItem
 
 public:
   explicit TerrainExaggeration(QQuickItem* parent = nullptr);
-  ~TerrainExaggeration() = default;
+  ~TerrainExaggeration() override = default;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void setElevationExaggeration(double factor);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.h
@@ -36,7 +36,7 @@ class ViewPointCloudDataOffline : public QObject
 
 public:
   explicit ViewPointCloudDataOffline(QObject* parent = nullptr);
-  ~ViewPointCloudDataOffline();
+  ~ViewPointCloudDataOffline() override;
 
   static void init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.h
@@ -40,9 +40,9 @@ class FindAddress : public QQuickItem
 
 public:
   explicit FindAddress(QQuickItem* parent = nullptr);
-  ~FindAddress();
+  ~FindAddress() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void geocodeAddress(const QString& address);
   Q_INVOKABLE void clearGraphics();

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.h
@@ -45,7 +45,7 @@ class FindPlace : public QQuickItem
 
 public:
   explicit FindPlace(QQuickItem* parent = nullptr);
-  ~FindPlace() = default;
+  ~FindPlace() override = default;
 
   enum class SearchMode
   {
@@ -54,7 +54,7 @@ public:
   };
   Q_ENUM(SearchMode)
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void setSuggestionsText(const QString& searchText);
   Q_INVOKABLE void geocodePOIs(const QString& poi, const QString& location);
@@ -91,7 +91,7 @@ private:
   bool m_poiTextHasFocus = true;
   bool m_isSearchingLocation = false;
   QString m_poiSearchText;
-  QString m_currentLocationText = "Current Location";
+  QString m_currentLocationText = QStringLiteral("Current Location");
   QObject* m_graphicParent = nullptr;
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.h
@@ -52,9 +52,9 @@ class OfflineGeocode : public QQuickItem
 
 public:
   explicit OfflineGeocode(QQuickItem* parent = nullptr);
-  ~OfflineGeocode();
+  ~OfflineGeocode() override;
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void geocodeWithSuggestion(int index);
   Q_INVOKABLE void geocodeWithText(const QString& address);

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.h
@@ -37,7 +37,7 @@ class SearchDictionarySymbolStyle : public QQuickItem
 
 public:
   explicit SearchDictionarySymbolStyle(QQuickItem* parent = nullptr);
-  ~SearchDictionarySymbolStyle();
+  ~SearchDictionarySymbolStyle() override;
 
   enum class FieldEnum {
     FieldNames,
@@ -48,7 +48,7 @@ public:
   };
   Q_ENUM(FieldEnum)
 
-  void componentComplete() Q_DECL_OVERRIDE;
+  void componentComplete() override;
   static void init();
   Q_INVOKABLE void search(const QStringList& namesSearchParam, const QStringList& tagsSearchParam,
                           const QStringList& classesSearchParam,const QStringList& categoriesSearchParam,

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/BuildLegend/BuildLegend.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/BuildLegend/BuildLegend.h
@@ -39,7 +39,7 @@ class BuildLegend : public QWidget
 
 public:
   explicit BuildLegend(QWidget* parent = nullptr);
-  ~BuildLegend();
+  ~BuildLegend() override;
 
 private:
   void addLayers();

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/GORenderers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/GORenderers.h
@@ -32,7 +32,7 @@ class GORenderers : public QWidget
 
 public:
   explicit GORenderers(QWidget* parent = nullptr);
-  ~GORenderers();
+  ~GORenderers() override;
 
 private:
   void createUi();

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.h
@@ -35,7 +35,7 @@ class GOSymbols : public QWidget
 
 public:
   explicit GOSymbols(QWidget* parent = nullptr);
-  ~GOSymbols();
+  ~GOSymbols() override;
 
 private:
   void addBuoyPoints(Esri::ArcGISRuntime::GraphicsOverlay* graphicsOverlay);

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.h
@@ -34,7 +34,7 @@ class ArcGISTiledLayerUrl : public QWidget
 
 public:
   explicit ArcGISTiledLayerUrl(QWidget* parent = nullptr);
-  ~ArcGISTiledLayerUrl();
+  ~ArcGISTiledLayerUrl() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.h
@@ -34,7 +34,7 @@ class ChangeBasemap : public QWidget
 
 public:
   explicit ChangeBasemap(QWidget* parent = nullptr);
-  ~ChangeBasemap();
+  ~ChangeBasemap() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/ChangeViewpoint.h
@@ -34,7 +34,7 @@ class ChangeViewpoint : public QWidget
 
 public:
   explicit ChangeViewpoint(QWidget* parent = nullptr);
-  ~ChangeViewpoint();
+  ~ChangeViewpoint() override;
 
 private slots:
   void changeToNewViewpoint(int);

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/DisplayMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/DisplayMap.h
@@ -32,7 +32,7 @@ class DisplayMap : public QWidget
 
 public:
   explicit DisplayMap(QWidget* parent = nullptr);
-   ~DisplayMap();
+   ~DisplayMap() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.h
@@ -38,7 +38,7 @@ class ManageBookmarks : public QWidget
 
 public:
   explicit ManageBookmarks(QWidget* parent = nullptr);
-  ~ManageBookmarks();
+  ~ManageBookmarks() override;
 
 private:
   void createUi();

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/MapLoaded.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/MapLoaded.h
@@ -34,7 +34,7 @@ class MapLoaded : public QWidget
 
 public:
   explicit MapLoaded(QWidget* parent = nullptr);
-  ~MapLoaded();
+  ~MapLoaded() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/MapRotation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/MapRotation.h
@@ -36,7 +36,7 @@ class MapRotation : public QWidget
 
 public:
   explicit MapRotation(QWidget* parent = nullptr);
-  ~MapRotation();
+  ~MapRotation() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.h
@@ -37,7 +37,7 @@ class OpenExistingMap : public QWidget
 
 public:
   explicit OpenExistingMap(QWidget* parent = nullptr);
-  ~OpenExistingMap();
+  ~OpenExistingMap() override;
 
 private:
   void createUi();
@@ -47,7 +47,7 @@ private:
   Esri::ArcGISRuntime::MapGraphicsView* m_mapView = nullptr;
   QPushButton* m_button = nullptr;
   QInputDialog* m_inputDialog = nullptr;
-  QMap<QString, QString > m_portalIds;
+  QMap<QString, QString> m_portalIds;
 
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/SetInitialMapArea.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/SetInitialMapArea.h
@@ -32,7 +32,7 @@ class SetInitialMapArea : public QWidget
 
 public:
   explicit SetInitialMapArea(QWidget* parent = nullptr);
-  ~SetInitialMapArea();
+  ~SetInitialMapArea() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.h
@@ -32,7 +32,7 @@ class SetInitialMapLocation : public QWidget
 
 public:
   explicit SetInitialMapLocation(QWidget* parent = nullptr);
-  ~SetInitialMapLocation();
+  ~SetInitialMapLocation() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/SetMapSpatialReference.h
@@ -34,7 +34,7 @@ class SetMapSpatialReference : public QWidget
 
 public:
   explicit SetMapSpatialReference(QWidget* parent = nullptr);
-  ~SetMapSpatialReference();
+  ~SetMapSpatialReference() override;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.h
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/BasicSceneView.h
@@ -32,7 +32,7 @@ class BasicSceneView : public QWidget
 
 public:
   explicit BasicSceneView(QWidget* parent = nullptr);
-   ~BasicSceneView();
+   ~BasicSceneView() override;
 
 private:
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;


### PR DESCRIPTION
@JamesMBallard  please review/merge.

- Add `override` when necessary.
- changes `Q_DECL_OVERRIDE` to `override` for consistency with the APIs.
- some code clean up (indentation, consistency)
- add `QStringLitteral` 
- uses `QString::arg(QString, QString, QString)`

Build tested on Mac.