### PR TITLE
Un-capitalising description titles

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/README.md
@@ -1,4 +1,4 @@
-# Get Elevation at Point
+# Get elevation at point
 
 Get the elevation for a given point on a surface.
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/README.md
@@ -1,4 +1,4 @@
-# Get Elevation at Point
+# Get elevation at point
 
 Get the elevation for a given point on a surface.
 


### PR DESCRIPTION
Having only the first word be capitalized in titles is the standard, had neglected to follow this rule in the sample descriptions. Amended.