### PR TITLE
Mfeigl/mobilemap unpack workflow

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
@@ -52,7 +52,7 @@ OpenMobileMap_MapPackage::OpenMobileMap_MapPackage(QQuickItem* parent) :
 {
   // create the MMPK data path
   // data is downloaded automatically by the sample viewer app. Instructions to download
-  // seperately are specified in the readme.
+  // separately are specified in the readme.
   const QString dataPath = defaultDataPath() + sampleFileYellowstone;
 
   // connect to the Mobile Map Package instance to determine if direct read is supported. Packages
@@ -123,55 +123,35 @@ void OpenMobileMap_MapPackage::componentComplete()
   MobileMapPackage::isDirectReadSupported(dataPath);
 }
 
-// Slot for handling when the package loads
-void OpenMobileMap_MapPackage::packageLoaded(const Error& e)
-{
-  if (!e.isEmpty())
-  {
-    qDebug() << QString("Package load error: %1 %2").arg(e.message(), e.additionalMessage());
-    return;
-  }
-
-  setMapToView();
-}
-
-// create map package and connect to signals
+// create map package
 void OpenMobileMap_MapPackage::createMapPackage(const QString& path)
 {
+  //! [open mobile map package cpp snippet]
   // instatiate a mobile map package
   m_mobileMapPackage = new MobileMapPackage(path, this);
 
   // wait for the mobile map package to load
   connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, [this](Error error)
   {
-    if (error.isEmpty())
+    if (!error.isEmpty())
     {
-      // set the map view's map to the first map in the mobile map package
-      setMapToView();
+      qDebug() << QString("Package load error: %1 %2").arg(error.message(), error.additionalMessage());
+      return;
+    }
+    else
+    {
+      if (!m_mobileMapPackage || !m_mapView || m_mobileMapPackage->maps().isEmpty())
+      {
+        return;
+      }
+
+      // The package contains a list of maps that could be shown in the UI for selection.
+      // For simplicity, obtain the first map in the list of maps.
+      // set the map on the map view to display
+      m_mapView->setMap(m_mobileMapPackage->maps().at(0));
     }
   });
 
-  connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, &OpenMobileMap_MapPackage::packageLoaded);
-
-  //! [open mobile map package cpp snippet]
   m_mobileMapPackage->load();
+  //! [open mobile map package cpp snippet]
 }
-
-void OpenMobileMap_MapPackage::setMapToView()
-{
-  if (!m_mobileMapPackage || !m_mapView)
-  {
-    return;
-  }
-
-  if (m_mobileMapPackage->maps().isEmpty())
-  {
-    return;
-  }
-
-  // The package contains a list of maps that could be shown in the UI for selection.
-  // For simplicity, obtain the first map in the list of maps
-  // set the map on the map view to display
-  m_mapView->setMap(m_mobileMapPackage->maps().at(0));
-}
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
@@ -16,16 +16,88 @@
 
 #include "OpenMobileMap_MapPackage.h"
 
-#include "MobileMapPackage.h"
-#include "MapQuickView.h"
 #include "Basemap.h"
+#include "MapQuickView.h"
+#include "MobileMapPackage.h"
+
 #include <QQmlProperty>
 
 using namespace Esri::ArcGISRuntime;
 
