### PR TITLE
setting temp path to explicit location

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.cpp
@@ -77,16 +77,6 @@ void DynamicWorkspaceRaster::componentComplete()
         {
           startLocalService(m_dataPath + "/usa_raster.tif");
           emit localServerInitializationComplete(true);
-
-          // create temp path
-          const QString tempPath = QDir::homePath() + "/EsriQtTemp";
-
-          // create the directory
-          if (!QDir(tempPath).exists())
-            QDir().mkdir(tempPath);
-
-          // set the temp data path for the local server
-          LocalServer::instance()->setTempDataPath(tempPath);
         }
       });
       LocalServer::start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.cpp
@@ -29,10 +29,8 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
-
 
 DynamicWorkspaceRaster::DynamicWorkspaceRaster(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent),
@@ -80,9 +78,15 @@ void DynamicWorkspaceRaster::componentComplete()
           startLocalService(m_dataPath + "/usa_raster.tif");
           emit localServerInitializationComplete(true);
 
-          // set temp path
-          QTemporaryDir tempDir;
-          LocalServer::instance()->setTempDataPath(tempDir.path());
+          // create temp path
+          const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+
+          // create the directory
+          if (!QDir(tempPath).exists())
+            QDir().mkdir(tempPath);
+
+          // set the temp data path for the local server
+          LocalServer::instance()->setTempDataPath(tempPath);
         }
       });
       LocalServer::start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.cpp
@@ -81,16 +81,6 @@ void DynamicWorkspaceShapefile::componentComplete()
         {
           emit localServerInitializationComplete(true);
           startLocalService(m_dataPath + "/mjrroads.shp");
-
-          // create temp path
-          const QString tempPath = QDir::homePath() + "/EsriQtTemp";
-
-          // create the directory
-          if (!QDir(tempPath).exists())
-            QDir().mkdir(tempPath);
-
-          // set the temp data path for the local server
-          LocalServer::instance()->setTempDataPath(tempPath);
         }
       });
       LocalServer::start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.cpp
@@ -33,7 +33,6 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -83,9 +82,15 @@ void DynamicWorkspaceShapefile::componentComplete()
           emit localServerInitializationComplete(true);
           startLocalService(m_dataPath + "/mjrroads.shp");
 
-          // set temp path
-          QTemporaryDir tempDir;
-          LocalServer::instance()->setTempDataPath(tempDir.path());
+          // create temp path
+          const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+
+          // create the directory
+          if (!QDir(tempPath).exists())
+            QDir().mkdir(tempPath);
+
+          // set the temp data path for the local server
+          LocalServer::instance()->setTempDataPath(tempPath);
         }
       });
       LocalServer::start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
@@ -26,7 +26,6 @@
 #include "Viewpoint.h"
 
 #include <QDir>
