### PR TITLE
fixing crash by checking for nullptr

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -71,7 +71,7 @@ ReadSymbolsFromMobileStyle::ReadSymbolsFromMobileStyle(QObject* parent /* = null
     m_models[index] = results;
 
     emit symbolResultsChanged();
-    updateSymbol();
+    updateSymbol(0, 0, 0, Qt::yellow, 40);
   });
 
   // Load the style

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -71,7 +71,7 @@ ReadSymbolsFromMobileStyle::ReadSymbolsFromMobileStyle(QObject* parent /* = null
     m_models[index] = results;
 
     emit symbolResultsChanged();
-    updateSymbol(0, 0, 0, Qt::yellow, 40);
+    updateSymbol(0, 0, 0, QColor(Qt::yellow), 40);
   });
 
   // Load the style

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -71,6 +71,7 @@ ReadSymbolsFromMobileStyle::ReadSymbolsFromMobileStyle(QObject* parent /* = null
     m_models[index] = results;
 
     emit symbolResultsChanged();
+    updateSymbol();
   });
 
   // Load the style
@@ -222,7 +223,7 @@ void ReadSymbolsFromMobileStyle::clearGraphics()
 
 void ReadSymbolsFromMobileStyle::updateSymbol(int hatIndex, int mouthIndex, int eyeIndex, QColor color, int size)
 {
-  if (!m_symbolStyle || !hatResults() || !mouthResults() || !eyeResults())
+  if (!m_symbolStyle || !hatResults() || !mouthResults() || !eyeResults() || !faceResults())
     return;
 
   // set the color and size members

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
@@ -56,7 +56,7 @@ public:
   static void init();
 
   Q_INVOKABLE void clearGraphics();
-  Q_INVOKABLE void updateSymbol(int hatIndex, int mouthIndex, int eyeIndex, QColor color, int size);
+  Q_INVOKABLE void updateSymbol(int hatIndex = 0, int mouthIndex = 0, int eyeIndex = 0, QColor color = QColor(Qt::yellow), int size = 40);
 
 signals:
   void mapViewChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h
@@ -56,7 +56,7 @@ public:
   static void init();
 
   Q_INVOKABLE void clearGraphics();
-  Q_INVOKABLE void updateSymbol(int hatIndex = 0, int mouthIndex = 0, int eyeIndex = 0, QColor color = QColor(Qt::yellow), int size = 40);
+  Q_INVOKABLE void updateSymbol(int hatIndex, int mouthIndex, int eyeIndex, QColor color, int size);
 
 signals:
   void mapViewChanged();


### PR DESCRIPTION
@JamesMBallard please review/merge. I was missing one null check which caused the crash. Need to explicitly call update on searchSymbolsCompleted now so that the symbol updates once each component is complete