-OpenMobileMap_MapPackage::OpenMobileMap_MapPackage(QQuickItem* parent) :
-    QQuickItem(parent)
+// helper method to get cross platform data path
+namespace {
+QString defaultDataPath()
 {
+  QString dataPath;
+
+#ifdef Q_OS_ANDROID
+  dataPath = "/sdcard";
+#elif defined Q_OS_IOS
+  dataPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#else
+  dataPath = QDir::homePath();
+#endif
+
+  return dataPath;
+}
+
+// sample MMPK location
+const QString sampleFileYellowstone {"/ArcGIS/Runtime/Data/mmpk/Yellowstone.mmpk"};
+
+} // namespace
+
+OpenMobileMap_MapPackage::OpenMobileMap_MapPackage(QQuickItem* parent) :
+  QQuickItem(parent)
+{
+  // create the MMPK data path
+  // data is downloaded automatically by the sample viewer app. Instructions to download
+  // seperately are specified in the readme.
+  const QString dataPath = defaultDataPath() + sampleFileYellowstone;
+
+  // connect to the Mobile Map Package instance to determine if direct read is supported. Packages
+  // that contain raster data cannot be read directly and must be unpacked first.
+  connect(MobileMapPackage::instance(), &MobileMapPackage::isDirectReadSupportedCompleted,
+          this, [this, dataPath](QUuid, bool supported)
+  {
+    // if direct read is supported, load the package
+    if (supported)
+    {
+      createMapPackage(dataPath);
+    }
+    // otherwise, the package needs to be unpacked
+    else
+    {
+      MobileMapPackage::unpack(dataPath, m_unpackTempDir.path());
+    }
+  });
+
+  // connect to the Mobile Map Package instance to know when the data is unpacked
+  connect(MobileMapPackage::instance(), &MobileMapPackage::unpackCompleted,
+          this, [this](QUuid, bool success)
+  {
+    // if the unpack was successful, load the unpacked package
+    if (success)
+    {
+      createMapPackage(m_unpackTempDir.path());
+    }
+    // log that the upack failed
+    else
+    {
+      qDebug() << "failed to unpack";
+    }
+  });
+
+  // connect to the Mobile Map Package instance to know when errors occur
+  connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
+          [](Error e)
+  {
+    if (e.isEmpty())
+    {
+      return;
+    }
+
+    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
+  });
 }
 
 OpenMobileMap_MapPackage::~OpenMobileMap_MapPackage() = default;
@@ -38,30 +110,62 @@ void OpenMobileMap_MapPackage::init()
 
 void OpenMobileMap_MapPackage::componentComplete()
 {
-    QQuickItem::componentComplete();
+  QQuickItem::componentComplete();
 
-    // find QML MapView component
-    m_mapView = findChild<MapQuickView*>("mapView");
+  // find QML MapView component
+  m_mapView = findChild<MapQuickView*>("mapView");
 
-    // get the data path
-    QString dataPath = QQmlProperty::read(this, "dataPath").toUrl().toLocalFile();
+  // get the data path
+  const QString dataPath = defaultDataPath() + sampleFileYellowstone;
 
-    //! [open mobile map package cpp snippet]
-    // instatiate a mobile map package
-    m_mobileMapPackage = new MobileMapPackage(dataPath + "Yellowstone.mmpk", this);
+  // Check if the MMPK can be read directly
+  MobileMapPackage::isDirectReadSupported(dataPath);
+}
 
-    // wait for the mobile map package to load
-    connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, [this](Error error)
+// Slot for handling when the package loads
+void OpenMobileMap_MapPackage::packageLoaded(Error e)
+{
+  if (!e.isEmpty())
+  {
+    qDebug() << QString("Package load error: %1 %2").arg(e.message(), e.additionalMessage());
+    return;
+  }
+
+  if (m_mobileMapPackage->maps().isEmpty())
+  {
+    return;
+  }
+
+  // The package contains a list of maps that could be shown in the UI for selection.
+  // For simplicity, obtain the first map in the list of maps
+  m_map = m_mobileMapPackage->maps().at(0);
+
+  // set the map on the map view to display
+  if (m_map && m_mapView)
+  {
+    m_mapView->setMap(m_map);
+  }
+}
+
+// create map package and connect to signals
+void OpenMobileMap_MapPackage::createMapPackage(const QString& path)
+{
+  // instatiate a mobile map package
+  m_mobileMapPackage = new MobileMapPackage(path, this);
+
+  // wait for the mobile map package to load
+  connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, [this](Error error)
+  {
+    if (error.isEmpty())
     {
-        if (error.isEmpty())
-        {
-            // set the map view's map to the first map in the mobile map package
-            m_mapView->setMap(m_mobileMapPackage->maps().at(0));
-        }
-    });
+      // set the map view's map to the first map in the mobile map package
+      m_mapView->setMap(m_mobileMapPackage->maps().at(0));
+    }
+  });
 
