### PR TITLE
Prior sample loose ends.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.json
@@ -4,7 +4,7 @@
         "CreateTerrainSurfaceFromLocalRaster.h",
         "CreateTerrainSurfaceFromLocalRaster.cpp"
     ],
-    "name" : "Create Terrain Surface from Local Raster",
+    "name" : "Create terrain surface from local raster",
     "dataItems" : [
         {
             "itemId" : "98092369c4ae4d549bbbd45dba993ebc",

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.md
@@ -9,8 +9,8 @@ The terrain surface is what the basemap, operational layers, and graphics are dr
 ## How it works
 
 1. Create a `Scene` and add it to a `SceneView`.
-2. Create a `RasterElevationSource` with a list of raster file paths.
-3. Add this source to the scene's base surface: `Scene.BaseSurface.ElevationSources.Add(rasterElevationSource)`.
+2. Create a `RasterElevationSource` with a list of local raster file paths, in this case a single .dt2 file
+3. Add this source to the scene's base surface: `Scene.BaseSurface.ElevationSources.append(rasterElevationSource)`.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.json
@@ -4,5 +4,5 @@
         "GetElevationAtPoint.h",
         "GetElevationAtPoint.cpp"
     ],
-    "name" : "Get Elevation At Point"
+    "name" : "Get elevation at point"
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.json
@@ -1,7 +1,7 @@
 {
     "source" :  "CreateTerrainSurfaceFromLocalRaster.qml",
     "otherSourceFiles" :  [],
-    "name" : "Create Terrain Surface from Local Raster",
+    "name" : "Create terrain surface from local raster",
     "dataItems" : [
         {
             "itemId" : "98092369c4ae4d549bbbd45dba993ebc",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.md
@@ -9,8 +9,8 @@ The terrain surface is what the basemap, operational layers, and graphics are dr
 ## How it works
 
 1. Create a `Scene` and add it to a `SceneView`.
-2. Create a `RasterElevationSource` with a list of raster file paths.
-3. Add this source to the scene's base surface: `Scene.BaseSurface.ElevationSources.Add(rasterElevationSource)`.
+2. Create a `RasterElevationSource`.
+3. Set the url property of the `RasterElevationSource` to the path of a local raster elevation source, in this case a .dt2 file.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.json
@@ -1,5 +1,5 @@
 {
     "source" :  "GetElevationAtPoint.qml",
     "otherSourceFiles" :  [],
-    "name" : "Get Elevation at Point"
+    "name" : "Get elevation at point"
 }


### PR DESCRIPTION
A few loose ends that I should have caught earlier
Changed display name of previous samples to be consistent with the others, (Starting with upper case, lower case subsequent words.)

Changed the README of createTerrainSurfaceFromLocalRaster to actually reflect the C++ call made in the sample (append), as well as have bespoke wording for setting the QML property.