### PR TITLE
Ldanzinger/fixes from verifications

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -115,6 +115,10 @@ ReadSymbolsFromMobileStyle::ReadSymbolsFromMobileStyle(QObject* parent /* = null
     // store the resulting symbol
     m_currentSymbol = static_cast<MultilayerPointSymbol*>(symbol);
 
+    // ensure cast was successful
+    if (!m_currentSymbol)
+      return;
+
     // set the size
     m_currentSymbol->setSize(m_symbolSize);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
@@ -79,8 +79,8 @@ private:
   SymbolImageProvider* m_symbolImageProvider = nullptr;
   QList<Esri::ArcGISRuntime::SymbolStyleSearchResultListModel*> m_models = { nullptr, nullptr, nullptr, nullptr };
   QList<QUuid> m_taskIds;
-  QColor m_currentColor;
-  int m_symbolSize;
+  QColor m_currentColor = QColor("yellow");
+  int m_symbolSize = 40;
   QUrl m_symbolImageUrl;
   QScopedPointer<QObject> m_graphicParent;
 };

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
@@ -79,7 +79,7 @@ private:
   SymbolImageProvider* m_symbolImageProvider = nullptr;
   QList<Esri::ArcGISRuntime::SymbolStyleSearchResultListModel*> m_models = { nullptr, nullptr, nullptr, nullptr };
   QList<QUuid> m_taskIds;
-  QColor m_currentColor = QColor("yellow");
+  QColor m_currentColor = QColor(Qt::yellow);
   int m_symbolSize = 40;
   QUrl m_symbolImageUrl;
   QScopedPointer<QObject> m_graphicParent;

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
@@ -22,17 +22,21 @@ ComboBox {
     id: rootComboBox
     textRole: "name"
     delegate: Item {
+        id: cboDelegate
         height: 30
         width: parent.width
 
         RowLayout {
             Image {
+                id: img
                 source: symbolUrl
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
             }
             Label {
                 text: name
+                Layout.preferredWidth: cboDelegate.width - img.width
+                elide: Text.ElideRight
             }
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
@@ -43,17 +43,21 @@ ComboBox {
         style.searchSymbols(params);
     }
     delegate: Item {
+        id: cboDelegate
         height: 30
         width: parent.width
 
         RowLayout {
             Image {
+                id: img
                 source: symbolUrl
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
             }
             Label {
                 text: name
+                Layout.preferredWidth: cboDelegate.width - img.width
+                elide: Text.ElideRight
             }
         }
 


### PR DESCRIPTION
@JamesMBallard please review/merge. A couple of issues addressed:

- setting width on text so elide works if text is too long
- Kathleen has reported random crash on iOS when it starts. Appears to most likely be a timing issue of some sort. I could repro one time only, making it hard to pin point. Adding 2 speculative safety measures that could help:
  - setting initial value to symbol size and color in case the block to set these on the symbol executes before the combo box values are initialized
  - checking casted pointer to ensure cast was successful