-    // load the mobile map package
-    m_mobileMapPackage->load();
-    //! [open mobile map package cpp snippet]
+  connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, &OpenMobileMap_MapPackage::packageLoaded);
+
+  //! [open mobile map package cpp snippet]
+  m_mobileMapPackage->load();
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
@@ -138,18 +138,17 @@ void OpenMobileMap_MapPackage::createMapPackage(const QString& path)
       qDebug() << QString("Package load error: %1 %2").arg(error.message(), error.additionalMessage());
       return;
     }
-    else
-    {
-      if (!m_mobileMapPackage || !m_mapView || m_mobileMapPackage->maps().isEmpty())
-      {
-        return;
-      }
 
-      // The package contains a list of maps that could be shown in the UI for selection.
-      // For simplicity, obtain the first map in the list of maps.
-      // set the map on the map view to display
-      m_mapView->setMap(m_mobileMapPackage->maps().at(0));
+    if (!m_mobileMapPackage || !m_mapView || m_mobileMapPackage->maps().isEmpty())
+    {
+      return;
     }
+
+    // The package contains a list of maps that could be shown in the UI for selection.
+    // For simplicity, obtain the first map in the list of maps.
+    // set the map on the map view to display
+    m_mapView->setMap(m_mobileMapPackage->maps().at(0));
+
   });
 
   m_mobileMapPackage->load();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
@@ -17,6 +17,7 @@
 #include "OpenMobileMap_MapPackage.h"
 
 #include "Basemap.h"
+#include "Error.h"
 #include "MapQuickView.h"
 #include "MobileMapPackage.h"
 
@@ -123,7 +124,7 @@ void OpenMobileMap_MapPackage::componentComplete()
 }
 
 // Slot for handling when the package loads
-void OpenMobileMap_MapPackage::packageLoaded(Error e)
+void OpenMobileMap_MapPackage::packageLoaded(const Error& e)
 {
   if (!e.isEmpty())
   {
@@ -131,20 +132,7 @@ void OpenMobileMap_MapPackage::packageLoaded(Error e)
     return;
   }
 
-  if (m_mobileMapPackage->maps().isEmpty())
-  {
-    return;
-  }
-
-  // The package contains a list of maps that could be shown in the UI for selection.
-  // For simplicity, obtain the first map in the list of maps
-  m_map = m_mobileMapPackage->maps().at(0);
-
-  // set the map on the map view to display
-  if (m_map && m_mapView)
-  {
-    m_mapView->setMap(m_map);
-  }
+  setMapToView();
 }
 
 // create map package and connect to signals
@@ -159,7 +147,7 @@ void OpenMobileMap_MapPackage::createMapPackage(const QString& path)
     if (error.isEmpty())
     {
       // set the map view's map to the first map in the mobile map package
-      m_mapView->setMap(m_mobileMapPackage->maps().at(0));
+      setMapToView();
     }
   });
 
@@ -167,5 +155,23 @@ void OpenMobileMap_MapPackage::createMapPackage(const QString& path)
 
   //! [open mobile map package cpp snippet]
   m_mobileMapPackage->load();
