### PR TITLE
removing tai-state check to match common design

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/GroupLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/GroupLayers.qml
@@ -75,16 +75,11 @@ Item {
             Component {
                 id: groupLayerDelegate
                 Column {
-                    ButtonGroup {
-                        id: childGroup
-                        exclusive: false
-                        checkState: parentBox.checkState
-                    }
-
                     CheckBox {
                         id: parentBox
                         text: name
-                        checkState: childGroup.checkState
+                        checked: true
+                        onCheckedChanged: layerVisible = checked
                     }
 
                     Repeater {
@@ -94,10 +89,7 @@ Item {
                             text: name
                             leftPadding: indicator.width
                             width: layerVisibilityRect.width - leftPadding
-                            ButtonGroup.group: childGroup
-                            onCheckedChanged: {
-                                layerVisible = checked;
-                            }
+                            onCheckedChanged: layerVisible = checked
                         }
                     }
                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/GroupLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/GroupLayers.qml
@@ -133,16 +133,11 @@ Rectangle {
             Component {
                 id: groupLayerDelegate
                 Column {
-                    ButtonGroup {
-                        id: childGroup
-                        exclusive: false
-                        checkState: parentBox.checkState
-                    }
-
                     CheckBox {
                         id: parentBox
                         text: name
-                        checkState: childGroup.checkState
+                        checked: true
+                        onCheckedChanged: layerVisible = checked
                     }
 
                     Repeater {
@@ -153,7 +148,6 @@ Rectangle {
                             text: name
                             leftPadding: indicator.width
                             width: layerVisibilityRect.width - leftPadding
-                            ButtonGroup.group: childGroup
                             onCheckedChanged: layerVisible = checked
                         }
                     }


### PR DESCRIPTION
@anmacdonald please review. Removing the tri-state nature of the nested checkbox as discussed at the sprint review. Child layers should retain their state regardless of parent state.