### PR TITLE
Mfeigl/update readme for Scene Properties Expressions

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates how to update the orientation of a graphic using scene property rotation expressions.
 
-![](ScenePropertiesExpressions.gif)
+![](screenshot.png)
 
 ## How to use the sample
 Move the `Heading` and `Pitch` sliders to change the orientation of graphics in the graphics overlay.

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates how to update the orientation of a graphic using scene property rotation expressions.
 
-![](ScenePropertiesExpressions.gif)
+![](screenshot.png)
 
 ## How to use the sample
 Move the `Heading` and `Pitch` sliders to change the orientation of graphics in the graphics overlay.


### PR DESCRIPTION
The screenshot names were incorrect within the READMEs, for Properties Expressions.