+}
+
+void OpenMobileMap_MapPackage::setMapToView()
+{
+  if (!m_mobileMapPackage || !m_mapView)
+  {
+    return;
+  }
+
+  if (m_mobileMapPackage->maps().isEmpty())
+  {
+    return;
+  }
+
+  // The package contains a list of maps that could be shown in the UI for selection.
+  // For simplicity, obtain the first map in the list of maps
+  // set the map on the map view to display
+  m_mapView->setMap(m_mobileMapPackage->maps().at(0));
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
@@ -21,13 +21,12 @@ namespace Esri
 {
   namespace ArcGISRuntime
   {
+    class Error;
     class Map;
     class MapQuickView;
     class MobileMapPackage;
   }
 }
-
-#include "Error.h"
 
 #include <QQuickItem>
 #include <QTemporaryDir>
@@ -44,12 +43,12 @@ public:
   static void init();
 
 private slots:
-  void packageLoaded(Esri::ArcGISRuntime::Error e);
+  void packageLoaded(const Esri::ArcGISRuntime::Error& e);
 
 private:
   void createMapPackage(const QString& path);
+  void setMapToView();
 
-  Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::MobileMapPackage* m_mobileMapPackage = nullptr;
   QTemporaryDir m_unpackTempDir;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
@@ -21,12 +21,16 @@ namespace Esri
 {
   namespace ArcGISRuntime
   {
+    class Map;
     class MapQuickView;
     class MobileMapPackage;
   }
 }
 
+#include "Error.h"
+
 #include <QQuickItem>
+#include <QTemporaryDir>
 
 class OpenMobileMap_MapPackage : public QQuickItem
 {
@@ -39,9 +43,16 @@ public:
   void componentComplete() override;
   static void init();
 
+private slots:
+  void packageLoaded(Esri::ArcGISRuntime::Error e);
+
 private:
+  void createMapPackage(const QString& path);
+
+  Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::MobileMapPackage* m_mobileMapPackage = nullptr;
+  QTemporaryDir m_unpackTempDir;
 };
 
 #endif // OPEN_MOBILE_MAP_MAP_PACKAGE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
@@ -42,12 +42,8 @@ public:
   void componentComplete() override;
   static void init();
 
-private slots:
-  void packageLoaded(const Esri::ArcGISRuntime::Error& e);
-
 private:
   void createMapPackage(const QString& path);
-  void setMapToView();
 
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::MobileMapPackage* m_mobileMapPackage = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -23,8 +23,6 @@ OpenMobileMap_MapPackageSample {
     width: 800
     height: 600
 
-    property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/mmpk/"
-
     // add a mapView component
     MapView {
         anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
@@ -55,7 +55,7 @@ OpenMobileScenePackage::OpenMobileScenePackage(QObject* parent /* = nullptr */):
 
   // create the MSPK data path
   // data is downloaded automatically by the sample viewer app. Instructions to download
-  // seperately are specified in the readme.
+  // separately are specified in the readme.
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/mspk/philadelphia.mspk";
 
   // connect to the Mobile Scene Package instance to determine if direct read is supported. Packages

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
@@ -16,6 +16,7 @@
 
 #include "OpenMobileScenePackage.h"
 
+#include "Error.h"
 #include "MobileScenePackage.h"
 #include "Scene.h"
 #include "SceneQuickView.h"
@@ -136,7 +137,7 @@ void OpenMobileScenePackage::setSceneView(SceneQuickView* sceneView)
 }
 
 // Slot for handling when the package loads
-void OpenMobileScenePackage::packageLoaded(Error e)
+void OpenMobileScenePackage::packageLoaded(const Error& e)
 {
   if (!e.isEmpty())
   {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.h
@@ -21,15 +21,17 @@ namespace Esri
 {
 namespace ArcGISRuntime
 {
+class Error;
 class Scene;
 class SceneQuickView;
 class MobileScenePackage;
 }
 }
 
-#include "Error.h"
 #include <QObject>
 #include <QTemporaryDir>
+
+
 
 class OpenMobileScenePackage : public QObject
 {
@@ -44,7 +46,7 @@ public:
   static void init();
 
 private slots:
-  void packageLoaded(Esri::ArcGISRuntime::Error e);
+  void packageLoaded(const Esri::ArcGISRuntime::Error& e);
 
 signals:
   void sceneViewChanged();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -58,10 +58,9 @@ Rectangle {
         }
 
         onErrorChanged: {
-            console.log("Mobile Scene Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
+            console.log("Mobile Map Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
         }
     }
-    //! [open mobile map package qml api snippet]
 
     // Connect to the various signals on MobileMapPackageUtility
     // to determine if direct read is supported and if an unpack
@@ -94,4 +93,5 @@ Rectangle {
             mmpk.load();
         }
     }
+    //! [open mobile map package qml api snippet]
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -24,6 +24,7 @@ Rectangle {
 
     //! [open mobile map package qml api snippet]
     property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/mmpk/"
+    property url unpackPath: System.temporaryFolder.url + "/MmpkQml_%1.mmpk".arg(new Date().getTime().toString())
 
     // Create MapView
     MapView {
@@ -31,23 +32,66 @@ Rectangle {
         anchors.fill: parent
     }
 
+    Component.onCompleted: {
+        // check if direct read is supported before proceeding
+        MobileMapPackageUtility.isDirectReadSupported(mmpk.path);
+    }
+
     // Create a Mobile Map Package and set the path
     MobileMapPackage {
         id: mmpk
         path: dataPath + "Yellowstone.mmpk"
 
-        // load the mobile map package
-        Component.onCompleted: {
-            mmpk.load();
-        }
-
         // wait for the mobile map package to load
         onLoadStatusChanged: {
-            if (loadStatus === Enums.LoadStatusLoaded) {
-                // set the map view's map to the first map in the mobile map package
-                mapView.map = mmpk.maps[0];
+            // only proceed once the map package is loaded
+            if (loadStatus !== Enums.LoadStatusLoaded) {
+                return;
             }
+
+            if (mmpk.maps.length < 1) {
+                return;
+            }
+
+            // set the map view's map to the first map in the mobile map package
+            mapView.map = mmpk.maps[0];
+        }
+
+        onErrorChanged: {
+            console.log("Mobile Scene Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
         }
     }
     //! [open mobile map package qml api snippet]
+
+    // Connect to the various signals on MobileMapPackageUtility
+    // to determine if direct read is supported and if an unpack
+    // is needed.
+    Connections {
+        target: MobileMapPackageUtility
+
+        onIsDirectReadSupportedStatusChanged: {
+            if (MobileMapPackageUtility.isDirectReadSupportedStatus !== Enums.TaskStatusCompleted) {
+                return;
+            }
+
+            // if direct read is supported, load the MobileMapPackage
+            if (MobileMapPackageUtility.isDirectReadSupportedResult) {
+                mmpk.load();
+            } else {
+                // direct read is not supported, and the data must be unpacked
+                MobileMapPackageUtility.unpack(mmpk.path, unpackPath)
+            }
+        }
+
+        onUnpackStatusChanged: {
+            if (MobileMapPackageUtility.unpackStatus !== Enums.TaskStatusCompleted)
+                return;
+
+            // set the new path to the unpacked mobile map package
+            mmpk.path = unpackPath;
+
+            // load the mobile map package
+            mmpk.load();
+        }
+    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -63,7 +63,7 @@ Rectangle {
     }
 
     // Connect to the various signals on MobileMapPackageUtility
-    // to determine if direct read is supported and if an unpack
+    // to determine if direct read is supported or if an unpack
     // is needed.
     Connections {
         target: MobileMapPackageUtility

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
@@ -57,7 +57,7 @@ Rectangle {
         }
 
         onErrorChanged: {
-            console.log("Mobile Map Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
+            console.log("Mobile Scene Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
         }
     }
 


### PR DESCRIPTION
Open Mobile Map Package checks MMPK files whether they need to be unpacked before they can be loaded; and if so, unpacks them before loading. Some MMPK files contain data which need to be unpacked before they could be read and used.