-#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -81,9 +80,15 @@ void LocalServerFeatureLayer::connectSignals()
     {
       qDebug() << "Local server started";
 
-      // set temp path
-      QTemporaryDir tempDir;
-      LocalServer::instance()->setTempDataPath(tempDir.path());
+      // create temp path
+      const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+
+      // create the directory
+      if (!QDir(tempPath).exists())
+        QDir().mkdir(tempPath);
+
+      // set the temp data path for the local server
+      LocalServer::instance()->setTempDataPath(tempPath);
 
       // start the local service
       m_localFeatureService->start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
@@ -79,19 +79,6 @@ void LocalServerFeatureLayer::connectSignals()
     if (LocalServer::status() == LocalServerStatus::Started)
     {
       qDebug() << "Local server started";
-
-      // create temp path
-      const QString tempPath = QDir::homePath() + "/EsriQtTemp";
-
-      // create the directory
-      if (!QDir(tempPath).exists())
-        QDir().mkdir(tempPath);
-
-      // set the temp data path for the local server
-      LocalServer::instance()->setTempDataPath(tempPath);
-
-      // start the local service
-      m_localFeatureService->start();
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -31,6 +31,7 @@
 #include "GeoprocessingDouble.h"
 #include "ArcGISMapImageLayer.h"
 
+#include <memory>
 #include <QDir>
 #include <QTemporaryDir>
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -32,7 +32,6 @@
 #include "ArcGISMapImageLayer.h"
 
 #include <QDir>
-#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -100,9 +99,15 @@ void LocalServerGeoprocessing::connectSignals()
   {
     if (LocalServer::status() == LocalServerStatus::Started)
     {
-      // set temp path
-      QTemporaryDir tempDir;
-      LocalServer::instance()->setTempDataPath(tempDir.path());
+      // create temp path
+      const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+
+      // create the directory
+      if (!QDir(tempPath).exists())
+        QDir().mkdir(tempPath);
+
+      // set the temp data path for the local server
+      LocalServer::instance()->setTempDataPath(tempPath);
 
       // start the service
       m_localGPService->start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -40,7 +40,7 @@ using namespace Esri::ArcGISRuntime;
 LocalServerGeoprocessing::LocalServerGeoprocessing(QQuickItem* parent) :
   QQuickItem(parent)
 {
-  // create temp path
+  // create temp/data path
   const QString tempPath = LocalServerGeoprocessing::shortestTempPath() + "/EsriQtTemp";
 
   // create the directory

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -31,7 +31,6 @@
 #include "GeoprocessingDouble.h"
 #include "ArcGISMapImageLayer.h"
 
-#include <memory>
 #include <QDir>
 #include <QTemporaryDir>
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -40,6 +40,15 @@ using namespace Esri::ArcGISRuntime;
 LocalServerGeoprocessing::LocalServerGeoprocessing(QQuickItem* parent) :
   QQuickItem(parent)
 {
+  // create temp path
+  const QString tempPath = LocalServerGeoprocessing::shortestTempPath() + "/EsriQtTemp";
+
+  // create the directory
+  m_tempDir = std::unique_ptr<QTemporaryDir>(new QTemporaryDir(tempPath));
+
+  // set the temp & app data path for the local server
+  LocalServer::instance()->setTempDataPath(m_tempDir->path());
+  LocalServer::instance()->setAppDataPath(m_tempDir->path());
 }
 
 // destructor
@@ -100,15 +109,6 @@ void LocalServerGeoprocessing::connectSignals()
   {
     if (LocalServer::status() == LocalServerStatus::Started)
     {
-      // create temp path
-      const QString tempPath = LocalServerGeoprocessing::shortestTempPath() + "/EsriQtTemp";
-
-      // create the directory
-      const QTemporaryDir tempDir(tempPath);
-
-      // set the temp data path for the local server
-      LocalServer::instance()->setTempDataPath(tempDir.path());
-
       // start the service
       m_localGPService->start();
       m_isReady = false;

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -32,6 +32,7 @@
 #include "ArcGISMapImageLayer.h"
 
 #include <QDir>
+#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -100,14 +101,13 @@ void LocalServerGeoprocessing::connectSignals()
     if (LocalServer::status() == LocalServerStatus::Started)
     {
       // create temp path
-      const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+      const QString tempPath = LocalServerGeoprocessing::shortestTempPath() + "/EsriQtTemp";
 
       // create the directory
-      if (!QDir(tempPath).exists())
-        QDir().mkdir(tempPath);
+      const QTemporaryDir tempDir(tempPath);
 
       // set the temp data path for the local server
-      LocalServer::instance()->setTempDataPath(tempPath);
+      LocalServer::instance()->setTempDataPath(tempDir.path());
 
       // start the service
       m_localGPService->start();
@@ -158,4 +158,17 @@ void LocalServerGeoprocessing::clearResults()
 {
   if (m_mapView->map()->operationalLayers()->size() > 1)
     m_mapView->map()->operationalLayers()->removeAt(1);
+}
+
+QString LocalServerGeoprocessing::shortestTempPath()
+{
+  // get tmp and home paths
+  const QString tmpPath = QDir::tempPath();
+  const QString homePath = QDir::homePath();
+
+  // return whichever is shorter, temp or home path
+  if (homePath.length() > tmpPath.length())
+    return tmpPath;
+  else
+    return homePath;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
@@ -30,9 +30,10 @@ class GeoprocessingTask;
 }
 }
 
+class QTemporaryDir;
+
 #include <QQuickItem>
 #include <QStringListModel>
-#include <QTemporaryDir>
 
 class LocalServerGeoprocessing : public QQuickItem
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
@@ -54,6 +54,7 @@ signals:
 
 private:
   void connectSignals();
+  static QString shortestTempPath();
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
@@ -32,6 +32,7 @@ class GeoprocessingTask;
 
 #include <QQuickItem>
 #include <QStringListModel>
+#include <QTemporaryDir>
 
 class LocalServerGeoprocessing : public QQuickItem
 {
@@ -63,6 +64,7 @@ private:
   Esri::ArcGISRuntime::LocalGeoprocessingService* m_localGPService = nullptr;
   Esri::ArcGISRuntime::GeoprocessingTask* m_gpTask = nullptr;
   bool m_isReady = false;
+  std::unique_ptr<QTemporaryDir> m_tempDir;
 };
 
 #endif // LOCAL_SERVER_GEOPROCESSING_H

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.h
@@ -32,6 +32,7 @@ class GeoprocessingTask;
 
 class QTemporaryDir;
 
+#include <memory>
 #include <QQuickItem>
 #include <QStringListModel>
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
@@ -77,16 +77,6 @@ void LocalServerMapImageLayer::connectSignals()
   {
     if (LocalServer::status() == LocalServerStatus::Started)
     {
-      // create temp path
-      const QString tempPath = QDir::homePath() + "/EsriQtTemp";
-
-      // create the directory
-      if (!QDir(tempPath).exists())
-        QDir().mkdir(tempPath);
-
-      // set the temp data path for the local server
-      LocalServer::instance()->setTempDataPath(tempPath);
-
       // start the service
       m_localMapService->start();
     }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
@@ -25,7 +25,6 @@
 #include "Viewpoint.h"
 
 #include <QDir>
-#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -78,9 +77,15 @@ void LocalServerMapImageLayer::connectSignals()
   {
     if (LocalServer::status() == LocalServerStatus::Started)
     {
-      // set temp path
-      QTemporaryDir tempDir;
-      LocalServer::instance()->setTempDataPath(tempDir.path());
+      // create temp path
+      const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+
+      // create the directory
+      if (!QDir(tempPath).exists())
+        QDir().mkdir(tempPath);
+
+      // set the temp data path for the local server
+      LocalServer::instance()->setTempDataPath(tempPath);
 
       // start the service
       m_localMapService->start();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -22,6 +22,7 @@
 #include "LocalFeatureService.h"
 #include "LocalGeoprocessingService.h"
 
+#include <memory>
 #include <QDesktopServices>
 #include <QDir>
 #include <QTemporaryDir>

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -24,7 +24,6 @@
 
 #include <QDesktopServices>
 #include <QDir>
-#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -78,9 +77,15 @@ void LocalServerServices::connectSignals()
       }
       case LocalServerStatus::Started:
       {
-        // set temp path
-        QTemporaryDir tempDir;
-        LocalServer::instance()->setTempDataPath(tempDir.path());
+        // create temp path
+        const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+
+        // create the directory
+        if (!QDir(tempPath).exists())
+          QDir().mkdir(tempPath);
+
+        // set the temp data path for the local server
+        LocalServer::instance()->setTempDataPath(tempPath);
 
         m_serverStatus.append("Server Status: STARTED\n");
         m_isServerRunning = true;

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -24,6 +24,7 @@
 
 #include <QDesktopServices>
 #include <QDir>
+#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -78,14 +79,13 @@ void LocalServerServices::connectSignals()
       case LocalServerStatus::Started:
       {
         // create temp path
-        const QString tempPath = QDir::homePath() + "/EsriQtTemp";
+        const QString tempPath = LocalServerServices::shortestTempPath() + "/EsriQtTemp";
 
         // create the directory
-        if (!QDir(tempPath).exists())
-          QDir().mkdir(tempPath);
+        const QTemporaryDir tempDir(tempPath);
 
         // set the temp data path for the local server
-        LocalServer::instance()->setTempDataPath(tempPath);
+        LocalServer::instance()->setTempDataPath(tempDir.path());
 
         m_serverStatus.append("Server Status: STARTED\n");
         m_isServerRunning = true;
@@ -291,4 +291,17 @@ void LocalServerServices::updateStatus(LocalService* service, const QString& ser
       break;
   }
   emit serverStatusChanged();
+}
+
+QString LocalServerServices::shortestTempPath()
+{
+  // get tmp and home paths
+  const QString tmpPath = QDir::tempPath();
+  const QString homePath = QDir::homePath();
+
+  // return whichever is shorter, temp or home path
+  if (homePath.length() > tmpPath.length())
+    return tmpPath;
+  else
+    return homePath;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -32,6 +32,16 @@ LocalServerServices::LocalServerServices(QQuickItem* parent) :
   QQuickItem(parent),
   m_dataPath(QDir::homePath() + "/ArcGIS/Runtime/Data")
 {
+  // create temp/data path
+  const QString tempPath = LocalServerServices::shortestTempPath() + "/EsriQtSample";
+
+  // create the directory
+  m_tempDir = std::unique_ptr<QTemporaryDir>(new QTemporaryDir(tempPath));
+
+  // set the temp & app data path for the local server
+  LocalServer::instance()->setTempDataPath(m_tempDir->path());
+  LocalServer::instance()->setAppDataPath(m_tempDir->path());
+
   emit dataPathChanged();
 }
 
@@ -78,15 +88,6 @@ void LocalServerServices::connectSignals()
       }
       case LocalServerStatus::Started:
       {
-        // create temp path
-        const QString tempPath = LocalServerServices::shortestTempPath() + "/EsriQtTemp";
-
-        // create the directory
-        const QTemporaryDir tempDir(tempPath);
-
-        // set the temp data path for the local server
-        LocalServer::instance()->setTempDataPath(tempDir.path());
-
         m_serverStatus.append("Server Status: STARTED\n");
         m_isServerRunning = true;
         emit isServerRunningChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -22,7 +22,6 @@
 #include "LocalFeatureService.h"
 #include "LocalGeoprocessingService.h"
 
-#include <memory>
 #include <QDesktopServices>
 #include <QDir>
 #include <QTemporaryDir>

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
@@ -30,6 +30,7 @@ namespace Esri
 }
 
 #include <QQuickItem>
+#include <QTemporaryDir>
 
 class LocalServerServices : public QQuickItem
 {
@@ -77,6 +78,7 @@ private:
   bool m_isServerRunning = false;
   bool m_isServiceRunning = false;
   QHash<QUrl, Esri::ArcGISRuntime::LocalService*> m_servicesHash;
+  std::unique_ptr<QTemporaryDir> m_tempDir;
 };
 
 #endif // LOCAL_SERVER_SERVICES_H

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
@@ -29,8 +29,9 @@ namespace Esri
   }
 }
 
+class QTemporaryDir;
+
 #include <QQuickItem>
-#include <QTemporaryDir>
 
 class LocalServerServices : public QQuickItem
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
@@ -65,6 +65,7 @@ private:
   bool isAnyServiceRunning();
   void updateStatus(Esri::ArcGISRuntime::LocalService* service, const QString& serviceName);
   void getCurrentServices();
+  static QString shortestTempPath();
 
 private:
   Esri::ArcGISRuntime::LocalMapService* m_localMapService = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.h
@@ -31,6 +31,7 @@ namespace Esri
 
 class QTemporaryDir;
 
+#include <memory>
 #include <QQuickItem>
 
 class LocalServerServices : public QQuickItem


### PR DESCRIPTION
@JamesMBallard please review/merge. Iterating on changes pushed up as part of https://github.com/Esri/arcgis-runtime-samples-qt/pull/883

@mbranscomb has let me know that due to path length issues, we need to explicitly set the temp path for local server samples to something shorter. 

As part of this pr I tried QDir::rootPath() so it was very short, but I think we are likely to hit permission issues especially on Linux. QDir::homePath should more reliably have write permissions I think