### PR TITLE
Ldanzinger/metadata transfer

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to execute a geoprocessing task to calculate a hotspot analysis based on the frequency of 911 calls",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geoprocessing",
+        "hotspot analysis",
+        "GeoprocessingTask",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingString",
+        "GeoprocessingResult",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-analyzehotspots.htm",
+    "relevant_apis": [
+        "GeoprocessingTask",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingString",
+        "GeoprocessingResult",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "snippets": [
+        "AnalyzeHotspots.cpp",
+        "AnalyzeHotspots.qml",
+        "AnalyzeHotspots.h"
+    ],
+    "title": "Analyze hotspots"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/README.metadata.json
@@ -1,0 +1,52 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to use GeoprocessingTask to calculate a viewshed using a geoprocessing service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geoprocessing",
+        "viewshed",
+        "visibility",
+        "GeoprocessingTask",
+        "GeoprocessingParameters",
+        "GeoprocessingJob",
+        "GeoprocessingFeatures",
+        "GeoprocessingResult",
+        "FeatureCollectionTable",
+        "GraphicsOverlay",
+        "SimpleRenderer",
+        "Graphic",
+        "SimpleMarkerSymbol",
+        "SimpleFillSymbol",
+        "FeatureIterator",
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-analyzeviewshed.htm",
+    "relevant_apis": [
+        "GeoprocessingTask",
+        "GeoprocessingParameters",
+        "GeoprocessingJob",
+        "GeoprocessingFeatures",
+        "GeoprocessingResult",
+        "FeatureCollectionTable",
+        "GraphicsOverlay",
+        "SimpleRenderer",
+        "Graphic",
+        "SimpleMarkerSymbol",
+        "SimpleFillSymbol",
+        "FeatureIterator",
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "AnalyzeViewshed.cpp",
+        "AnalyzeViewshed.h",
+        "AnalyzeViewshed.qml"
+    ],
+    "title": "Viewshed (geoprocessing)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates measuring 3D distances between two points in a scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "analysis",
+        "3D",
+        "measurement"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-distancemeasurementanalysis.htm",
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "LocationDistanceMeasurement"
+    ],
+    "snippets": [
+        "DistanceMeasurementAnalysis.qml",
+        "DistanceMeasurementAnalysis.cpp",
+        "DistanceMeasurementAnalysis.h"
+    ],
+    "title": "Distance measurement analysis"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Analysis",
+    "description": "Show a line of sight between two moving objects",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "line of sight",
+        "visibility",
+        "AnalysisOverlay",
+        "GeoElementLineOfSight"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-lineofsightgeoelement.htm",
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "GeoElementLineOfSight"
+    ],
+    "snippets": [
+        "LineOfSightGeoElement.cpp",
+        "LineOfSightGeoElement.h",
+        "LineOfSightGeoElement.qml"
+    ],
+    "title": "Line of sight (geoelement)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to perform a line of sight analysis between two points in a SceneView",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "line of sight",
+        "visibility",
+        "AnalysisOverlay",
+        "LocationLineOfSight",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-lineofsightlocation.htm",
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "LocationLineOfSight",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource"
+    ],
+    "snippets": [
+        "LineOfSightLocation.cpp",
+        "LineOfSightLocation.h",
+        "LineOfSightLocation.qml"
+    ],
+    "title": "Line of sight (location)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to query a table to get aggregated statistics back for a specific field",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "query",
+        "statistics",
+        "StatisticsQueryParameters",
+        "StatisticDefinition",
+        "StatisticsQueryResult",
+        "StatisticsRecordIterator",
+        "StatisticRecord",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-statisticalquery.htm",
+    "relevant_apis": [
+        "StatisticsQueryParameters",
+        "StatisticDefinition",
+        "StatisticsQueryResult",
+        "StatisticsRecordIterator",
+        "StatisticRecord",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "StatisticalQuery.qml",
+        "StatisticalQuery.cpp",
+        "StatisticalQuery.h"
+    ],
+    "title": "Statistical query"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to query a feature table to get statistics for one or more specified fields",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "statistics",
+        "sort results",
+        "ServiceFeatureTable",
+        "StatisticQueryParameters",
+        "StatisticQueryResult",
+        "StatisticIterator",
+        "StatisticRecord",
+        "StatisticDefinition",
+        "OrderBy"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-statisticalquerygroupsort.htm",
+    "relevant_apis": [
+        "ServiceFeatureTable",
+        "StatisticQueryParameters",
+        "StatisticQueryResult",
+        "StatisticIterator",
+        "StatisticRecord",
+        "StatisticDefinition",
+        "OrderBy"
+    ],
+    "snippets": [
+        "StatisticResultListModel.h",
+        "StatisticalQueryGroupSort.qml",
+        "StatisticResultListModel.cpp",
+        "OptionsPage.qml",
+        "StatisticalQueryGroupSort.cpp",
+        "StatisticalQueryGroupSort.h",
+        "ResultsPage.qml"
+    ],
+    "title": "Statistical query (group and sort)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to calculate a Viewshed from a SceneView's current Camera Viewpoint",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-viewshedcamera.htm",
+    "relevant_apis": [
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "snippets": [
+        "ViewshedCamera.cpp",
+        "ViewshedCamera.qml",
+        "ViewshedCamera.h"
+    ],
+    "title": "Viewshed (camera)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/README.metadata.json
@@ -1,0 +1,40 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to calculate a Viewshed from a GeoElement",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "viewshed",
+        "GeoElementViewshed",
+        "AnalysisOverlay",
+        "ArcGISSceneLayer",
+        "GraphicsOverlay",
+        "LayerSceneProperties",
+        "GeometryEngine",
+        "ModelSceneSymbol",
+        "GeodeticDistanceResult",
+        "SimpleRenderer",
+        "OrbitGeoElementCameraController."
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-viewshedgeoelement.htm",
+    "relevant_apis": [
+        "GeoElementViewshed",
+        "AnalysisOverlay",
+        "ArcGISSceneLayer",
+        "GraphicsOverlay",
+        "LayerSceneProperties",
+        "GeometryEngine",
+        "ModelSceneSymbol",
+        "GeodeticDistanceResult",
+        "SimpleRenderer",
+        "OrbitGeoElementCameraController."
+    ],
+    "snippets": [
+        "ViewshedGeoElement.cpp",
+        "ViewshedGeoElement.h",
+        "ViewshedGeoElement.qml"
+    ],
+    "title": "Viewshed (geoelement)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/README.metadata.json
@@ -1,0 +1,40 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to calculate a viewshed from a Point location",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "location",
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-viewshedlocation.htm",
+    "relevant_apis": [
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "snippets": [
+        "ViewshedLocation.qml",
+        "ViewshedSlider.qml",
+        "ColorDialog.qml",
+        "ViewshedLocation.h",
+        "ViewshedLocation.cpp"
+    ],
+    "title": "Viewshed (location)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to add and delete items (in this case a local .csv file) in a user's portal",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "portal item",
+        "new item",
+        "AuthenticationView",
+        "Portal",
+        "PortalItem",
+        "PortalUser"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-additemstoportal.htm",
+    "relevant_apis": [
+        "AuthenticationView",
+        "Portal",
+        "PortalItem",
+        "PortalUser"
+    ],
+    "snippets": [
+        "AddItemsToPortal.cpp",
+        "AddItemsToPortal.h",
+        "AddItemsToPortal.qml"
+    ],
+    "title": "Add items to portal"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates an approach to using OAuth2 for authenticating with an ArcGIS portal",
+    "ignore": true,
+    "images": [],
+    "keywords": [
+        "authentication",
+        "login",
+        "security",
+        "password",
+        "authorization",
+        "credential",
+        "AuthenticationChallenge",
+        "AuthenticationManager",
+        "Portal"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-oauthredirectexample.htm",
+    "relevant_apis": [
+        "AuthenticationChallenge",
+        "AuthenticationManager",
+        "Portal"
+    ],
+    "snippets": [
+        "OAuthRedirectExample.qml",
+        "OAuthRedirectExample.h",
+        "MyApplication.h",
+        "OAuthRedirectHandler.cpp",
+        "OAuthRedirectHandler.h",
+        "MyApplication.cpp",
+        "OAuthRedirectExample.cpp"
+    ],
+    "title": "OAuth redirect example"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to retrieve a user's details via a Portal",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "portal user",
+        "user details",
+        "Portal",
+        "Credential",
+        "PortalUser",
+        "PortalInfo",
+        "AuthenticationView",
+        "AuthenticationManager"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-portaluserinfo.htm",
+    "relevant_apis": [
+        "Portal",
+        "Credential",
+        "PortalUser",
+        "PortalInfo",
+        "AuthenticationView",
+        "AuthenticationManager"
+    ],
+    "snippets": [
+        "PortalUserInfo.h",
+        "PortalUserInfo.cpp",
+        "PortalUserInfo.qml"
+    ],
+    "title": "Portal user info"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to find portal items by using a keyword, and limit the results to items of a certain type - in this case, web maps",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "portal item",
+        "search",
+        "find",
+        "Portal",
+        "PortalQueryParametersForItems",
+        "PortalQueryResultSetForItems",
+        "PortalItemListModel",
+        "PortalItem"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-searchforwebmap.htm",
+    "relevant_apis": [
+        "Portal",
+        "PortalQueryParametersForItems",
+        "PortalQueryResultSetForItems",
+        "PortalItemListModel",
+        "PortalItem"
+    ],
+    "snippets": [
+        "SearchForWebmap.qml",
+        "SearchForWebmap.h",
+        "SearchForWebmap.cpp"
+    ],
+    "title": "Search for web map by keyword"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to load a Portal and then use the organization's predefined basemaps query to get all basemaps",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "predefined basemap",
+        "Portal",
+        "Credential",
+        "AuthenticationManager",
+        "BasemapListModel",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-showorgbasemaps.htm",
+    "relevant_apis": [
+        "Portal",
+        "Credential",
+        "AuthenticationManager",
+        "BasemapListModel",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "ShowOrgBasemaps.h",
+        "ShowOrgBasemaps.qml",
+        "ShowOrgBasemaps.cpp"
+    ],
+    "title": "Show organization basemaps"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to access a map service that is secured with ArcGIS token-based authentication",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "authentication",
+        "token",
+        "map service",
+        "AuthenticationManager",
+        "AuthenticationChallenge",
+        "AuthenticationView",
+        "Map",
+        "MapView",
+        "ArcGISMapImageLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-tokenauthentication.htm",
+    "relevant_apis": [
+        "AuthenticationManager",
+        "AuthenticationChallenge",
+        "AuthenticationView",
+        "Map",
+        "MapView",
+        "ArcGISMapImageLayer"
+    ],
+    "snippets": [
+        "TokenAuthentication.cpp",
+        "TokenAuthentication.qml",
+        "TokenAuthentication.h"
+    ],
+    "title": "Token authentication"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to build a legend for all the operational layers in the map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "legend",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISTiledLayer",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "LegendInfo",
+        "LegendInfoListModel"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-buildlegend.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISTiledLayer",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "LegendInfo",
+        "LegendInfoListModel"
+    ],
+    "snippets": [
+        "BuildLegend.qml",
+        "BuildLegend.cpp",
+        "BuildLegend.h"
+    ],
+    "title": "Build a legend"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/README.metadata.json
@@ -1,0 +1,45 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to display grids such as MGRS, Lat/Lon, USNG, and UTM on a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapView",
+        "Grid",
+        "LatitudeLongitudeGrid",
+        "MGRSGrid",
+        "UTMGrid",
+        "USNGGrid",
+        "MGRSGrid",
+        "LatitudeLongitudeGrid",
+        "USNGGrid",
+        "UTMGrid",
+        "TextSymbol",
+        "SimpleLineSymbol"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaygrid.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Grid",
+        "LatitudeLongitudeGrid",
+        "MGRSGrid",
+        "UTMGrid",
+        "USNGGrid",
+        "MGRSGrid",
+        "LatitudeLongitudeGrid",
+        "USNGGrid",
+        "UTMGrid",
+        "TextSymbol",
+        "SimpleLineSymbol"
+    ],
+    "snippets": [
+        "DisplayGrid.qml",
+        "DisplayGrid.h",
+        "DisplayGrid.cpp"
+    ],
+    "title": "Display a grid"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -1,0 +1,53 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates applying a dictionary renderer to graphics, in order to display military symbology without the need for a feature table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "dictionary renderer",
+        "military symbology",
+        "Basemap",
+        "DictionaryRenderer",
+        "Envelope",
+        "Geometry",
+        "GeometryEngine",
+        "Graphic",
+        "GraphicListModel",
+        "GraphicsOverlay",
+        "Map",
+        "MapQuickView",
+        "MultipartBuilder",
+        "Point",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "SpatialReference",
+        "DictionarySymbolStyle"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-godictionaryrenderer.htm",
+    "relevant_apis": [
+        "Basemap",
+        "DictionaryRenderer",
+        "Envelope",
+        "Geometry",
+        "GeometryEngine",
+        "Graphic",
+        "GraphicListModel",
+        "GraphicsOverlay",
+        "Map",
+        "MapQuickView",
+        "MultipartBuilder",
+        "Point",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "SpatialReference",
+        "DictionarySymbolStyle"
+    ],
+    "snippets": [
+        "GODictionaryRenderer.qml",
+        "GODictionaryRenderer.cpp",
+        "GODictionaryRenderer.h"
+    ],
+    "title": "Graphics overlay (dictionary renderer)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
@@ -1,0 +1,53 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates applying a dictionary renderer to a graphics overlay in a 3D scene to display military symbology",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "dictionary renderer",
+        "military symbology",
+        "ArcGISTiledElevationSource",
+        "Basemap",
+        "Camera",
+        "DictionaryRenderer",
+        "Envelope",
+        "Geometry",
+        "GeometryEngine",
+        "Graphic",
+        "GraphicsOverlay",
+        "Point",
+        "Scene",
+        "SceneQuickView",
+        "SceneView",
+        "SpatialReference",
+        "Surface",
+        "DictionarySymbolStyle"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-godictionaryrenderer-3d.htm",
+    "relevant_apis": [
+        "ArcGISTiledElevationSource",
+        "Basemap",
+        "Camera",
+        "DictionaryRenderer",
+        "Envelope",
+        "Geometry",
+        "GeometryEngine",
+        "Graphic",
+        "GraphicsOverlay",
+        "Point",
+        "Scene",
+        "SceneQuickView",
+        "SceneView",
+        "SpatialReference",
+        "Surface",
+        "DictionarySymbolStyle"
+    ],
+    "snippets": [
+        "GODictionaryRenderer_3D.cpp",
+        "GODictionaryRenderer_3D.h",
+        "GODictionaryRenderer_3D.qml"
+    ],
+    "title": "Graphics overlay (dictionary renderer) 3D"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GORenderers/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to add graphics and set a renderer on graphic overlays",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-gorenderers.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder"
+    ],
+    "snippets": [
+        "GORenderers.cpp",
+        "GORenderers.h",
+        "GORenderers.qml"
+    ],
+    "title": "Add graphics with renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/README.metadata.json
@@ -1,0 +1,43 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to add graphics with symbols to a graphics overlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder",
+        "GraphicsOverlay"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-gosymbols.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder",
+        "GraphicsOverlay"
+    ],
+    "snippets": [
+        "GOSymbols.cpp",
+        "GOSymbols.qml",
+        "GOSymbols.h"
+    ],
+    "title": "Add graphics with symbols"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to identify graphics in a graphics overlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "identify graphics",
+        "MapView",
+        "Map",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleFillSymbol",
+        "SimpleRenderer",
+        "PolygonBuilder"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-identifygraphics.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleFillSymbol",
+        "SimpleRenderer",
+        "PolygonBuilder"
+    ],
+    "snippets": [
+        "IdentifyGraphics.h",
+        "IdentifyGraphics.qml",
+        "IdentifyGraphics.cpp"
+    ],
+    "title": "Identify graphics"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to create PictureMarkerSymbols from the different types of image resources",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Point",
+        "GraphicsOverlay",
+        "Graphic",
+        "PictureMarkerSymbol",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-picturemarkersymbol.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Point",
+        "GraphicsOverlay",
+        "Graphic",
+        "PictureMarkerSymbol",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Picture_Marker_Symbol.qml",
+        "Picture_Marker_Symbol.h",
+        "Picture_Marker_Symbol.cpp"
+    ],
+    "title": "Picture marker symbol"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/README.metadata.json
@@ -1,0 +1,45 @@
+{
+    "category": "Display information",
+    "description": "Open a mobile style (.stylx) and read its contents.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MultilayerPointSymbol",
+        "Symbol::createSwatch",
+        "SymbolLayer",
+        "SymbolStyle",
+        "SymbolStyle::searchSymbols",
+        "SymbolStyle::fetchSymbol",
+        "SymbolStyleSearchResultListModel",
+        "SymbolStyleSearchResult",
+        "SymbolStyleSearchParameters",
+        "advanced",
+        "symbology",
+        "multilayer",
+        "mobile style",
+        "stylx"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "MultilayerPointSymbol",
+        "Symbol::createSwatch",
+        "SymbolLayer",
+        "SymbolStyle",
+        "SymbolStyle::searchSymbols",
+        "SymbolStyle::fetchSymbol",
+        "SymbolStyleSearchResultListModel",
+        "SymbolStyleSearchResult",
+        "SymbolStyleSearchParameters"
+    ],
+    "snippets": [
+        "ReadSymbolsFromMobileStyle.qml",
+        "ReadSymbolsFromMobileStyle.h",
+        "ReadSymbolsFromMobileStyle.cpp",
+        "SymbolComboBox.qml",
+        "SymbolImageProvider.h",
+        "SymbolImageProvider.cpp"
+    ],
+    "title": "Read symbols from a mobile style"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to show location coordinates on a Map using a Callout",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapView",
+        "Callout",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-showcallout.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Callout",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "ShowCallout.h",
+        "ShowCallout.qml",
+        "ShowCallout.cpp"
+    ],
+    "title": "Show callout"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to display labels on a FeatureLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Labels",
+        "LabelDefinition",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-showlabelsonlayers.htm",
+    "relevant_apis": [
+        "LabelDefinition",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "ShowLabelsOnLayers.cpp",
+        "ShowLabelsOnLayers.qml",
+        "ShowLabelsOnLayers.h"
+    ],
+    "title": "Show labels on layers"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to add a point graphic, symbolized by a red circle specified via a SimpleMarkerSymbol, to a GraphicsOverlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "Viewpoint",
+        "Point",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-simplemarkersymbol.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "Viewpoint",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Simple_Marker_Symbol.cpp",
+        "Simple_Marker_Symbol.h",
+        "Simple_Marker_Symbol.qml"
+    ],
+    "title": "Simple marker symbol"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to create a SimpleRenderer and add it to a GraphicsOverlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleMarkerSymbol",
+        "SimpleRenderer",
+        "Point",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-simplerenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleMarkerSymbol",
+        "SimpleRenderer",
+        "Point",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Simple_Renderer.qml",
+        "Simple_Renderer.cpp",
+        "Simple_Renderer.h"
+    ],
+    "title": "Simple renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to override the default renderer of a shapefile when displaying with a FeatureLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "shapefile",
+        "shape file",
+        "ShapefileFeatureTable",
+        "FeatureLayer",
+        "SimpleRenderer",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-symbolizeshapefile.htm",
+    "relevant_apis": [
+        "ShapefileFeatureTable",
+        "FeatureLayer",
+        "SimpleRenderer",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Map"
+    ],
+    "snippets": [
+        "SymbolizeShapefile.cpp",
+        "SymbolizeShapefile.qml",
+        "SymbolizeShapefile.h"
+    ],
+    "title": "Symbolize a shapefile"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to use a UniqueValueRenderer to style different Features in a FeatureLayer with different Symbols",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "style features",
+        "Map",
+        "MapView",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "UniqueValueRenderer",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Viewpoint",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-uniquevaluerenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "UniqueValueRenderer",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Viewpoint",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Unique_Value_Renderer.qml",
+        "Unique_Value_Renderer.h",
+        "Unique_Value_Renderer.cpp"
+    ],
+    "title": "Unique value renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/README.metadata.json
@@ -1,0 +1,41 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to add features to a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "create feature",
+        "feature table",
+        "edit feature",
+        "feature service",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "FeatureEditResult"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-addfeaturesfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "FeatureEditResult"
+    ],
+    "snippets": [
+        "AddFeaturesFeatureService.qml",
+        "AddFeaturesFeatureService.h",
+        "AddFeaturesFeatureService.cpp"
+    ],
+    "title": "Add features (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/README.metadata.json
@@ -1,0 +1,44 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to delete a feature from a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "delete feature",
+        "feature editing",
+        "feature service",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-deletefeaturesfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "snippets": [
+        "DeleteFeaturesFeatureService.cpp",
+        "DeleteFeaturesFeatureService.h",
+        "DeleteFeaturesFeatureService.qml"
+    ],
+    "title": "Delete features (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.metadata.json
@@ -1,0 +1,49 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to generate an offline mobile geodatabase from a feature service, edit the feature's geometry while disconnected, and synchronize the local edits back to a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sync edits",
+        "generate mobile geodatabase",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "FeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseJob",
+        "GenerateGeodatabaseParameters",
+        "SyncGeodatabaseJob",
+        "SyncGeodatabaseParameters",
+        "GenerateLayerOption",
+        "SyncLayerOption"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-editandsyncfeatures.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "FeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseJob",
+        "GenerateGeodatabaseParameters",
+        "SyncGeodatabaseJob",
+        "SyncGeodatabaseParameters",
+        "GenerateLayerOption",
+        "SyncLayerOption"
+    ],
+    "snippets": [
+        "EditAndSyncFeatures.qml",
+        "EditAndSyncFeatures.h",
+        "EditAndSyncFeatures.cpp"
+    ],
+    "title": "Edit and sync features"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/README.metadata.json
@@ -1,0 +1,47 @@
+{
+    "category": "Edit data",
+    "description": "The sample demonstrates how to add, delete, and fetch attachments for a specific feature in a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "edit feature attachments",
+        "attachments",
+        "edit features",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "AttachmentListModel"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-editfeatureattachments.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "AttachmentListModel"
+    ],
+    "snippets": [
+        "EditFeatureAttachments.cpp",
+        "main.qml",
+        "EditFeatureAttachments.h",
+        "EditFeatureAttachments.qml"
+    ],
+    "title": "Edit feature attachments"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/README.metadata.json
@@ -1,0 +1,46 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to edit attributes of a feature in a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "edit feature attributes",
+        "attributes",
+        "edit features",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "Point"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-updateattributesfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "Point"
+    ],
+    "snippets": [
+        "UpdateAttributesFeatureService.cpp",
+        "UpdateAttributesFeatureService.qml",
+        "UpdateAttributesFeatureService.h"
+    ],
+    "title": "Update attributes (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/README.metadata.json
@@ -1,0 +1,41 @@
+{
+    "category": "Edit data",
+    "description": "The sample demonstrates how to update geometry of a feature in a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-updategeometryfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "snippets": [
+        "UpdateGeometryFeatureService.h",
+        "UpdateGeometryFeatureService.qml",
+        "UpdateGeometryFeatureService.cpp"
+    ],
+    "title": "Update geometry (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to override and reset a feature layer renderer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Envelope",
+        "SimpleLineSymbol",
+        "SimpleRenderer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayer-changerenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Envelope",
+        "SimpleLineSymbol",
+        "SimpleRenderer"
+    ],
+    "snippets": [
+        "FeatureLayerChangeRenderer.qml",
+        "FeatureLayerChangeRenderer.cpp",
+        "FeatureLayerChangeRenderer.h"
+    ],
+    "title": "Feature layer change renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/README.metadata.json
@@ -1,0 +1,36 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to limit the features to display on the map using a definition expression",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "definition expression",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Point"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerdefinitionexpression.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Point"
+    ],
+    "snippets": [
+        "FeatureLayerDefinitionExpression.qml",
+        "FeatureLayerDefinitionExpression.cpp",
+        "FeatureLayerDefinitionExpression.h"
+    ],
+    "title": "Feature layer definition expression"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to display a FeatureLayer with military symbology, using ArcGIS Runtime's DictionaryRenderer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "dictionary renderer",
+        "military symbology",
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "DictionarySymbolStyle",
+        "DictionaryRenderer",
+        "Geodatabase",
+        "FeatureLayer",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerdictionaryrenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "DictionarySymbolStyle",
+        "DictionaryRenderer",
+        "Geodatabase",
+        "FeatureLayer",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "FeatureLayerDictionaryRenderer.cpp",
+        "FeatureLayerDictionaryRenderer.h",
+        "FeatureLayerDictionaryRenderer.qml"
+    ],
+    "title": "Feature layer (dictionary renderer)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to consume an Esri feature service by using a FeatureLayer and a ServiceFeatureTable",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "qt/latest/cpp/sample-code/sample-qt-featurelayer-featureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "FeatureLayerFeatureService.qml",
+        "FeatureLayerFeatureService.cpp",
+        "FeatureLayerFeatureService.h"
+    ],
+    "title": "Feature layer (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to open a GeoPackage, obtain a feature table from the package, and display the table as a FeatureLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GeoPackage",
+        "GeoPackageFeatureTable",
+        "FeatureLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayergeopackage.htm",
+    "relevant_apis": [
+        "GeoPackage",
+        "GeoPackageFeatureTable",
+        "FeatureLayer",
+        "Map"
+    ],
+    "snippets": [
+        "FeatureLayer_GeoPackage.cpp",
+        "FeatureLayer_GeoPackage.qml",
+        "FeatureLayer_GeoPackage.h"
+    ],
+    "title": "Feature layer (GeoPackage)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to consume an Esri mobile geodatabase by using a FeatureLayer and a GeodatabaseFeatureTable",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "mobile geodatabase",
+        "MapView",
+        "Map",
+        "Basemap",
+        "GeodatabaseFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayergeodatabase.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "GeodatabaseFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "FeatureLayerGeodatabase.qml",
+        "FeatureLayerGeodatabase.cpp",
+        "FeatureLayerGeodatabase.h"
+    ],
+    "title": "Feature layer (geodatabase)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to query a feature layer using a feature table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapQuickView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Viewpoint"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerquery.htm",
+    "relevant_apis": [
+        "MapQuickView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "FeatureLayerQuery.h",
+        "FeatureLayerQuery.cpp",
+        "FeatureLayerQuery.qml"
+    ],
+    "title": "Feature layer query"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/README.metadata.json
@@ -1,0 +1,40 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to select features in a feature layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "feature selection",
+        "MapQuickView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "Envelope",
+        "GeoElement"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerselection.htm",
+    "relevant_apis": [
+        "MapQuickView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "Envelope",
+        "GeoElement"
+    ],
+    "snippets": [
+        "FeatureLayerSelection.cpp",
+        "FeatureLayerSelection.h",
+        "FeatureLayerSelection.qml"
+    ],
+    "title": "Feature layer selection"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to take a feature service offline by generating a geodatabase",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "mobile geodatabase",
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "GeodatabaseFeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseParameters",
+        "GenerateLayerOption",
+        "GenerateGeodatabaseJob"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-generategeodatabase.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "GeodatabaseFeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseParameters",
+        "GenerateLayerOption",
+        "GenerateGeodatabaseJob"
+    ],
+    "snippets": [
+        "GenerateGeodatabase.qml",
+        "GenerateGeodatabase.cpp",
+        "GenerateGeodatabase.h"
+    ],
+    "title": "Generate geodatabase"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/README.metadata.json
@@ -1,0 +1,40 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to query a layer for features that are in a related table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "related features",
+        "ArcGISFeatureTable",
+        "ArcGISFeature",
+        "RelatedFeatureQueryResult",
+        "FeatureQueryResult",
+        "FeatureIterator",
+        "Map",
+        "MapView",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-listrelatedfeatures.htm",
+    "relevant_apis": [
+        "ArcGISFeatureTable",
+        "ArcGISFeature",
+        "RelatedFeatureQueryResult",
+        "FeatureQueryResult",
+        "FeatureIterator",
+        "Map",
+        "MapView",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "RelatedFeatureListModel.h",
+        "ListRelatedFeatures.h",
+        "ListRelatedFeatures.cpp",
+        "RelatedFeatureListModel.cpp",
+        "RelatedFeature.cpp",
+        "ListRelatedFeatures.qml",
+        "RelatedFeature.h"
+    ],
+    "title": "List related features"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to use a feature table with the OnInteractionCache feature request mode",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-servicefeaturetable-cache.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "ServiceFeatureTableCache.qml",
+        "ServiceFeatureTableCache.cpp",
+        "ServiceFeatureTableCache.h"
+    ],
+    "title": "Service feature table (cache)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to use a feature service in manual cache mode",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "QueryParameters"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-servicefeaturetable-manualcache.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "QueryParameters"
+    ],
+    "snippets": [
+        "ServiceFeatureTableManualCache.cpp",
+        "ServiceFeatureTableManualCache.qml",
+        "ServiceFeatureTableManualCache.h"
+    ],
+    "title": "Service feature table (manual cache)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to use a feature table in on interaction no cache mode",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-servicefeaturetable-nocache.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "ServiceFeatureTableNoCache.cpp",
+        "ServiceFeatureTableNoCache.qml",
+        "ServiceFeatureTableNoCache.h"
+    ],
+    "title": "Service feature table (no cache)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/TimeBasedQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/TimeBasedQuery/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to query data using a time extent",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "time",
+        "time extent",
+        "query",
+        "TimeExtent",
+        "QueryParameters",
+        "ServiceFeatureTable::populateFromService"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-timebasedquery.htm",
+    "relevant_apis": [
+        "TimeExtent",
+        "QueryParameters",
+        "ServiceFeatureTable::populateFromService"
+    ],
+    "snippets": [
+        "TimeBasedQuery.cpp",
+        "TimeBasedQuery.h",
+        "TimeBasedQuery.qml"
+    ],
+    "title": "Time based query"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to use GeometryEngine::buffer to create polygons from a map location and linear distance (radius)",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "buffer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-buffer.htm",
+    "relevant_apis": [
+        "GeometryEngine::buffer",
+        "GeometryEngine::bufferGeodetic",
+        "GraphicsOverlay"
+    ],
+    "snippets": [
+        "Buffer.cpp",
+        "Buffer.h",
+        "Buffer.qml"
+    ],
+    "title": "Buffer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to clip a geometry with an envelope using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "clip"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-clipgeometry.htm",
+    "relevant_apis": [
+        "GeometryEngine::clip",
+        "GraphicsOverlay",
+        "Graphic",
+        "Geometry",
+        "Envelope"
+    ],
+    "snippets": [
+        "ClipGeometry.h",
+        "ClipGeometry.qml",
+        "ClipGeometry.cpp"
+    ],
+    "title": "Clip geometry"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/README.metadata.json
@@ -1,0 +1,36 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to build the various Geometry objects that are supported in ArcGIS Runtime",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "create geometry",
+        "Point",
+        "Multipoint",
+        "Polyline",
+        "Polygon",
+        "Envelope",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "MultipointBuilder"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-creategeometries.htm",
+    "relevant_apis": [
+        "Point",
+        "Multipoint",
+        "Polyline",
+        "Polygon",
+        "Envelope",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "MultipointBuilder"
+    ],
+    "snippets": [
+        "CreateGeometries.cpp",
+        "CreateGeometries.h",
+        "CreateGeometries.qml"
+    ],
+    "title": "Create geometries"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to cut a geometry with a polyline using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "split geometry"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-cutgeometry.htm",
+    "relevant_apis": [
+        "GeometryEngine",
+        "GeometryEngine::cut"
+    ],
+    "snippets": [
+        "CutGeometry.cpp",
+        "CutGeometry.h",
+        "CutGeometry.qml"
+    ],
+    "title": "Cut geometry"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to densify (add additional vertices) or generalize (reduce vertices) a polyline geometry",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "densify geometry",
+        "generalize geometry"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-densifyandgeneralize.htm",
+    "relevant_apis": [
+        "GeometryEngine::densify",
+        "GeometryEngine::generalize",
+        "PointCollection",
+        "Multipoint",
+        "Polyline"
+    ],
+    "snippets": [
+        "DensifyAndGeneralize.qml",
+        "DensifyAndGeneralize.cpp",
+        "DensifyAndGeneralize.h"
+    ],
+    "title": "Densify and generalize"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Geometry",
+    "description": "Coordinates can be written as text that is formatted in different ways",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "CoordinateFormatter",
+        "Point",
+        "Graphic"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-formatcoordinates.htm",
+    "relevant_apis": [
+        "coordinates",
+        "decimal degrees",
+        "degrees minutes seconds",
+        "MGRS",
+        "USNG",
+        "UTM",
+        "CoordinateFormatter"
+    ],
+    "snippets": [
+        "FormatCoordinates.qml",
+        "main.qml",
+        "FormatCoordinates.cpp",
+        "FormatCoordinates.h"
+    ],
+    "title": "Format coordinates"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to perform geodesic operations on geometries using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "densify",
+        "geodesic distance",
+        "geodetic distance"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-geodesicoperations.htm",
+    "relevant_apis": [
+        "GeometryEngine::densifyGeodetic",
+        "GeometryEngine::lengthGeodetic"
+    ],
+    "snippets": [
+        "GeodesicOperations.qml",
+        "GeodesicOperations.h",
+        "GeodesicOperations.cpp"
+    ],
+    "title": "Geodesic operations"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to use the TransformationCatalog to get a list of available DatumTransformations that can be used to project a Geometry between two different SpatialReferences, and how to use one of the transformations to perform the GeometryEngine.project operation",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geographic transformation",
+        "datum transformation",
+        "geometry engine"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-listtransformations.htm",
+    "relevant_apis": [
+        "TransformationCatalog",
+        "DatumTransformation",
+        "GeographicTransformation",
+        "GeographicTransformationStep",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "ListTransformations.h",
+        "ListTransformations.qml",
+        "ListTransformations.cpp"
+    ],
+    "title": "List transformations by suitability"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to project a point from one spatial reference to another",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "project geometry",
+        "spatial seference",
+        "projection",
+        "coordinate system",
+        "geometry engine"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-projectgeometry.htm",
+    "relevant_apis": [
+        "GeometryEngine",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "ProjectGeometry.cpp",
+        "ProjectGeometry.h",
+        "ProjectGeometry.qml"
+    ],
+    "title": "Project"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to perform spatial operations on geometries using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "geometric union",
+        "geometric difference",
+        "geometric symmetric difference",
+        "geometric intersection"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-spatialoperations.htm",
+    "relevant_apis": [
+        "GeometryEngine",
+        "GeometryEngine::union",
+        "GeometryEngine::difference",
+        "GeometryEngine::symmetricDifference",
+        "GeometryEngine::intersection",
+        "Geometry",
+        "Graphic",
+        "GraphicsOverlay",
+        "PolygonBuilder"
+    ],
+    "snippets": [
+        "SpatialOperations.qml",
+        "SpatialOperations.h",
+        "SpatialOperations.cpp"
+    ],
+    "title": "Spatial operations"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/README.metadata.json
@@ -1,0 +1,36 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to determine the spatial relationships between two geometries",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "spatial analysis",
+        "spatial relationships",
+        "intersects",
+        "touches",
+        "disjoint",
+        "crosses",
+        "within",
+        "overlaps",
+        "contains"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-spatialrelationships.htm",
+    "relevant_apis": [
+        "GeometryEngine::intersects",
+        "GeometryEngine::touches",
+        "GeometryEngine::disjoint",
+        "GeometryEngine::crosses",
+        "GeometryEngine::within",
+        "GeometryEngine::overlaps",
+        "GeometryEngine::contains"
+    ],
+    "snippets": [
+        "SpatialRelationships.cpp",
+        "SpatialRelationships.h",
+        "SpatialRelationships.qml"
+    ],
+    "title": "Spatial relationships"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Layers",
+    "description": "Display nautical charts per the ENC specification.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "EncCell",
+        "EncDataset",
+        "EncExchangeSet",
+        "EncLayer",
+        "Data",
+        "ENC",
+        "maritime",
+        "nautical chart",
+        "layers",
+        "hydrographic"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "EncCell",
+        "EncDataset",
+        "EncExchangeSet",
+        "EncLayer"
+    ],
+    "snippets": [
+        "AddEncExchangeSet.h",
+        "AddEncExchangeSet.cpp",
+        "AddEncExchangeSet.qml"
+    ],
+    "title": "Add ENC exchange set"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a map image layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "map image layer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-arcgismapimagelayerurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer"
+    ],
+    "snippets": [
+        "ArcGISMapImageLayerUrl.qml",
+        "ArcGISMapImageLayerUrl.h",
+        "ArcGISMapImageLayerUrl.cpp"
+    ],
+    "title": "ArcGIS map image layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a tiled map service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-arcgistiledlayerurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer"
+    ],
+    "snippets": [
+        "ArcGISTiledLayerUrl.qml",
+        "ArcGISTiledLayerUrl.h",
+        "ArcGISTiledLayerUrl.cpp"
+    ],
+    "title": "ArcGIS tiled layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use blend renderer on a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "blend renderers",
+        "hillshade",
+        "MapQuickView",
+        "Raster",
+        "RasterLayer",
+        "BlendRenderer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-blendrasterlayer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapQuickView",
+        "Raster",
+        "RasterLayer",
+        "BlendRenderer"
+    ],
+    "snippets": [
+        "BlendRasterLayer.cpp",
+        "BlendRasterLayer.h",
+        "BlendRasterLayer.qml",
+        "ColorRampModel.qml",
+        "SlopeTypeModel.qml"
+    ],
+    "title": "Blend raster layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Layers",
+    "description": "Browse a WFS service for layers and add them to the map.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WfsService",
+        "WfsServiceInfo",
+        "WfsLayerInfo",
+        "WfsFeatureTable",
+        "FeatureLayer",
+        "WfsFeatureTable::AxisOrder",
+        "OGC",
+        "WFS",
+        "feature",
+        "web",
+        "service",
+        "layers",
+        "browse",
+        "catalog"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [        
+        "WfsService",
+        "WfsServiceInfo",
+        "WfsLayerInfo",
+        "WfsFeatureTable",
+        "FeatureLayer",
+        "WfsFeatureTable::AxisOrder"
+    ],
+    "snippets": [
+        "BrowseWfsLayers.cpp",
+        "BrowseWfsLayers.h",
+        "BrowseWfsLayers.qml"
+    ],
+    "title": "Browse WFS layers"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to change the renderer on a map image layer sublayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sublayer renderer",
+        "dynamic layer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-changesublayerrenderer.htm",
+    "relevant_apis": [
+        "ArcGISMapImageSublayer",
+        "ClassBreaksRenderer",
+        "ClassBreak",
+        "ArcGISMapImageSublayer::renderer"
+    ],
+    "snippets": [
+        "ChangeSublayerRenderer.cpp",
+        "ChangeSublayerRenderer.qml",
+        "ChangeSublayerRenderer.h"
+    ],
+    "title": "Change sublayer renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how you can hide or show sublayers of a map image layer by using the ArcGISSublayerListModel",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sublayer",
+        "visibility"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-changesublayervisibility.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISSublayerListModel"
+    ],
+    "snippets": [
+        "ChangeSublayerVisibility.h",
+        "ChangeSublayerVisibility.cpp",
+        "ChangeSublayerVisibility.qml"
+    ],
+    "title": "Change sublayer visibility"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "Load and display KML files from various sources, including URLs, local files, and Portal items",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "KML",
+        "KMZ",
+        "OGC",
+        "Keyhole"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaykml.htm",
+    "relevant_apis": [
+        "KmlLayer",
+        "KmlDataset"
+    ],
+    "snippets": [
+        "DisplayKml.h",
+        "DisplayKml.qml",
+        "DisplayKml.cpp"
+    ],
+    "title": "Display KML"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a file with a network link, including displaying any network link control messages at launch",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "KML",
+        "KMZ",
+        "OGC",
+        "Keyhole",
+        "Network Link",
+        "Network Link Control"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaykmlnetworklinks.htm",
+    "relevant_apis": [
+        "KmlDataset(Url)",
+        "KmlLayer(KmlDataset)",
+        "KmlNetworkLink",
+        "KmlNetworkLinkMessageReceived"
+    ],
+    "snippets": [
+        "DisplayKmlNetworkLinks.cpp",
+        "DisplayKmlNetworkLinks.qml",
+        "DisplayKmlNetworkLinks.h",
+        "MessageButton.qml"
+    ],
+    "title": "Display KML network links"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Layers",
+    "description": "Display a layer from a WFS service, requesting only features for the current extent.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WfsFeatureTable",
+        "WfsFeatureTable::populateFromService",
+        "FeatureLayer",
+        "OGC",
+        "WFS",
+        "feature",
+        "web",
+        "service",
+        "layers",
+        "browse",
+        "catalog",
+        "interaction cache"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "WfsFeatureTable",
+        "WfsFeatureTable::populateFromService",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "DisplayWfsLayer.cpp",
+        "DisplayWfsLayer.h",
+        "DisplayWfsLayer.qml"
+    ],
+    "title": "Display a WFS layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to export tiles from a map service for offline use",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "map tiles", 
+        "create tile cache"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-exporttiles.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "ExportTileCacheTask",
+        "ExportTileCacheJob",
+        "ExportTiledCacheParameters"
+    ],
+    "snippets": [
+        "ExportTiles.qml",
+        "ExportTiles.h",
+        "ExportTiles.cpp"
+    ],
+    "title": "Export tiles"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create a feature collection layer to show a query result from a service feature table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Map",
+        "MapQuickView",
+        "ServiceFeatureTable"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurecollectionlayerquery.htm",
+    "relevant_apis": [
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Map",
+        "MapQuickView",
+        "ServiceFeatureTable"
+    ],
+    "snippets": [
+        "FeatureCollectionLayerQuery.qml",
+        "FeatureCollectionLayerQuery.cpp",
+        "FeatureCollectionLayerQuery.h"
+    ],
+    "title": "Feature collection layer (query)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates the differences between static and dynamic rendering mode for a FeatureLayer in a Map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "MapView",
+        "Map",
+        "Viewpoint"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerrenderingmodemap.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "MapView",
+        "Map",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "FeatureLayerRenderingModeMap.h",
+        "FeatureLayerRenderingModeMap.cpp",
+        "FeatureLayerRenderingModeMap.qml"
+    ],
+    "title": "Feature layer rendering mode (map)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates the differences between static and dynamic rendering mode for a FeatureLayer in a 3D Scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "SceneView",
+        "Scene",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerrenderingmodescene.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "SceneView",
+        "Scene",
+        "Camera"
+    ],
+    "snippets": [
+        "FeatureLayerRenderingModeScene.qml",
+        "FeatureLayerRenderingModeScene.h",
+        "FeatureLayerRenderingModeScene.cpp"
+    ],
+    "title": "Feature layer rendering mode (scene)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to open a shapefile stored on the device and display it as a feature layer with default symbology",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "shapefile",
+        "shape file",
+        "feature layer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayershapefile.htm",
+    "relevant_apis": [
+        "ShapefileFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "FeatureLayerShapefile.qml",
+        "FeatureLayerShapefile.h",
+        "FeatureLayerShapefile.cpp"
+    ],
+    "title": "Feature layer (shapefile)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create a new feature collection with several feature collection tables",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "feature collection",
+        "feature collection layer",
+        "feature collection table"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-feature-collection-layer.htm",
+    "relevant_apis": [
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Field",
+        "Feature",
+        "SimpleRenderer",
+        "SimpleMarkerSymbol",
+        "SimpleLineSymbol",
+        "SimpleFillSymbol"
+    ],
+    "snippets": [
+        "Feature_Collection_Layer.qml",
+        "Feature_Collection_Layer.cpp",
+        "Feature_Collection_Layer.h"
+    ],
+    "title": "Feature collection layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Layers",
+    "description": "Group a collection of layers together and toggle their visibility as a group.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GroupLayer",
+        "Layers",
+        "group layer",
+        "LayerListModel"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "GroupLayer"
+    ],
+    "snippets": [
+        "GroupLayers.cpp",
+        "GroupLayers.h",
+        "GroupLayers.qml"
+    ],
+    "title": "Group layers"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Layers",
+    "description": "This sample shows how to apply a HillshadeRenderer to a RasterLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "hillshade",
+        "shaded relief",
+        "lighting angle"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-hillshade-renderer.htm",
+    "relevant_apis": [
+        "HillshadeRenderer",
+        "RasterLayer",
+        "Raster",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "HillshadeSettings.qml",
+        "HillshadeSlopeTypeModel.qml",
+        "Hillshade_Renderer.cpp",
+        "Hillshade_Renderer.h",
+        "Hillshade_Renderer.qml"
+    ],
+    "title": "Hillshade renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Layers",
+    "description": "Load a WFS feature table using an XML query.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "WfsFeatureTable"
+        "WfsFeatureTable::populateFromService",
+        "OGC",
+        "WFS",
+        "feature",
+        "web",
+        "service",
+        "XML",
+        "query"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "FeatureLayer",
+        "WfsFeatureTable"
+        "WfsFeatureTable::populateFromService"
+    ],
+    "snippets": [
+        "LoadWfsXmlQuery.cpp",
+        "LoadWfsXmlQuery.h",
+        "LoadWfsXmlQuery.qml"
+    ],
+    "title": "Load WFS with XML query"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "Add, remove, and reorder operational layers in a map.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "ArcGISMap",
+        "ArcGISMapImageLayer",
+        "LayerListModel",
+        "LayerListModel::append",
+        "LayerListModel::move",
+        "LayerListModel::removeAt"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "ArcGISMap",
+        "ArcGISMapImageLayer",
+        "LayerListModel",
+        "LayerListModel::append",
+        "LayerListModel::move",
+        "LayerListModel::removeAt"
+    ],
+    "snippets": [
+        "ManageOperationalLayers.qml"
+    ],
+    "title": "Manage operational layers"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to add the OpenStreetMap layer to a map as a Basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "OSM",
+        "OpenStreetMap"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-osm-layer.htm",
+    "relevant_apis": [
+        "OpenStreetMapLayer",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "OSM_Layer.h",
+        "OSM_Layer.cpp",
+        "OSM_Layer.qml"
+    ],
+    "title": "OpenStreetMap layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to execute an attribute and spatial query on the sublayers of an ArcGIS map image layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "query sublayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-querymapimagesublayer.htm",
+    "relevant_apis": [
+        "ServiceFeatureTable",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageLayer::loadTablesAndLayers",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageSublayer::table",
+        "QueryParameters"
+    ],
+    "snippets": [
+        "QueryMapImageSublayer.qml",
+        "QueryMapImageSublayer.h",
+        "QueryMapImageSublayer.cpp"
+    ],
+    "title": "Query map image sublayer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Layers",
+    "description": "Demonstrates how to use a colormap renderer on raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "colormap renderer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rastercolormaprenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "Basemap",
+        "ColormapRenderer",
+        "MapQuickView",
+        "Raster",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterColormapRenderer.cpp",
+        "RasterColormapRenderer.qml",
+        "RasterColormapRenderer.h"
+    ],
+    "title": "Colormap renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to apply a RasterFunction to a local Raster file and display the output with a RasterLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "RasterFunction",
+        "RasterLayer",
+        "Raster",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterfunctionfile.htm",
+    "relevant_apis": [
+        "RasterFunction",
+        "RasterLayer",
+        "Raster",
+        "Map"
+    ],
+    "snippets": [
+        "RasterFunctionFile.qml",
+        "RasterFunctionFile.h",
+        "RasterFunctionFile.cpp"
+    ],
+    "title": "Raster function (file)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ImageServiceRaster and apply a RasterFunction to it",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterFunction",
+        "RasterFunctionArguments",
+        "RasterLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterfunctionservice.htm",
+    "relevant_apis": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterFunction",
+        "RasterFunctionArguments",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterFunctionService.h",
+        "RasterFunctionService.cpp",
+        "RasterFunctionService.qml"
+    ],
+    "title": "Raster function (service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "Demonstrates how to create and use a raster layer made from a local raster file",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Raster",
+        "RasterLayer",
+        "Basemap",
+        "Map",
+        "MapQuickView"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterlayerfile.htm",
+    "relevant_apis": [
+        "Raster",
+        "RasterLayer",
+        "Basemap",
+        "Map",
+        "MapQuickView"
+    ],
+    "snippets": [
+        "RasterLayerFile.cpp",
+        "RasterLoader.qml",
+        "main.qml",
+        "RasterLayerFile.qml",
+        "RasterLayerFile.h"
+    ],
+    "title": "Raster layer (file)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to open a GeoPackage, obtain a raster from the package, and display the table as a RasterLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GeoPackage",
+        "GeoPackageRaster",
+        "RasterLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterlayergeopackage.htm",
+    "relevant_apis": [
+        "GeoPackage",
+        "GeoPackageRaster",
+        "RasterLayer",
+        "Map"
+    ],
+    "snippets": [
+        "RasterLayerGeoPackage.qml",
+        "RasterLayerGeoPackage.cpp",
+        "RasterLayerGeoPackage.h"
+    ],
+    "title": "Raster layer (GeoPackage)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ImageServiceRaster and add it to a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterlayerservice.htm",
+    "relevant_apis": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterLayerService.cpp",
+        "RasterLayerService.h",
+        "RasterLayerService.qml"
+    ],
+    "title": "Raster layer (service)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ImageServiceRaster, fetch the RenderingRules from the service info, and use a RenderingRule to create an ImageServiceRaster and add it to a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "raster rendering rule"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterrenderingrule.htm",
+    "relevant_apis": [
+        "Map",
+        "ImageServiceRaster",
+        "RenderingRuleInfo",
+        "RenderingRule",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterRenderingRule.qml",
+        "RasterRenderingRule.h",
+        "RasterRenderingRule.cpp"
+    ],
+    "title": "Raster rendering rule"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use an RGB renderer with a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "RGB renderer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterrgbrenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Raster",
+        "RasterLayer",
+        "RGBRenderer"
+    ],
+    "snippets": [
+        "RasterRgbRenderer.qml",
+        "RasterRgbRenderer.h",
+        "RasterRgbRenderer.cpp"
+    ],
+    "title": "RGB renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use stretch renderer on a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "stretch renderer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-rasterstretchrenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Raster",
+        "RasterLayer",
+        "StretchRenderer"
+    ],
+    "snippets": [
+        "RasterStretchRenderer.h",
+        "RasterStretchRenderer.cpp",
+        "RasterStretchRenderer.qml",
+        "InputWithLabel.qml"
+    ],
+    "title": "Stretch renderer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to dynamically change the style of a sublayer in a WMS layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WMS style",
+        "change style"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-stylewmslayer.htm",
+    "relevant_apis": [
+        "WmsLayer",
+        "WmsSublayer",
+        "WmsLayerInfo",
+        "WmsSublayer::currentStyle"
+    ],
+    "snippets": [
+        "StyleWmsLayer.qml",
+        "StyleWmsLayer.cpp",
+        "StyleWmsLayer.h"
+    ],
+    "title": "Style WMS layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use a vector tiled layer from an ArcGIS Online service as a basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "vector tiled layer",
+        "vector tile layer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-vectortilelayerurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISVectorTiledLayer"
+    ],
+    "snippets": [
+        "VectorTiledLayerUrl.qml",
+        "VectorTiledLayerUrl.cpp",
+        "VectorTiledLayerUrl.h"
+    ],
+    "title": "Vector tiled layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to load a Web Map Tile Service (WMTS) and display it as a layer in a Map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "web map tile service"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-wmts-layer.htm",
+    "relevant_apis": [
+        "WmtsLayer",
+        "WmtsLayerInfo",
+        "WmtsService",
+        "WmtsServiceInfo",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "WMTS_Layer.qml",
+        "WMTS_Layer.h",
+        "WMTS_Layer.cpp"
+    ],
+    "title": "WMTS layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display map tiles from an online resource using the WebTiledLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "web tiled layer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-web-tiled-layer.htm",
+    "relevant_apis": [
+        "WebTiledLayer",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "Web_Tiled_Layer.cpp",
+        "Web_Tiled_Layer.qml",
+        "Web_Tiled_Layer.h"
+    ],
+    "title": "Web tiled layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a WMS Layer from an online URL",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WmsLayer",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-wmslayerurl.htm",
+    "relevant_apis": [
+        "WmsLayer",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "WmsLayerUrl.cpp",
+        "WmsLayerUrl.h",
+        "WmsLayerUrl.qml"
+    ],
+    "title": "WMS layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceRaster/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Local Server",
+    "description": "This sample demonstrates how to dynamically add a local raster file to a map using the Local Server",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Offline",
+      "Disconnected",
+      "LocalServer",
+      "Image",
+        "DynamicWorkspace",
+        "LocalMapService",
+        "RasterWorkspace",
+        "RasterSublayerSource",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-dynamicworkspaceraster.htm",
+    "relevant_apis": [
+        "LocalServer",
+        "DynamicWorkspace",
+        "LocalMapService",
+        "RasterWorkspace",
+        "RasterSublayerSource",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+  "snippets": [
+    "DynamicWorkspaceRaster.h",
+    "DynamicWorkspaceRaster.qml",
+    "DynamicWorkspaceRaster.cpp",
+    "main.qml"
+  ],
+    "title": "Dynamic workspace raster"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/DynamicWorkspaceShapefile/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Local Server",
+    "description": "This sample demonstrates how to dynamically add a shapefile to a map using the Local Server",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Offline",
+      "FeatureTable",
+      "LocalServer",
+        "DynamicWorkspace",
+        "LocalMapService",
+        "TableSublayerSource",
+        "ShapefileWorkspace",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-dynamicworkspaceshapefile.htm",
+    "relevant_apis": [
+        "LocalServer",
+        "DynamicWorkspace",
+        "LocalMapService",
+        "TableSublayerSource",
+        "ShapefileWorkspace",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "snippets": [
+        "DynamicWorkspaceShapefile.h",
+        "DynamicWorkspaceShapefile.qml",
+        "main.qml",
+        "DynamicWorkspaceShapefile.cpp"
+    ],
+    "title": "Dynamic workspace shapefile"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Local Server",
+    "description": "Demonstrates how to start the Local Server and local feature service, create a feature layer from the local feature service, and add it to a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Offline",
+      "FeatureLayer",
+        "LocalFeatureService",
+        "LocalServer",
+        "LocalServerStatus"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-localserverfeaturelayer.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "LocalFeatureService",
+        "LocalServer",
+        "LocalServerStatus"
+    ],
+    "snippets": [
+        "LocalServerFeatureLayer.h",
+        "LocalServerFeatureLayer.cpp",
+        "LocalServerFeatureLayer.qml"
+    ],
+    "title": "Local Server feature layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.metadata.json
@@ -1,0 +1,39 @@
+{
+  "category": "Local Server",
+  "description": "Demonstrates how to create contour lines from local raster data using a local geoprocessing package (.gpk) and the contour geoprocessing tool",
+  "ignore": false,
+  "images": [
+    "screenshot.png"
+  ],
+  "keywords": [
+    "Offline",
+    "Analysis",
+    "GeoprocessingDouble",
+    "GeoprocessingJob",
+    "GeoprocessingParameter",
+    "GeoprocessingParameters",
+    "GeoprocessingTask",
+    "LocalGeoprocessingService",
+    "LocalGeoprocessingService.ServiceType",
+    "LocalServer",
+    "LocalServerStatus"
+  ],
+  "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-localservergeoprocessing.htm",
+  "relevant_apis": [
+    "GeoprocessingDouble",
+    "GeoprocessingJob",
+    "GeoprocessingParameter",
+    "GeoprocessingParameters",
+    "GeoprocessingTask",
+    "LocalGeoprocessingService",
+    "LocalGeoprocessingService.ServiceType",
+    "LocalServer",
+    "LocalServerStatus"
+  ],
+  "snippets": [
+    "LocalServerGeoprocessing.qml",
+    "LocalServerGeoprocessing.h",
+    "LocalServerGeoprocessing.cpp"
+  ],
+  "title": "Local Server geoprocessing"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Local Server",
+    "description": "Demonstrates how to start the Local Server and Local Map Service, create an ArcGIS Map Image Layer from the Local Map Service, and add it to a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Offline",
+        "ArcGISMapImageLayer",
+        "LocalMapService",
+        "LocalServer",
+        "LocalServerStatus"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-localservermapimagelayer.htm",
+    "relevant_apis": [
+        "ArcGISMapImageLayer",
+        "LocalMapService",
+        "LocalServer",
+        "LocalServerStatus"
+    ],
+    "snippets": [
+        "LocalServerMapImageLayer.qml",
+        "LocalServerMapImageLayer.cpp",
+        "LocalServerMapImageLayer.h"
+    ],
+    "title": "Local Server map image layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Local Server",
+    "description": "Demonstrates how to start and stop the Local Server and start and stop a local map, feature, and geoprocessing service running on the Local Server",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "LocalFeatureService",
+        "LocalGeoprocessingService",
+        "LocalMapService",
+        "LocalServer",
+        "LocalServerStatus",
+        "LocalService"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-localserverservices.htm",
+    "relevant_apis": [
+        "LocalFeatureService",
+        "LocalGeoprocessingService",
+        "LocalMapService",
+        "LocalServer",
+        "LocalServerStatus",
+        "LocalService"
+    ],
+    "snippets": [
+        "LocalServerServices.qml",
+        "main.qml",
+        "LocalServerServices.cpp",
+        "LocalServerServices.h"
+    ],
+    "title": "Local server services"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to change a map's basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-changebasemap.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "ChangeBasemap.h",
+        "ChangeBasemap.qml",
+        "ChangeBasemap.cpp"
+    ],
+    "title": "Change basemap"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to change the viewpoint of a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Area of Interest",
+        "Extent",
+      "Viewpoint",
+        "Map",
+        "Envelope"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-changeviewpoint.htm",
+    "relevant_apis": [
+        "Viewpoint",
+        "Map",
+        "Envelope"
+    ],
+    "snippets": [
+        "ChangeViewpoint.cpp",
+        "ChangeViewpoint.qml",
+        "ChangeViewpoint.h"
+    ],
+    "title": "Change viewpoint"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to author a Map in ArcGIS Runtime and save it to ArcGIS Online as a web map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WebMap",
+        "Create Map",
+        "Map",
+        "Portal",
+        "Map::saveAs()"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-createandsavemap.htm",
+    "relevant_apis": [
+        "Map",
+        "Portal",
+        "Map::saveAs()"
+    ],
+    "snippets": [
+        "SaveOptionsWindow.qml",
+        "CreateAndSaveMap.qml",
+        "LayerWindow.qml",
+        "CreateAndSaveMap.h",
+        "CreateAndSaveMap.cpp"
+    ],
+    "title": "Create and save map"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Maps",
+  "description": "This sample demonstrates how you can enable Location Display to display your current position on the map, as well as switch between different types of AutoPan Modes",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "GPS",
+      "Navigate",
+      "Route",
+      "MapView",
+        "Map",
+        "LocationDisplay"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaydevicelocation.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "LocationDisplay"
+    ],
+    "snippets": [
+        "DisplayDeviceLocation.qml",
+        "DisplayDeviceLocation.h",
+        "DisplayDeviceLocation.cpp"
+    ],
+    "title": "Display device location"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to use the DrawStatus value of the MapView to notify the user that the MapView is drawing",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Status",
+      "MapView",
+        "Map",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "Viewpoint",
+        "Envelope"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaydrawingstatus.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "Viewpoint",
+        "Envelope"
+    ],
+    "snippets": [
+        "DisplayDrawingStatus.h",
+        "DisplayDrawingStatus.qml",
+        "DisplayDrawingStatus.cpp"
+    ],
+    "title": "Display drawing status"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/README.metadata.json
@@ -1,0 +1,41 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to get the view state of a Layer in a Map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Status",
+      "Load",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISTiledLayer",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "LayerViewState",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaylayerviewdrawstate.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISTiledLayer",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "LayerViewState",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "DisplayLayerViewDrawState.qml",
+        "DisplayLayerViewDrawState.cpp",
+        "DisplayLayerViewDrawState.h"
+    ],
+    "title": "Display layer view draw state"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to display a map view with a basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displaymap.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "DisplayMap.cpp",
+        "DisplayMap.qml",
+        "DisplayMap.h"
+    ],
+    "title": "Display a map"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/README.metadata.json
@@ -1,0 +1,47 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to take a web map offline",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Offline",
+      "Disconnected",
+      "Map",
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "MapView",
+        "EnveloperBuilder",
+        "AuthenticationView",
+        "AuthenticationManager",
+        "PortalItem",
+        "Portal",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-generateofflinemap.htm",
+    "relevant_apis": [
+        "Map",
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "MapView",
+        "EnveloperBuilder",
+        "AuthenticationView",
+        "AuthenticationManager",
+        "PortalItem",
+        "Portal",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "GenerateOfflineMap.qml",
+        "GenerateOfflineMap.h",
+        "DownloadButton.qml",
+        "GenerateWindow.qml",
+        "GenerateOfflineMap.cpp"
+    ],
+    "title": "Generate offline map"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Maps",
+    "description": "Use the `OfflineMapTask` to take a web map offline, but instead of downloading an online basemap, use one which is already on the device.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "Offline"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult"
+    ],
+    "snippets": [
+        "GenerateOfflineMapLocalBasemap.cpp",
+        "GenerateOfflineMapLocalBasemap.qml",
+        "GenerateOfflineMapLocalBasemap.h",
+        "DownloadButton.qml",
+        "GenerateWindow.qml"
+    ],
+    "title": "Generate offline map with local basemap"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.metadata.json
@@ -1,0 +1,37 @@
+{
+  "category": "Maps",
+  "description": "You can use the OfflineMapTask to take a webmap offline. Overrides allow you to adjust the settings used for taking each layer in the map offline",
+  "ignore": false,
+  "images": [
+    "screenshot.png"
+  ],
+  "keywords": [
+    "Offline",
+    "OfflineMapTask",
+    "GenerateGeodatabaseParameters",
+    "GenerateOfflineMapParameters",
+    "GenerateOfflineMapParameterOverrides",
+    "GenerateOfflineMapJob",
+    "GenerateOfflineMapResult",
+    "ExportTileCacheParameters"
+  ],
+  "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-generateofflinemapoverrides.htm",
+  "relevant_apis": [
+    "OfflineMapTask",
+    "GenerateGeodatabaseParameters",
+    "GenerateOfflineMapParameters",
+    "GenerateOfflineMapParameterOverrides",
+    "GenerateOfflineMapJob",
+    "GenerateOfflineMapResult",
+    "ExportTileCacheParameters"
+  ],
+  "snippets": [
+    "OverridesWindow.qml",
+    "GenerateOfflineMap_Overrides.cpp",
+    "DownloadButton.qml",
+    "GenerateWindow.qml",
+    "GenerateOfflineMap_Overrides.h",
+    "GenerateOfflineMap_Overrides.qml"
+  ],
+  "title": "Generate Offline Map (Overrides)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to identify features on a map across the different layers in the map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Find",
+      "Search",
+      "Attribute",
+        "MapView",
+        "IdentifyLayerResult",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageSublayer",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-identifylayers.htm",
+    "relevant_apis": [
+        "MapView",
+        "IdentifyLayerResult",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageSublayer",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "IdentifyLayers.cpp",
+        "IdentifyLayers.h",
+        "IdentifyLayers.qml"
+    ],
+    "title": "Identify layers"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to access and add bookmarks to a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Area of Interest",
+      "Extent",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "Bookmark",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-managebookmarks.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "Bookmark",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "ManageBookmarks.cpp",
+        "ManageBookmarks.h",
+        "ManageBookmarks.qml"
+    ],
+    "title": "Manage bookmarks"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to determine the map's load status",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "State",
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-maploaded.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "MapLoaded.qml",
+        "MapLoaded.cpp",
+        "MapLoaded.h"
+    ],
+    "title": "Map loaded"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Maps",
+    "description": "Set the map's reference scale and which feature layers should honor the reference scale.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "Map",
+        "Maps & Scenes"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "FeatureLayer",
+        "Map"        
+    ],
+    "snippets": [
+        "MapReferenceScale.qml",
+        "MapReferenceScale.h",
+        "MapReferenceScale.cpp"
+    ],
+    "title": "Map reference scale"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to rotate a map view",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Rotation",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Point",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-maprotation.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "MapRotation.h",
+        "MapRotation.cpp",
+        "MapRotation.qml"
+    ],
+    "title": "Map rotation"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to set the minimum and maximum scale of a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Extent",
+      "Maps",
+        "2D",
+        "scale",
+        "setMinScale",
+        "setMaxScale",
+        "zoom",
+        "Map::setMinScale",
+        "Map::setMaxScale"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-minmaxscale.htm",
+    "relevant_apis": [
+        "Map::setMinScale",
+        "Map::setMaxScale"
+    ],
+    "snippets": [
+        "MinMaxScale.qml",
+        "MinMaxScale.h",
+        "MinMaxScale.cpp"
+    ],
+    "title": "Min-Max scale"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/README.metadata.json
@@ -1,0 +1,53 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to geocode and route using data in a map package",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Navigate",
+        "Offline",
+        "MobileMapPackage",
+        "RouteTask",
+        "RouteParameters",
+        "RouteResult",
+        "Stop",
+        "LocatorTask",
+        "GeocodeResult",
+        "ReverseGeocodeParameters",
+        "Graphic",
+        "GraphicsOverlay",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "TextSymbol",
+        "SimpleRenderer",
+        "Callout"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-mobilemap-searchandroute.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "MobileMapPackage",
+        "RouteTask",
+        "RouteParameters",
+        "RouteResult",
+        "Stop",
+        "LocatorTask",
+        "GeocodeResult",
+        "ReverseGeocodeParameters",
+        "Graphic",
+        "GraphicsOverlay",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "TextSymbol",
+        "SimpleRenderer",
+        "Callout"
+    ],
+    "snippets": [
+        "MobileMap_SearchAndRoute.cpp",
+        "MobileMap_SearchAndRoute.qml",
+        "MobileMap_SearchAndRoute.h"
+    ],
+    "title": "Mobile map (search and route)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to open an existing map from a URL",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-openmapurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "OpenMapUrl.cpp",
+        "OpenMapUrl.h",
+        "OpenMapUrl.qml"
+    ],
+    "title": "Open Map (URL)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to open and display a map from a Mobile Map Package",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Offline",
+      "Disconnected",
+        "MapView",
+        "MobileMapPackage"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-openmobilemap-mappackage.htm",
+    "relevant_apis": [
+        "MapView",
+        "MobileMapPackage"
+    ],
+    "snippets": [
+        "OpenMobileMap_MapPackage.qml",
+        "OpenMobileMap_MapPackage.cpp",
+        "OpenMobileMap_MapPackage.h"
+    ],
+    "title": "Open mobile map (map package)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to read rasters and feature tables from GeoPackages to show them as layers in a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Offline",
+      "OGC",
+      "GeoPackage",
+        "Map",
+        "Esri::ArcGISRuntime::GeoPackage"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-readgeopackage.htm",
+    "relevant_apis": [
+        "Esri::ArcGISRuntime::GeoPackage"
+    ],
+    "snippets": [
+        "ReadGeoPackage.h",
+        "ReadGeoPackage.cpp",
+        "ReadGeoPackage.qml"
+    ],
+    "title": "Read GeoPackage"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to create a map with a predefined initial extent",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Viewpoint",
+        "Area of Interest",
+        "Basemap",
+        "Viewpoint",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-setinitialmaparea.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "SetInitialMapArea.qml",
+        "SetInitialMapArea.cpp",
+        "SetInitialMapArea.h"
+    ],
+    "title": "Set initial map area"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to create a map with a basemap, centered at a specific location and scale",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Viewpoint",
+      "Area of Interest",
+      "Extent"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-setinitialmaplocation.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map"
+    ],
+    "snippets": [
+        "SetInitialMapLocation.qml",
+        "SetInitialMapLocation.cpp",
+        "SetInitialMapLocation.h"
+    ],
+    "title": "Set initial map location"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to set the initial spatial reference of a map so that all layers that support reprojection are projected into the map's spatial reference",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Projection",
+      "Geographic",
+      "Coordinate System",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-setmapspatialreference.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "SetMapSpatialReference.qml",
+        "SetMapSpatialReference.h",
+        "SetMapSpatialReference.cpp"
+    ],
+    "title": "Set map spatial reference"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how you can tap and hold on a map to get the magnifier",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Magnify",
+      "Display",
+      "Zoom"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-showmagnifier.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "ShowMagnifier.cpp",
+        "ShowMagnifier.h",
+        "ShowMagnifier.qml"
+    ],
+    "title": "Show magnifier"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to take a screenshot of the MapView",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Screenshot",
+        "Screen capture",
+        "Export",
+        "GeoView::exportImage"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-takescreenshot.htm",
+    "relevant_apis": [
+        "GeoView::exportImage"
+    ],
+    "snippets": [
+        "TakeScreenshot.cpp",
+        "TakeScreenshot.h",
+        "TakeScreenshot.qml",
+        "MapImageProvider.cpp",
+        "MapImageProvider.h"
+    ],
+    "title": "Take screenshot"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Routing",
+    "description": "This sample demonstrates how to solve a Closest Facility Task to find the closest route between a facility (hospital) and an incident (black cross)",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Network Analysis",
+      "Service Area",
+        "ClosestFacilityTask",
+        "ClosestFacilityParameters",
+        "ClosestFacilityResult",
+        "Facility",
+        "Incident"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-closestfacility.htm",
+    "relevant_apis": [
+        "ClosestFacilityTask",
+        "ClosestFacilityParameters",
+        "ClosestFacilityResult",
+        "Facility",
+        "Incident"
+    ],
+    "snippets": [
+        "ClosestFacility.h",
+        "ClosestFacility.qml",
+        "ClosestFacility.cpp"
+    ],
+    "title": "Closest facility"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Routing",
+    "description": "This sample demonstrates how to get a route between two locations",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Network Analysis",
+      "Navigation",
+      "Travel",
+      "Directions",
+        "RouteTask",
+        "RouteParameters",
+        "Stop",
+        "RouteResult",
+        "DirectionManeuverListModel"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-findroute.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "SimpleRenderer",
+        "RouteTask",
+        "RouteParameters",
+        "Stop",
+        "RouteResult",
+        "DirectionManeuverListModel"
+    ],
+    "snippets": [
+        "FindRoute.qml",
+        "FindRoute.h",
+        "FindRoute.cpp"
+    ],
+    "title": "Find route"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Routing",
+    "description": "Demonstrates how to find services areas around a point using the ServiceAreaTask",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+      "Network Analysis",
+      "Service Area",
+      "Closest Facility",
+        "PolylineBarrier",
+        "ServiceAreaFacility",
+        "ServiceAreaParameters",
+        "ServiceAreaPolygon",
+        "ServiceAreaResult",
+        "ServiceAreaTask"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-servicearea.htm",
+    "relevant_apis": [
+        "Map",
+        "GraphicsOverlay",
+        "MapView",
+        "PolylineBarrier",
+        "ServiceAreaFacility",
+        "ServiceAreaParameters",
+        "ServiceAreaPolygon",
+        "ServiceAreaResult",
+        "ServiceAreaTask",
+        "PolylineBuilder"
+    ],
+    "snippets": [
+        "ServiceArea.h",
+        "ServiceArea.cpp",
+        "ServiceArea.qml"
+    ],
+    "title": "Service area"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "View a point scene layer from a scene service.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "ArcGISSceneLayer",
+        "3D",
+        "point",
+        "scene layer",
+        "layers"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "ArcGISSceneLayer"
+    ],
+    "snippets": [
+        "AddAPointSceneLayer.h",
+        "AddAPointSceneLayer.cpp",
+        "AddAPointSceneLayer.qml"
+    ],
+    "title": "Add a point scene layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Scenes",
+    "description": "View an integrated mesh layer from a scene service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "integrated mesh",
+        "layer"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-addintegratedmeshlayer.htm",
+    "relevant_apis": [
+        "IntegratedMeshLayer"
+    ],
+    "snippets": [
+        "AddIntegratedMeshLayer.cpp",
+        "AddIntegratedMeshLayer.h",
+        "main.qml",
+        "AddIntegratedMeshLayer.qml"
+    ],
+    "title": "Add an integrated mesh layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Scenes",
+    "description": "Demonstrates how to animate a graphic's position and rotation and follow it using a OrbitGeoElementCameraController",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "animation",
+        "camera controller",
+        "model scene symbol"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-animate3dsymbols.htm",
+    "relevant_apis": [
+        "Map",
+        "Scene",
+        "Camera",
+        "GlobeCameraController",
+        "Graphic",
+        "GraphicsOverlay",
+        "SurfacePlacement",
+        "MapView",
+        "ModelSceneSymbol",
+        "OrbitGeoElementCameraController",
+        "Point",
+        "Polyline",
+        "Renderer",
+        "SceneProperties",
+        "SceneView",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "MissionData.h",
+        "Animate3DSymbols.cpp",
+        "Animate3DSymbols.h",
+        "main.qml",
+        "Animate3DSymbols.qml",
+        "LabeledSlider.qml",
+        "MissionData.cpp"
+    ],
+    "title": "Animate 3D symbols"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to display a scene with an elevation surface",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-basicsceneviewurl.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface"
+    ],
+    "snippets": [
+        "BasicSceneView.h",
+        "BasicSceneView.qml",
+        "BasicSceneView.cpp"
+    ],
+    "title": "Display a scene"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "Changes the appearance of the atmosphere in a scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "atmosphere",
+        "scene",
+        "atmosphere effect"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-change-atmosphere-effect.htm",
+    "relevant_apis": [
+        "Scene",
+        "AtmosphereEffect",
+        "SceneQuickView"
+    ],
+    "snippets": [
+        "ChangeAtmosphereEffect.qml",
+        "main.qml",
+        "ChangeAtmosphereEffect.h",
+        "ChangeAtmosphereEffect.cpp"
+    ],
+    "title": "Change atmosphere effect"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Scenes",
+    "description": "Control the behavior of the camera in a scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "camera controller",
+        "camera",
+        "3D"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-choosecameracontroller.htm",
+    "relevant_apis": [
+        "ArcGISScene",
+        "Camera",
+        "GlobeCameraController",
+        "OrbitGeoElementCameraController",
+        "OrbitLocationCameraController",
+        "SceneView"
+    ],
+    "snippets": [
+        "ChooseCameraController.cpp",
+        "main.qml",
+        "ChooseCameraController.qml",
+        "ChooseCameraController.h"
+    ],
+    "title": "Choose camera controller"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "Use a terrain surface with elevation described by a raster file",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "Raster",
+        "elevation surface"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-createterrainsurfacefromlocalraster.htm",
+    "relevant_apis": [
+        "RasterElevationSource",
+        "Surface"
+    ],
+    "snippets": [
+        "CreateTerrainSurfaceFromLocalRaster.cpp",
+        "main.qml",
+        "CreateTerrainSurfaceFromLocalRaster.qml",
+        "CreateTerrainSurfaceFromLocalRaster.h"
+    ],
+    "title": "Create terrain surface from a local raster"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "Set the terrain surface with elevation described by a local tile package",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "tile cache",
+        "elevation surface"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-createterrainsurfacefromlocaltilepackage.htm",
+    "relevant_apis": [
+        "ArcGISTiledElevationSource", 
+        "Surface"
+    ],
+    "snippets": [
+        "CreateTerrainSurfaceFromLocalTilePackage.h",
+        "CreateTerrainSurfaceFromLocalTilePackage.cpp",
+        "main.qml",
+        "CreateTerrainSurfaceFromLocalTilePackage.qml"
+    ],
+    "title": "Create terrain surface from a local tile package"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to display a scene service with a scene layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface",
+        "ArcGISSceneLayer",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-displayscenelayer.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface",
+        "ArcGISSceneLayer",
+        "Camera"
+    ],
+    "snippets": [
+        "DisplaySceneLayer.cpp",
+        "DisplaySceneLayer.h",
+        "DisplaySceneLayer.qml"
+    ],
+    "title": "Display a scene layer"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to create a graphic using a distance composite scene symbol",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "distance"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-distancecompositesymbolurl.htm",
+    "relevant_apis": [
+        "Scene",
+        "ArcGISTiledElevationSource",
+        "Camera",
+        "DistanceCompositeSceneSymbol",
+        "DistanceCompositeSceneSymbol.Range",
+        "Graphic",
+        "GraphicsOverlay",
+        "ModelSceneSymbol",
+        "Range",
+        "RangeCollection",
+        "SceneView",
+        "SimpleMarkerSceneSymbol"
+    ],
+    "snippets": [
+        "DistanceCompositeSymbol.qml",
+        "DistanceCompositeSymbol.cpp",
+        "DistanceCompositeSymbol.h"
+    ],
+    "title": "Distance composite symbol"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to render graphics extruded in the Z direction",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "extrusion",
+        "z direction",
+        "ArcGISScene",
+        "Graphic",
+        "GraphicsOverlay",
+        "Renderer",
+        "Renderer->SceneProperties"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-extrudegraphics.htm",
+    "relevant_apis": [
+        "ArcGISScene",
+        "Graphic",
+        "GraphicsOverlay",
+        "Renderer",
+        "Renderer->SceneProperties"
+    ],
+    "snippets": [
+        "ExtrudeGraphics.qml",
+        "ExtrudeGraphics.cpp",
+        "ExtrudeGraphics.h"
+    ],
+    "title": "Extrude graphics"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to apply extrusion to a renderer on a feature layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "vertically extrude", 
+        "renderer",
+        "3D"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-featurelayerextrusion.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "ExtrusionMode",
+        "Renderer",
+        "SceneProperties"
+    ],
+    "snippets": [
+        "FeatureLayerExtrusion.qml",
+        "FeatureLayerExtrusion.h",
+        "FeatureLayerExtrusion.cpp"
+    ],
+    "title": "Feature layer extrusion"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "Get the elevation for a given point on a surface",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "detect elevation"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-getelevationatpoint.htm",
+    "relevant_apis": [
+        "ArcGISTiledElevationSource",
+        "BaseSurface",
+        "ElevationSourceListModel",
+        "SceneView"
+    ],
+    "snippets": [
+        "GetElevationAtPoint.qml",
+        "main.qml",
+        "GetElevationAtPoint.cpp",
+        "GetElevationAtPoint.h"
+    ],
+    "title": "Get elevation at point"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "Opens and displays a scene from a Mobile Scene Package (specifically, basemaps and features) used to display an offline 3D scene.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "offline",
+        "3D",
+        "mobile scene package",
+        "mspk"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-openmobilescenepackage.htm",
+    "relevant_apis": [
+        "MobileScenePackage",
+        "Scene",
+        "SceneView"
+    ],
+    "snippets": [
+        "OpenMobileScenePackage.cpp",
+        "OpenMobileScenePackage.h",
+        "main.qml",
+        "OpenMobileScenePackage.qml"
+    ],
+    "title": "Open mobile scene package"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to open a scene from a Portal item",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "web scene",
+        "portal",
+        "portal item"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-openscene.htm",
+    "relevant_apis": [
+        "Scene",
+        "PortalItem"
+    ],
+    "snippets": [
+        "OpenScene.qml",
+        "OpenScene.cpp",
+        "OpenScene.h"
+    ],
+    "title": "Open a scene (portal item)"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Scenes",
+    "description": "Fix the camera to point at and rotate around a target object.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "OrbitGeoElementCameraController",
+        "Camera",
+        "SceneView",
+        "3D"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "OrbitGeoElementCameraController"
+    ],
+    "snippets": [
+        "OrbitCameraAroundObject.h",
+        "OrbitCameraAroundObject.cpp",
+        "OrbitCameraAroundObject.qml"
+    ],
+    "title": "Orbit the camera around an object"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to identify and select GeoElements in an ArcGISSceneLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geoelement",
+        "identify"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-scenelayerselection.htm",
+    "relevant_apis": [
+        "ArcGISSceneLayer",
+        "ArcGISSceneLayer::selectFeature",
+        "SceneView::identifyLayer",
+        "IdentifyLayerResult"
+    ],
+    "snippets": [
+        "SceneLayerSelection.qml",
+        "SceneLayerSelection.h",
+        "SceneLayerSelection.cpp"
+    ],
+    "title": "Scene layer selection"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to update the orientation of a graphic using scene property rotation expressions",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "rotation expressions"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-scenepropertiesexpressions.htm",
+    "relevant_apis": [
+        "SimpleRenderer",
+        "GraphicsOverlay",
+        "RendererSceneProperties"
+    ],
+    "snippets": [
+        "ScenePropertiesExpressions.cpp",
+        "ScenePropertiesExpressions.h",
+        "main.qml",
+        "ScenePropertiesExpressions.qml"
+    ],
+    "title": "Scene properties expressions"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to control the surface placement of a 3D graphic",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "vertical placement"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-surfaceplacement.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "Viewpoint",
+        "Camera",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point"
+    ],
+    "snippets": [
+        "Surface_Placement.qml",
+        "Surface_Placement.h",
+        "Surface_Placement.cpp"
+    ],
+    "title": "Surface placement"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to create symbols with different 3D shapes",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "create 3D shapes"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-scenesymbols.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSceneSymbol"
+    ],
+    "snippets": [
+        "Symbols.qml",
+        "Symbols.h",
+        "Symbols.cpp"
+    ],
+    "title": "Scene symbols"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to keep the viewpoints of multiple map or scene views in sync, so that navigating one view immediately updates the other",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sync maps",
+        "multiple views",
+        "synchronization"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-syncmapviewsceneview.htm",
+    "relevant_apis": [
+        "GeoView",
+        "GeoView::viewpointChanged",
+        "GeoView::isNavigating",
+        "GeoView::currentViewpoint",
+        "GeoView::setViewpoint"
+    ],
+    "snippets": [
+        "SyncMapViewSceneView.cpp",
+        "main.qml",
+        "SyncMapViewSceneView.h",
+        "SyncMapViewSceneView.qml"
+    ],
+    "title": "Sync map and scene views"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to exaggerate a scene's terrain surface",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "elevation",
+        "exaggeration"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-terrainexaggeration.htm",
+    "relevant_apis": [
+        "Surface",
+        "Surface::setElevationExaggeration"
+    ],
+    "snippets": [
+        "TerrainExaggeration.h",
+        "TerrainExaggeration.cpp",
+        "TerrainExaggeration.qml"
+    ],
+    "title": "Terrain exaggeration"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "See through terrain in a scene and move the camera underground.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Surface",
+        "Surface.navigationConstraint",
+        "3D",
+        "subsurface",
+        "underground",
+        "utilities"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "Surface",
+        "Surface::navigationConstraint"
+    ],
+    "snippets": [
+        "ViewContentBeneathTerrainSurface.h",
+        "ViewContentBeneathTerrainSurface.cpp",
+        "ViewContentBeneathTerrainSurface.qml"
+    ],
+    "title": "View content beneath terrain surface"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Scenes",
+    "description": "Display local 3D point cloud data",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "point cloud",
+        "lidar"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-viewpointclouddataoffline.htm",
+    "relevant_apis": [
+        "PointCloudLayer"
+    ],
+    "snippets": [
+        "ViewPointCloudDataOffline.cpp",
+        "main.qml",
+        "ViewPointCloudDataOffline.qml",
+        "ViewPointCloudDataOffline.h"
+    ],
+    "title": "View point cloud data offline"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to geocode an address and show it on the map view",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "search for address",
+        "find address",
+        "geocode",
+        "find location"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-findaddress.htm",
+    "relevant_apis": [
+        "LocatorTask",
+        "GeocodeParameters",
+        "GeocodeResult",
+        "GraphicsOverlay",
+        "MapView",
+        "Map"
+    ],
+    "snippets": [
+        "FindAddress.qml",
+        "FindAddress.h",
+        "FindAddress.cpp"
+    ],
+    "title": "Find address"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to use geocode functionality to search for points of interest around a location or within an extent",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "point of interest",
+        "find location"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-findplace.htm",
+    "relevant_apis": [
+        "LocatorTask",
+        "GeocodeParameters",
+        "GeocodeResult",
+        "SuggestListModel",
+        "SuggestParameters",
+        "Callout",
+        "GeometryEngine",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleRenderer",
+        "PictureMarkerSymbol",
+        "LocationDisplay",
+        "IdentifyGraphicsOverlayResult",
+        "MapView",
+        "Map"
+    ],
+    "snippets": [
+        "FindPlace.cpp",
+        "FindPlace.h",
+        "FindPlace.qml",
+        "SearchBox.qml",
+        "SuggestionView.qml",
+        "SearchButton.qml"
+    ],
+    "title": "Find a place"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to geocode and reverse geocode addresses and locations without network connectivity",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "reverse geocode",
+        "offline geocode"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-offlinegeocode.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "Callout",
+        "LocatorTask",
+        "GeocodeResult",
+        "GeocodeParameters",
+        "ReverseGeocodeParameters",
+        "SuggestListModel",
+        "GraphicOverlay",
+        "PictureMarkerSymbol",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "OfflineGeocode.cpp",
+        "OfflineGeocode.qml",
+        "OfflineGeocode.h"
+    ],
+    "title": "Offline geocode"
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to search a DictionarySymbolStyle and return the results in a ListView",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "military symbology",
+        "symbol dictionary"
+    ],
+    "redirect_from": "/qt/latest/cpp/sample-code/sample-qt-searchdictionarysymbolstyle.htm",
+    "relevant_apis": [
+        "DictionarySymbolStyle",
+        "SymbolStyleSearchParameters"
+    ],
+    "snippets": [
+        "SearchDictionarySymbolStyle.h",
+        "SearchDictionarySymbolStyle.cpp",
+        "SearchDictionarySymbolStyle.qml"
+    ],
+    "title": "Search dictionary symbol style"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to execute a geoprocessing task to calculate a hotspot analysis based on the frequency of 911 calls",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geoprocessing",
+        "hotspot analysis",
+        "GeoprocessingTask",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingString",
+        "GeoprocessingResult",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-analyzehotspots.htm",
+    "relevant_apis": [
+        "GeoprocessingTask",
+        "GeoprocessingJob",
+        "GeoprocessingParameters",
+        "GeoprocessingString",
+        "GeoprocessingResult",
+        "ArcGISMapImageLayer",
+        "Map"
+    ],
+    "snippets": [
+        "AnalyzeHotspots.qml"
+    ],
+    "title": "Analyze hotspots"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/README.metadata.json
@@ -1,0 +1,50 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to use GeoprocessingTask to calculate a viewshed using a geoprocessing service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geoprocessing",
+        "viewshed",
+        "visibility",
+        "GeoprocessingTask",
+        "GeoprocessingParameters",
+        "GeoprocessingJob",
+        "GeoprocessingFeatures",
+        "GeoprocessingResult",
+        "FeatureCollectionTable",
+        "GraphicsOverlay",
+        "SimpleRenderer",
+        "Graphic",
+        "SimpleMarkerSymbol",
+        "SimpleFillSymbol",
+        "FeatureIterator",
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-analyzeviewshed.htm",
+    "relevant_apis": [
+        "GeoprocessingTask",
+        "GeoprocessingParameters",
+        "GeoprocessingJob",
+        "GeoprocessingFeatures",
+        "GeoprocessingResult",
+        "FeatureCollectionTable",
+        "GraphicsOverlay",
+        "SimpleRenderer",
+        "Graphic",
+        "SimpleMarkerSymbol",
+        "SimpleFillSymbol",
+        "FeatureIterator",
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "AnalyzeViewshed.qml"
+    ],
+    "title": "Viewshed (geoprocessing)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates measuring 3D distances between two points in a scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "analysis",
+        "3D",
+        "measurement",
+        "AnalysisOverlay",
+        "LocationDistanceMeasurement"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-distancemeasurementanalysis.htm",
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "LocationDistanceMeasurement"
+    ],
+    "snippets": [
+        "DistanceMeasurementAnalysis.qml"
+    ],
+    "title": "Distance measurement analysis"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Analysis",
+    "description": "Show a line of sight between two moving objects",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "line of sight",
+        "visibility",
+        "AnalysisOverlay",
+        "GeoElementLineOfSight",
+        "LineOfSight.targetVisibility"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-lineofsightgeoelement.htm",
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "GeoElementLineOfSight",
+        "LineOfSight.targetVisibility"
+    ],
+    "snippets": [
+        "LineOfSightGeoElement.qml"
+    ],
+    "title": "Line of sight (geoelement)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to perform a line of sight analysis between two points in a SceneView",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "line of sight",
+        "visibility",
+        "AnalysisOverlay",
+        "LocationLineOfSight",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-lineofsightlocation.htm",
+    "relevant_apis": [
+        "AnalysisOverlay",
+        "LocationLineOfSight",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource"
+    ],
+    "snippets": [
+        "LineOfSightLocation.qml"
+    ],
+    "title": "Line of sight (location)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to query a table to get aggregated statistics back for a specific field",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "query",
+        "statistics",
+        "StatisticsQueryParameters",
+        "StatisticDefinition",
+        "StatisticsQueryResult",
+        "StatisticsRecordIterator",
+        "StatisticRecord",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-statisticalquery.htm",
+    "relevant_apis": [
+        "StatisticsQueryParameters",
+        "StatisticDefinition",
+        "StatisticsQueryResult",
+        "StatisticsRecordIterator",
+        "StatisticRecord",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "StatisticalQuery.qml"
+    ],
+    "title": "Statistical query"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to query a feature table to get statistics for one or more specified fields",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "statistics",
+        "sort results",
+        "ServiceFeatureTable",
+        "StatisticQueryParameters",
+        "StatisticQueryResult",
+        "StatisticIterator",
+        "StatisticRecord",
+        "StatisticDefinition",
+        "OrderBy"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-statisticalquerygroupsort.htm",
+    "relevant_apis": [
+        "ServiceFeatureTable",
+        "StatisticQueryParameters",
+        "StatisticQueryResult",
+        "StatisticIterator",
+        "StatisticRecord",
+        "StatisticDefinition",
+        "OrderBy"
+    ],
+    "snippets": [
+        "StatisticalQueryGroupSort.qml",
+        "OptionsPage.qml",
+        "ResultsPage.qml"
+    ],
+    "title": "Statistical query (group and sort)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to calculate a Viewshed from a SceneView's current Camera Viewpoint",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-viewshedcamera.htm",
+    "relevant_apis": [
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "snippets": [
+        "ViewshedCamera.qml"
+    ],
+    "title": "Viewshed (camera)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to calculate a Viewshed from a GeoElement",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "viewshed",
+        "GeoElementViewshed",
+        "AnalysisOverlay",
+        "ArcGISSceneLayer",
+        "GraphicsOverlay",
+        "LayerSceneProperties",
+        "GeometryEngine",
+        "ModelSceneSymbol",
+        "GeodeticDistanceResult",
+        "SimpleRenderer",
+        "OrbitGeoElementCameraController."
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-viewshedgeoelement.htm",
+    "relevant_apis": [
+        "GeoElementViewshed",
+        "AnalysisOverlay",
+        "ArcGISSceneLayer",
+        "GraphicsOverlay",
+        "LayerSceneProperties",
+        "GeometryEngine",
+        "ModelSceneSymbol",
+        "GeodeticDistanceResult",
+        "SimpleRenderer",
+        "OrbitGeoElementCameraController."
+    ],
+    "snippets": [
+        "ViewshedGeoElement.qml"
+    ],
+    "title": "Viewshed (geoelement)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Analysis",
+    "description": "This sample demonstrates how to calculate a viewshed from a Point location",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "location",
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-viewshedlocation.htm",
+    "relevant_apis": [
+        "LocationViewshed",
+        "AnalysisOverlay",
+        "Analysis",
+        "Viewshed",
+        "Scene",
+        "SceneView",
+        "Surface",
+        "ArcGISTiledElevationSource",
+        "Camera"
+    ],
+    "snippets": [
+        "ViewshedLocation.qml",
+        "ViewshedSlider.qml",
+        "ColorDialog.qml"
+    ],
+    "title": "Viewshed (location)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to add and delete items (in this case a local .csv file) in a user's portal",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "portal item",
+        "new item",
+        "AuthenticationView",
+        "Portal",
+        "PortalItem",
+        "PortalUser"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-additemstoportal.htm",
+    "relevant_apis": [
+        "AuthenticationView",
+        "Portal",
+        "PortalItem",
+        "PortalUser"
+    ],
+    "snippets": [
+        "AddItemsToPortal.qml"
+    ],
+    "title": "Add items to portal"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to retrieve a user's details via a Portal",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "portal user",
+        "user details",
+        "Portal",
+        "Credential",
+        "PortalUser",
+        "PortalInfo",
+        "AuthenticationView",
+        "AuthenticationManager"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-portaluserinfo.htm",
+    "relevant_apis": [
+        "Portal",
+        "Credential",
+        "PortalUser",
+        "PortalInfo",
+        "AuthenticationView",
+        "AuthenticationManager"
+    ],
+    "snippets": [
+        "PortalUserInfo.qml"
+    ],
+    "title": "Portal user info"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to find portal items by using a keyword, and limit the results to items of a certain type - in this case, web maps",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "portal item",
+        "search",
+        "find",
+        "Portal",
+        "PortalQueryParametersForItems",
+        "PortalQueryResultSetForItems",
+        "PortalItemListModel",
+        "PortalItem"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-searchforwebmap.htm",
+    "relevant_apis": [
+        "Portal",
+        "PortalQueryParametersForItems",
+        "PortalQueryResultSetForItems",
+        "PortalItemListModel",
+        "PortalItem"
+    ],
+    "snippets": [
+        "SearchForWebmap.qml"
+    ],
+    "title": "Search for web map by keyword"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to load a Portal and then use the organization's predefined basemaps query to get all basemaps",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "predefined basemaps",
+        "Portal",
+        "Credential",
+        "AuthenticationManager",
+        "BasemapListModel",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-showorgbasemaps.htm",
+    "relevant_apis": [
+        "Portal",
+        "Credential",
+        "AuthenticationManager",
+        "BasemapListModel",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "ShowOrgBasemaps.qml"
+    ],
+    "title": "Show organization basemaps"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Cloud and portal",
+    "description": "This sample demonstrates how to access a map service that is secured with ArcGIS token-based authentication",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "authentication",
+        "token",
+        "map service",
+        "AuthenticationManager",
+        "AuthenticationChallenge",
+        "AuthenticationView",
+        "Map",
+        "MapView",
+        "ArcGISMapImageLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-tokenauthentication.htm",
+    "relevant_apis": [
+        "AuthenticationManager",
+        "AuthenticationChallenge",
+        "AuthenticationView",
+        "Map",
+        "MapView",
+        "ArcGISMapImageLayer"
+    ],
+    "snippets": [
+        "TokenAuthentication.qml"
+    ],
+    "title": "Token authentication"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to build a legend for all the operational layers in the map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "legend",
+        "3D",
+        "integrated mesh",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISSublayerListModel",
+        "ArcGISTiledLayer",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "LegendInfo"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-buildlegend.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISSublayerListModel",
+        "ArcGISTiledLayer",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "LegendInfo"
+    ],
+    "snippets": [
+        "BuildLegend.qml"
+    ],
+    "title": "Build a legend"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/README.metadata.json
@@ -1,0 +1,43 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to display grids such as MGRS, Lat/Lon, USNG, and UTM on a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapView",
+        "ArcGISGrid",
+        "LatitudeLongitudeGrid",
+        "MGRSGrid",
+        "UTMGrid",
+        "USNGGrid",
+        "MGRSGrid",
+        "LatitudeLongitudeGrid",
+        "USNGGrid",
+        "UTMGrid",
+        "TextSymbol",
+        "SimpleLineSymbol"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaygrid.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISGrid",
+        "LatitudeLongitudeGrid",
+        "MGRSGrid",
+        "UTMGrid",
+        "USNGGrid",
+        "MGRSGrid",
+        "LatitudeLongitudeGrid",
+        "USNGGrid",
+        "UTMGrid",
+        "TextSymbol",
+        "SimpleLineSymbol"
+    ],
+    "snippets": [
+        "DisplayGrid.qml"
+    ],
+    "title": "Display a grid"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -1,0 +1,43 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates applying a dictionary renderer to graphics to display military symbology",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "dictionary renderer",
+        "military symbology",
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "GraphicsOverlay",
+        "DictionaryRenderer",
+        "DictionarySymbolStyle",
+        "SpatialReference",
+        "PointBuilder",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "Graphic",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-godictionaryrenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "GraphicsOverlay",
+        "DictionaryRenderer",
+        "DictionarySymbolStyle",
+        "SpatialReference",
+        "PointBuilder",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "Graphic",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "GODictionaryRenderer.qml"
+    ],
+    "title": "Graphics overlay (dictionary renderer)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates applying a dictionary renderer to a graphics overlay in a 3D scene to display military symbology",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "dictionary renderer",
+        "military symbology",
+        "SceneView",
+        "Scene",
+        "BasemapImagery",
+        "GraphicsOverlay",
+        "DictionaryRenderer",
+        "DictionarySymbolStyle",
+        "SpatialReference",
+        "PointBuilder",
+        "Graphic",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-godictionaryrenderer-3d.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "BasemapImagery",
+        "GraphicsOverlay",
+        "DictionaryRenderer",
+        "DictionarySymbolStyle",
+        "SpatialReference",
+        "PointBuilder",
+        "Graphic",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "GODictionaryRenderer_3D.qml"
+    ],
+    "title": "Graphics overlay (dictionary renderer) 3D"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GORenderers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GORenderers/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to add graphics and set renderer on graphic overlays",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-gorenderers.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder"
+    ],
+    "snippets": [
+        "GORenderers.qml"
+    ],
+    "title": "Add graphics with renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/README.metadata.json
@@ -1,0 +1,41 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to add graphics with symbols to a graphics overlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "BasemapOceans",
+        "ViewpointCenter",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder",
+        "GraphicsOverlay"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-gosymbols.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapOceans",
+        "ViewpointCenter",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point",
+        "PolylineBuilder",
+        "PolygonBuilder",
+        "GraphicsOverlay"
+    ],
+    "snippets": [
+        "GOSymbols.qml"
+    ],
+    "title": "Add graphics with symbols"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to identify graphics in a graphics overlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "identify graphics",
+        "MapView",
+        "Map",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleFillSymbol",
+        "PolygonBuilder"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-identifygraphics.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleFillSymbol",
+        "PolygonBuilder"
+    ],
+    "snippets": [
+        "IdentifyGraphics.qml"
+    ],
+    "title": "Identify graphics"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to create PictureMarkerSymbols from the different types of image resources",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "Envelope",
+        "GraphicsOverlay",
+        "Point",
+        "PictureMarkerSymbol",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-picturemarkersymbol.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "Envelope",
+        "GraphicsOverlay",
+        "Point",
+        "PictureMarkerSymbol",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Picture_Marker_Symbol.qml"
+    ],
+    "title": "Picture marker symbol"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/README.metadata.json
@@ -1,0 +1,41 @@
+{
+    "category": "Display information",
+    "description": "Open a mobile style (.stylx) and read its contents.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MultilayerPointSymbol",
+        "Symbol::createSwatch",
+        "SymbolLayer",
+        "SymbolStyle",
+        "SymbolStyle::searchSymbols",
+        "SymbolStyle::fetchSymbol",
+        "SymbolStyleSearchResultListModel",
+        "SymbolStyleSearchResult",
+        "SymbolStyleSearchParameters",
+        "advanced",
+        "symbology",
+        "multilayer",
+        "mobile style",
+        "stylx"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "MultilayerPointSymbol",
+        "Symbol::createSwatch",
+        "SymbolLayer",
+        "SymbolStyle",
+        "SymbolStyle.searchSymbols",
+        "SymbolStyle.fetchSymbol",
+        "SymbolStyleSearchResultListModel",
+        "SymbolStyleSearchResult",
+        "SymbolStyleSearchParameters"
+    ],
+    "snippets": [
+        "ReadSymbolsFromMobileStyle.qml",
+        "SymbolComboBox.qml"
+    ],
+    "title": "Read symbols from a mobile style"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to show location coordinates on a Map using a Callout",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapView",
+        "Callout",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-showcallout.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Callout",
+        "Viewpoint",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "ShowCallout.qml"
+    ],
+    "title": "Show callout"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to display labels on a FeatureLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "labels",
+        "LabelDefinition",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-showlabelsonlayers.htm",
+    "relevant_apis": [
+        "LabelDefinition",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "ShowLabelsOnLayers.qml"
+    ],
+    "title": "Show labels on layers"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to add a point graphic, symbolized by a red circle specified via a SimpleMarkerSymbol, to a GraphicsOverlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "Viewpoint",
+        "Point",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-simplemarkersymbol.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "Viewpoint",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Simple_Marker_Symbol.qml"
+    ],
+    "title": "Simple marker symbol"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to create a SimpleRenderer and add it to a GraphicsOverlay",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Envelope",
+        "Viewpoint",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleRenderer",
+        "SimpleMarkerSymbol",
+        "Point",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-simplerenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Envelope",
+        "Viewpoint",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleRenderer",
+        "SimpleMarkerSymbol",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Simple_Renderer.qml"
+    ],
+    "title": "Simple renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to override the default renderer of a shapefile when displaying with a FeatureLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "shapefile",
+        "shape file",
+        "ShapefileFeatureTable",
+        "FeatureLayer",
+        "SimpleRenderer",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-symbolizeshapefile.htm",
+    "relevant_apis": [
+        "ShapefileFeatureTable",
+        "FeatureLayer",
+        "SimpleRenderer",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Map"
+    ],
+    "snippets": [
+        "SymbolizeShapefile.qml"
+    ],
+    "title": "Symbolize a shapefile"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Display information",
+    "description": "This sample demonstrates how to use a UniqueValueRenderer to style different Features in a FeatureLayer with different Symbols",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "style features",
+        "Map",
+        "MapView",
+        "Basemap",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "UniqueValueRenderer",
+        "UniqueValue",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Viewpoint",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-uniquevaluerenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Basemap",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "UniqueValueRenderer",
+        "UniqueValue",
+        "SimpleFillSymbol",
+        "SimpleLineSymbol",
+        "Viewpoint",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "Unique_Value_Renderer.qml"
+    ],
+    "title": "Unique value renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to add features to a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "FeatureEditResult"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-addfeaturesfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "FeatureEditResult"
+    ],
+    "snippets": [
+        "AddFeaturesFeatureService.qml"
+    ],
+    "title": "Add features (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to delete a feature from a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "delete feature",
+        "feature editing",
+        "feature service",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-deletefeaturesfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "snippets": [
+        "DeleteFeaturesFeatureService.qml"
+    ],
+    "title": "Delete features (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/README.metadata.json
@@ -1,0 +1,47 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to generate an offline mobile geodatabase from a feature service, edit the feature's geometry while disconnected, and synchronize the local edits back to a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sync edits",
+        "generate mobile geodatabase",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "FeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseJob",
+        "GenerateGeodatabaseParameters",
+        "SyncGeodatabaseJob",
+        "SyncGeodatabaseParameters",
+        "GenerateLayerOption",
+        "SyncLayerOption"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-editandsyncfeatures.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "FeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseJob",
+        "GenerateGeodatabaseParameters",
+        "SyncGeodatabaseJob",
+        "SyncGeodatabaseParameters",
+        "GenerateLayerOption",
+        "SyncLayerOption"
+    ],
+    "snippets": [
+        "EditAndSyncFeatures.qml"
+    ],
+    "title": "Edit and sync features"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/README.metadata.json
@@ -1,0 +1,45 @@
+{
+    "category": "Edit data",
+    "description": "The sample demonstrates how to add, delete, and fetch attachments for a specific feature in a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "edit feature attachments",
+        "attachments",
+        "edit features",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "AttachmentListModel"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-editfeatureattachments.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "AttachmentListModel"
+    ],
+    "snippets": [
+        "main.qml",
+        "EditFeatureAttachments.qml"
+    ],
+    "title": "Edit feature attachments"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/README.metadata.json
@@ -1,0 +1,44 @@
+{
+    "category": "Edit data",
+    "description": "This sample demonstrates how to edit attributes of a feature in a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "edit feature attributes",
+        "attributes",
+        "edit features",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "Point"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-updateattributesfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult",
+        "Point"
+    ],
+    "snippets": [
+        "UpdateAttributesFeatureService.qml"
+    ],
+    "title": "Update attributes (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/README.metadata.json
@@ -1,0 +1,39 @@
+{
+    "category": "Edit data",
+    "description": "The sample demonstrates how to update geometry of a feature in a feature service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-updategeometryfeatureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "ArcGISFeature",
+        "FeatureEditResult",
+        "FeatureQueryResult"
+    ],
+    "snippets": [
+        "UpdateGeometryFeatureService.qml"
+    ],
+    "title": "Update geometry (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to override and reset a feature layer renderer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Envelope",
+        "SimpleLineSymbol",
+        "SimpleRenderer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayer-changerenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Envelope",
+        "SimpleLineSymbol",
+        "SimpleRenderer"
+    ],
+    "snippets": [
+        "FeatureLayer_ChangeRenderer.qml"
+    ],
+    "title": "Feature layer change renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to limit the features to display on the map using a definition expression",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "definition expression",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Point"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerdefinitionexpression.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Point"
+    ],
+    "snippets": [
+        "FeatureLayer_DefinitionExpression.qml"
+    ],
+    "title": "Feature layer definition expression"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to display a FeatureLayer with military symbology, using ArcGIS Runtime's DictionaryRenderer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "DictionarySymbolStyle",
+        "DictionaryRenderer",
+        "Geodatabase",
+        "FeatureLayer",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerdictionaryrenderer.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapTopographic",
+        "DictionarySymbolStyle",
+        "DictionaryRenderer",
+        "Geodatabase",
+        "FeatureLayer",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "FeatureLayer_DictionaryRenderer.qml"
+    ],
+    "title": "Feature layer (dictionary renderer)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to add a feature layer using a feature service to the map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayer-featureservice.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "FeatureLayer_FeatureService.qml"
+    ],
+    "title": "Feature layer (feature service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to consume an Esri mobile geodatabase by using a FeatureLayer and a GeodatabaseFeatureTable",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "mobile geodatabase",
+        "MapView",
+        "Map",
+        "Basemap",
+        "GeodatabaseFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayergeodatabase.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "GeodatabaseFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "FeatureLayer_Geodatabase.qml"
+    ],
+    "title": "Feature layer (geodatabase)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to open a GeoPackage, obtain a feature table from the package, and display the table as a FeatureLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GeoPackage",
+        "GeoPackageFeatureTable",
+        "FeatureLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayergeopackage.htm",
+    "relevant_apis": [
+        "GeoPackage",
+        "GeoPackageFeatureTable",
+        "FeatureLayer",
+        "Map"
+    ],
+    "snippets": [
+        "FeatureLayer_GeoPackage.qml"
+    ],
+    "title": "Feature layer (GeoPackage)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to query a feature layer using a feature table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Viewpoint"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerquery.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "FeatureLayer_Query.qml"
+    ],
+    "title": "Feature layer query"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to select features in a feature layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "feature selection",
+        "MapView",
+        "Map",
+        "BasemapStreets",
+        "ViewpointExtent",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "Envelope",
+        "GeoElement"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerselection.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapStreets",
+        "ViewpointExtent",
+        "SpatialReference",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Feature",
+        "Envelope",
+        "GeoElement"
+    ],
+    "snippets": [
+        "FeatureLayer_Selection.qml"
+    ],
+    "title": "Feature layer selection"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/README.metadata.json
@@ -1,0 +1,40 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to take a feature service offline by generating a geodatabase",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "mobile geodatabase",
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "GeodatabaseFeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseParameters",
+        "GenerateLayerOption",
+        "GenerateGeodatabaseJob"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-generategeodatabase.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "GeodatabaseFeatureTable",
+        "GeodatabaseSyncTask",
+        "GenerateGeodatabaseParameters",
+        "GenerateLayerOption",
+        "GenerateGeodatabaseJob"
+    ],
+    "snippets": [
+        "GenerateGeodatabase.qml"
+    ],
+    "title": "Generate geodatabase"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to query a layer for features that are in a related table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "related features",
+        "ArcGISFeatureTable",
+        "ArcGISFeature",
+        "RelatedFeatureQueryResult",
+        "FeatureQueryResult",
+        "FeatureIterator",
+        "Map",
+        "MapView",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-listrelatedfeatures.htm",
+    "relevant_apis": [
+        "ArcGISFeatureTable",
+        "ArcGISFeature",
+        "RelatedFeatureQueryResult",
+        "FeatureQueryResult",
+        "FeatureIterator",
+        "Map",
+        "MapView",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "ListRelatedFeatures.qml"
+    ],
+    "title": "List related features"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to use a feature table with the FeatureRequestModeOnInteractionCache feature request mode",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Enums"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-servicefeaturetable-cache.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "Enums"
+    ],
+    "snippets": [
+        "ServiceFeatureTable_Cache.qml"
+    ],
+    "title": "Service feature table (cache)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to use a feature service in manual cache mode",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "QueryParameters"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-servicefeaturetable-manualcache.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer",
+        "QueryParameters"
+    ],
+    "snippets": [
+        "ServiceFeatureTable_ManualCache.qml"
+    ],
+    "title": "Service feature table (manual cache)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to use a feature table in on interaction no cache mode",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-servicefeaturetable-nocache.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "ServiceFeatureTable_NoCache.qml"
+    ],
+    "title": "Service feature table (no cache)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/TimeBasedQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/TimeBasedQuery/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Features",
+    "description": "This sample demonstrates how to query data using a time extent",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "time",
+        "time extent",
+        "query",
+        "TimeExtent",
+        "QueryParameters",
+        "ServiceFeatureTable::populateFromService"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-timebasedquery.htm",
+    "relevant_apis": [
+        "TimeExtent",
+        "QueryParameters",
+        "ServiceFeatureTable::populateFromService"
+    ],
+    "snippets": [
+        "TimeBasedQuery.qml"
+    ],
+    "title": "Time based query"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to use GeometryEngine.buffer to create polygons from a map location and linear distance (radius)",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "analysis",
+        "buffer",
+        "geometry engine",
+        "GeometryEngine",
+        "GeometryEngine.buffer",
+        "GeometryEngine.bufferGeodetic",
+        "GraphicsOverlay"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-buffer.htm",
+    "relevant_apis": [
+        "GeometryEngine.buffer",
+        "GeometryEngine.bufferGeodetic",
+        "GraphicsOverlay"
+    ],
+    "snippets": [
+        "Buffer.qml"
+    ],
+    "title": "Buffer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to clip a geometry with an envelope using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "clip",
+        "geometry",
+        "GeometryEngine",
+        "GeometryEngine.clip",
+        "GraphicsOverlay",
+        "Graphic",
+        "Geometry",
+        "Envelope"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-clipgeometry.htm",
+    "relevant_apis": [
+        "GeometryEngine.clip",
+        "GraphicsOverlay",
+        "Graphic",
+        "Geometry",
+        "Envelope"
+    ],
+    "snippets": [
+        "ClipGeometry.qml"
+    ],
+    "title": "Clip geometry"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to build the various Geometry objects that are supported in ArcGIS Runtime",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "create geometry",
+        "line",
+        "Point",
+        "Multipoint",
+        "Polyline",
+        "Polygon",
+        "Envelope",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "MultipointBuilder"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-creategeometries.htm",
+    "relevant_apis": [
+        "Point",
+        "Multipoint",
+        "Polyline",
+        "Polygon",
+        "Envelope",
+        "PolygonBuilder",
+        "PolylineBuilder",
+        "MultipointBuilder"
+    ],
+    "snippets": [
+        "CreateGeometries.qml"
+    ],
+    "title": "Create geometries"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to cut a geometry with a polyline using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry",
+        "cut",
+        "split",
+        "GeometryEngine",
+        "GeometryEngine::cut"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-cutgeometry.htm",
+    "relevant_apis": [
+        "GeometryEngine",
+        "GeometryEngine::cut"
+    ],
+    "snippets": [
+        "CutGeometry.qml"
+    ],
+    "title": "Cut geometry"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to densify (add additional vertices) or generalize (reduce vertices) a polyline geometry",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "densify",
+        "generalize",
+        "geometry",
+        "GeometryEngine.densify",
+        "GeometryEngine.generalize",
+        "PointCollection",
+        "Multipoint",
+        "Polyline"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-densifyandgeneralize.htm",
+    "relevant_apis": [
+        "GeometryEngine.densify",
+        "GeometryEngine.generalize",
+        "PointCollection",
+        "Multipoint",
+        "Polyline"
+    ],
+    "snippets": [
+        "DensifyAndGeneralize.qml"
+    ],
+    "title": "Densify and generalize"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Geometry",
+    "description": "Coordinates can be written as text that is formatted in different ways",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "CoordinateFormatter",
+        "Point",
+        "Graphic"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-formatcoordinates.htm",
+    "relevant_apis": [
+        "CoordinateFormatter",
+        "Point",
+        "Graphic"
+    ],
+    "snippets": [
+        "FormatCoordinates.qml"
+    ],
+    "title": "Format coordinates"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to perform geodesic operations on geometries using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "densify",
+        "geodesic distance",
+        "geodetic distance",
+        "GeometryEngine::densifyGeodetic",
+        "GeometryEngine::lengthGeodetic"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-geodesicoperations.htm",
+    "relevant_apis": [
+        "GeometryEngine::densifyGeodetic",
+        "GeometryEngine::lengthGeodetic"
+    ],
+    "snippets": [
+        "GeodesicOperations.qml"
+    ],
+    "title": "Geodesic operations"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to use the TransformationCatalog to get a list of available DatumTransformations that can be used to project a Geometry between two different SpatialReferences, and how to use one of the transformations to perform the GeometryEngine.project operation",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geographic transformation",
+        "datum transformation",
+        "geometry engine",
+        "TransformationCatalog",
+        "DatumTransformation",
+        "GeographicTransformation",
+        "GeographicTransformationStep",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-listtransformations.htm",
+    "relevant_apis": [
+        "TransformationCatalog",
+        "DatumTransformation",
+        "GeographicTransformation",
+        "GeographicTransformationStep",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "ListTransformations.qml"
+    ],
+    "title": "List transformations by suitability"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to project a point from one spatial reference to another",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "project geometry",
+        "spatial reference",
+        "projection",
+        "coordinate system",
+        "geometry engine",
+        "GeometryEngine",
+        "Point",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-projectgeometry.htm",
+    "relevant_apis": [
+        "GeometryEngine",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "ProjectGeometry.qml"
+    ],
+    "title": "Project"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/README.metadata.json
@@ -1,0 +1,40 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to perform spatial operations on geometries using the GeometryEngine",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "geometric union",
+        "geometric difference",
+        "geometric symmetric difference",
+        "geometric intersection",
+        "GeometryEngine",
+        "GeometryEngine::union",
+        "GeometryEngine::difference",
+        "GeometryEngine::symmetricDifference",
+        "GeometryEngine::intersection",
+        "Geometry",
+        "Graphic",
+        "GraphicsOverlay",
+        "PolygonBuilder"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-spatialoperations.htm",
+    "relevant_apis": [
+        "GeometryEngine",
+        "GeometryEngine::union",
+        "GeometryEngine::difference",
+        "GeometryEngine::symmetricDifference",
+        "GeometryEngine::intersection",
+        "Geometry",
+        "Graphic",
+        "GraphicsOverlay",
+        "PolygonBuilder"
+    ],
+    "snippets": [
+        "SpatialOperations.qml"
+    ],
+    "title": "Spatial operations"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Geometry",
+    "description": "This sample demonstrates how to determine the spatial relationships between two geometries",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geometry engine",
+        "spatial analysis",
+        "spatial relationships",
+        "intersects",
+        "touches",
+        "disjoint",
+        "crosses",
+        "within",
+        "overlaps",
+        "contains"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-spatialrelationships.htm",
+    "relevant_apis": [
+        "GeometryEngine.intersects",
+        "GeometryEngine.touches",
+        "GeometryEngine.disjoint",
+        "GeometryEngine.crosses",
+        "GeometryEngine.within",
+        "GeometryEngine.overlaps",
+        "GeometryEngine.contains"
+    ],
+    "snippets": [
+        "SpatialRelationships.qml"
+    ],
+    "title": "Spatial relationships"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "Display nautical charts per the ENC specification.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "EncCell",
+        "EncDataset",
+        "EncExchangeSet",
+        "EncLayer",
+        "Data",
+        "ENC",
+        "maritime",
+        "nautical chart",
+        "layers",
+        "hydrographic"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "EncCell",
+        "EncDataset",
+        "EncExchangeSet",
+        "EncLayer"
+    ],
+    "snippets": [
+        "AddEncExchangeSet.qml"
+    ],
+    "title": "Add ENC exchange set"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ArcGISMapImageLayer from a URL",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "map image layer",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-arcgismapimagelayerurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer"
+    ],
+    "snippets": [
+        "ArcGISMapImageLayerUrl.qml"
+    ],
+    "title": "ArcGIS map image layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a tiled map service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-arcgistiledlayerurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISTiledLayer"
+    ],
+    "snippets": [
+        "ArcGISTiledLayerUrl.qml"
+    ],
+    "title": "ArcGIS tiled layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/README.metadata.json
@@ -1,0 +1,31 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use blend renderer on a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "blend renderers",
+        "hillshade",
+        "Map",
+        "MapQuickView",
+        "Raster",
+        "RasterLayer",
+        "BlendRenderer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-blendrasterlayer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapQuickView",
+        "Raster",
+        "RasterLayer",
+        "BlendRenderer"
+    ],
+    "snippets": [
+        "ColorRampModel.qml",
+        "SlopeTypeModel.qml",
+        "BlendRasterLayer.qml"
+    ],
+    "title": "Blend raster layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Layers",
+    "description": "Browse a WFS service for layers and add them to the map.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WfsService",
+        "WfsServiceInfo",
+        "WfsLayerInfo",
+        "WfsFeatureTable",
+        "FeatureLayer",
+        "WfsFeatureTable.AxisOrder",
+        "OGC",
+        "WFS",
+        "feature",
+        "web",
+        "service",
+        "layers",
+        "browse",
+        "catalog"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [        
+        "WfsService",
+        "WfsServiceInfo",
+        "WfsLayerInfo",
+        "WfsFeatureTable",
+        "FeatureLayer",
+        "WfsFeatureTable.AxisOrder"
+    ],
+    "snippets": [
+        "BrowseWfsLayers.qml"
+    ],
+    "title": "Browse WFS layers"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to change the renderer on a map image layer sublayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Sublayer renderer",
+        "dynamic layer",
+        "ArcGISMapImageSublayer",
+        "ClassBreaksRenderer",
+        "ClassBreak",
+        "ArcGISMapImageSublayer.renderer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-changesublayerrenderer.htm",
+    "relevant_apis": [
+        "ArcGISMapImageSublayer",
+        "ClassBreaksRenderer",
+        "ClassBreak",
+        "ArcGISMapImageSublayer.renderer"
+    ],
+    "snippets": [
+        "ChangeSublayerRenderer.qml"
+    ],
+    "title": "Change sublayer renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how you can hide or show sublayers of a map image layer by using the ArcGISSublayerListModel",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sublayer",
+        "visibility",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISSublayerListModel"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-changesublayervisibility.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISMapImageLayer",
+        "ArcGISSublayerListModel"
+    ],
+    "snippets": [
+        "ChangeSublayerVisibility.qml"
+    ],
+    "title": "Change sublayer visibility"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "Load and display KML files from various sources, including URLs, local files, and Portal items",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "KML",
+        "KMZ",
+        "OGC",
+        "Keyhole",
+        "KmlLayer",
+        "KmlDataset"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaykml.htm",
+    "relevant_apis": [
+        "KmlLayer",
+        "KmlDataset"
+    ],
+    "snippets": [
+        "DisplayKml.qml"
+    ],
+    "title": "Display KML"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a file with a network link, including displaying any network link control messages at launch",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "KML",
+        "KMZ",
+        "OGC",
+        "Keyhole",
+        "Network Link",
+        "Network Link Control",
+        "KmlDataset(Url)",
+        "KmlLayer(KmlDataset)",
+        "KmlNetworkLink",
+        "kmlNetworkLinkMessageReceived"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaykmlnetworklinks.htm",
+    "relevant_apis": [
+        "KmlDataset(Url)",
+        "KmlLayer(KmlDataset)",
+        "KmlNetworkLink",
+        "KmlNetworkLinkMessageReceived"
+    ],
+    "snippets": [
+        "MessageButton.qml",
+        "DisplayKmlNetworkLinks.qml"
+    ],
+    "title": "Display KML network links"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Layers",
+    "description": "Display a layer from a WFS service, requesting only features for the current extent.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WfsFeatureTable",
+        "WfsFeatureTable.populateFromService",
+        "FeatureLayer",
+        "OGC",
+        "WFS",
+        "feature",
+        "web",
+        "service",
+        "layers",
+        "browse",
+        "catalog",
+        "interaction cache"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "WfsFeatureTable",
+        "WfsFeatureTable.populateFromService",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "DisplayWfsLayer.qml"
+    ],
+    "title": "Display a WFS layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to export tiles from a map service for offline use",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "map tiles",
+        "credate tile caches",
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "ExportTileCacheTask",
+        "ExportTileCacheJob",
+        "ExportTiledCacheParameters"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-exporttiles.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "ExportTileCacheTask",
+        "ExportTileCacheJob",
+        "ExportTiledCacheParameters"
+    ],
+    "snippets": [
+        "ExportTiles.qml"
+    ],
+    "title": "Export tiles"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "This samples demonstrates how to create a feature collection layer to show a query result from a service feature table",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Map",
+        "MapQuickView",
+        "ServiceFeatureTable"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurecollectionlayerquery.htm",
+    "relevant_apis": [
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Map",
+        "MapQuickView",
+        "ServiceFeatureTable"
+    ],
+    "snippets": [
+        "FeatureCollectionLayerQuery.qml"
+    ],
+    "title": "Feature collection layer (query)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates the differences between static and dynamic rendering mode for a FeatureLayer in a Map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "MapView",
+        "Map",
+        "Viewpoint"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerrenderingmodemap.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "MapView",
+        "Map",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "FeatureLayerRenderingModeMap.qml"
+    ],
+    "title": "Feature layer rendering mode (map)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates the differences between static and dynamic rendering mode for a FeatureLayer in a 3D Scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "SceneView",
+        "Scene",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerrenderingmodescene.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "LoadSettings",
+        "ServiceFeatureTable",
+        "SceneView",
+        "Scene",
+        "Camera"
+    ],
+    "snippets": [
+        "FeatureLayerRenderingModeScene.qml"
+    ],
+    "title": "Feature layer rendering mode (scene)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to open a shapefile stored on the device and display it as a feature layer with default symbology",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "shapefile",
+        "shape file",
+        "feature layer",
+        "ShapefileFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayershapefile.htm",
+    "relevant_apis": [
+        "ShapefileFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "FeatureLayerShapefile.qml"
+    ],
+    "title": "Feature layer (shapefile)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/README.metadata.json
@@ -1,0 +1,38 @@
+{
+    "category": "Layers",
+    "description": "This samples demonstrates how to create a new feature collection with several feature collection tables",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "feature collection",
+        "feature collection layer",
+        "feature collection table",
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Field",
+        "Feature",
+        "SimpleRenderer",
+        "SimpleMarkerSymbol",
+        "SimpleLineSymbol",
+        "SimpleFillSymbol"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-feature-collection-layer.htm",
+    "relevant_apis": [
+        "FeatureCollection",
+        "FeatureCollectionLayer",
+        "FeatureCollectionTable",
+        "Field",
+        "Feature",
+        "SimpleRenderer",
+        "SimpleMarkerSymbol",
+        "SimpleLineSymbol",
+        "SimpleFillSymbol"
+    ],
+    "snippets": [
+        "Feature_Collection_Layer.qml"
+    ],
+    "title": "Feature collection layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Layers",
+    "description": "Group a collection of layers together and toggle their visibility as a group.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GroupLayer",
+        "Layers",
+        "group layer",
+        "LayerListModel"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "GroupLayer"
+    ],
+    "snippets": [
+        "GroupLayers.qml"
+    ],
+    "title": "Group layers"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Layers",
+    "description": "This sample shows how to apply a HillshadeRenderer to a RasterLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "hillshade",
+        "shaded relief",
+        "lighting angle",
+        "HillshadeRenderer",
+        "RasterLayer",
+        "Raster",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-hillshade-renderer.htm",
+    "relevant_apis": [
+        "HillshadeRenderer",
+        "RasterLayer",
+        "Raster",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "HillshadeSettings.qml",
+        "Hillshade_Renderer.qml",
+        "HillshadeSlopeTypeModel.qml"
+    ],
+    "title": "Hillshade renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Layers",
+    "description": "Load a WFS feature table using an XML query.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "WfsFeatureTable"
+        "WfsFeatureTable.populateFromService",
+        "OGC",
+        "WFS",
+        "feature",
+        "web",
+        "service",
+        "XML",
+        "query"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "FeatureLayer",
+        "WfsFeatureTable"
+        "WfsFeatureTable.populateFromService"
+    ],
+    "snippets": [
+        "LoadWfsXmlQuery.qml"
+    ],
+    "title": "Load WFS with XML query"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "Add, remove, and reorder operational layers in a map.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "ArcGISMap",
+        "ArcGISMapImageLayer",
+        "LayerListModel",
+        "LayerListModel.append",
+        "LayerListModel.move",
+        "LayerListModel.remove"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "ArcGISMap",
+        "ArcGISMapImageLayer",
+        "LayerListModel",
+        "LayerListModel.append",
+        "LayerListModel.move",
+        "LayerListModel.remove"
+    ],
+    "snippets": [
+        "ManageOperationalLayers.qml"
+    ],
+    "title": "Manage operational layers"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to add the OpenStreetMap layer to a map as a Basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "OSM",
+        "OpenStreetMap",
+        "OpenStreetMapLayer",
+        "BasemapOpenStreetMap",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-osm-layer.htm",
+    "relevant_apis": [
+        "OpenStreetMapLayer",
+        "BasemapOpenStreetMap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "OSM_Layer.qml"
+    ],
+    "title": "OpenStreetMap layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to execute an attribute and spatial query on the sublayers of an ArcGIS map image layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "query sublayer",
+        "ServiceFeatureTable",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageLayer.loadTablesAndLayers",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageSublayer.table",
+        "QueryParameters"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-querymapimagesublayer.htm",
+    "relevant_apis": [
+        "ServiceFeatureTable",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageLayer.loadTablesAndLayers",
+        "ArcGISMapImageSublayer",
+        "ArcGISMapImageSublayer.table",
+        "QueryParameters"
+    ],
+    "snippets": [
+        "QueryMapImageSublayer.qml"
+    ],
+    "title": "Query map image sublayer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Layers",
+    "description": "Demonstrates how to use a colormap renderer on raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "colormap renderer",
+        "Map",
+        "Basemap",
+        "ColormapRenderer",
+        "MapView",
+        "Raster",
+        "RasterLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rastercolormaprenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "Basemap",
+        "ColormapRenderer",
+        "MapView",
+        "Raster",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterColormapRenderer.qml"
+    ],
+    "title": "Colormap renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to apply a RasterFunction to a local Raster file and display the output with a RasterLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "RasterFunction",
+        "RasterLayer",
+        "Raster",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterfunctionfile.htm",
+    "relevant_apis": [
+        "RasterFunction",
+        "RasterLayer",
+        "Raster",
+        "Map"
+    ],
+    "snippets": [
+        "RasterFunctionFile.qml"
+    ],
+    "title": "Raster function (file)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ImageServiceRaster and apply a RasterFunction to it",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterFunction",
+        "RasterFunctionArguments",
+        "RasterLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterfunctionservice.htm",
+    "relevant_apis": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterFunction",
+        "RasterFunctionArguments",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterFunctionService.qml"
+    ],
+    "title": "Raster function (service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "Demonstrates how to create and use a raster layer made from a local raster file",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Raster",
+        "RasterLayer",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterlayerfile.htm",
+    "relevant_apis": [
+        "Raster",
+        "RasterLayer",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "RasterLoader.qml",
+        "main.qml",
+        "RasterLayerFile.qml"
+    ],
+    "title": "Raster layer (file)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to open a GeoPackage, obtain a raster from the package, and display the table as a RasterLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GeoPackage",
+        "GeoPackageRaster",
+        "RasterLayer",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterlayergeopackage.htm",
+    "relevant_apis": [
+        "GeoPackage",
+        "GeoPackageRaster",
+        "RasterLayer",
+        "Map"
+    ],
+    "snippets": [
+        "RasterLayerGeoPackage.qml"
+    ],
+    "title": "Raster layer (GeoPackage)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ImageServiceRaster and add it to a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterlayerservice.htm",
+    "relevant_apis": [
+        "Map",
+        "MapQuickView",
+        "ImageServiceRaster",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterLayerService.qml"
+    ],
+    "title": "Raster layer (service)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to create an ImageServiceRaster, fetch the RenderingRules from the service info, and use a RenderingRule to create an ImageServiceRaster and add it to a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "raster rendering rule",
+        "Map",
+        "ImageServiceRaster",
+        "RenderingRuleInfo",
+        "RenderingRule",
+        "RasterLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterrenderingrule.htm",
+    "relevant_apis": [
+        "Map",
+        "ImageServiceRaster",
+        "RenderingRuleInfo",
+        "RenderingRule",
+        "RasterLayer"
+    ],
+    "snippets": [
+        "RasterRenderingRule.qml"
+    ],
+    "title": "Raster rendering rule"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/README.metadata.json
@@ -1,0 +1,34 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use an rgb renderer with a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "RGB renderer",
+        "Map",
+        "MapView",
+        "MinMaxStretchParameters",
+        "PercentClipStretchParameters",
+        "Raster",
+        "RasterLayer",
+        "RGBRenderer",
+        "StandardDeviationStretchParameters"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterrgbrenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "MinMaxStretchParameters",
+        "PercentClipStretchParameters",
+        "Raster",
+        "RasterLayer",
+        "RGBRenderer",
+        "StandardDeviationStretchParameters"
+    ],
+    "snippets": [
+        "RasterRgbRenderer.qml"
+    ],
+    "title": "RGB renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use stretch renderer on a raster layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "stretch renderer",
+        "Map",
+        "MapView",
+        "Raster",
+        "RasterLayer",
+        "StretchRenderer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-rasterstretchrenderer.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "Raster",
+        "RasterLayer",
+        "StretchRenderer"
+    ],
+    "snippets": [
+        "InputWithLabel.qml",
+        "RasterStretchRenderer.qml"
+    ],
+    "title": "Stretch renderer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to dynamically change the style of a sublayer in a WMS layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WMS style",
+        "change style",
+        "WmsLayer",
+        "WmsSublayer",
+        "WmsLayerInfo",
+        "WmsSublayer.currentStyle"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-stylewmslayer.htm",
+    "relevant_apis": [
+        "WmsLayer",
+        "WmsSublayer",
+        "WmsLayerInfo",
+        "WmsSublayer.currentStyle"
+    ],
+    "snippets": [
+        "StyleWmsLayer.qml"
+    ],
+    "title": "Style WMS layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to use a vector tiled layer from an ArcGIS Online service as a basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "vector tiled layer",
+        "vector tile layer",
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISVectorTiledLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-vectortilelayerurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ArcGISVectorTiledLayer"
+    ],
+    "snippets": [
+        "VectorTiledLayerUrl.qml"
+    ],
+    "title": "Vector tiled layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to load a Web Map Tile Service (WMTS) and display it as a layer in a Map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "web map tile service",
+        "WmtsLayer",
+        "WmtsLayerInfo",
+        "WmtsService",
+        "WmtsServiceInfo",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-wmts-layer.htm",
+    "relevant_apis": [
+        "WmtsLayer",
+        "WmtsLayerInfo",
+        "WmtsService",
+        "WmtsServiceInfo",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "WMTS_Layer.qml"
+    ],
+    "title": "WMTS layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display map tiles from an online resource using the WebTiledLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "web tiled layer",
+        "WebTiledLayer",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-web-tiled-layer.htm",
+    "relevant_apis": [
+        "WebTiledLayer",
+        "Basemap",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "Web_Tiled_Layer.qml"
+    ],
+    "title": "Web tiled layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Layers",
+    "description": "This sample demonstrates how to display a WMS Layer from an online URL",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "WmsLayer",
+        "Map",
+        "MapView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-wmslayerurl.htm",
+    "relevant_apis": [
+        "WmsLayer",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "WmsLayerUrl.qml"
+    ],
+    "title": "WMS layer (URL)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to change a map's basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-changebasemap.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "ChangeBasemap.qml"
+    ],
+    "title": "Change basemap"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to change the viewpoint of a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "area of interest",
+        "extent",
+        "viewpoint",
+        "map",
+        "envelope",
+        "ViewpointExtent",
+        "EnvelopeBuilder"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-changeviewpoint.htm",
+    "relevant_apis": [
+        "Map",
+        "ViewpointExtent",
+        "EnvelopeBuilder"
+    ],
+    "snippets": [
+        "ChangeViewpoint.qml"
+    ],
+    "title": "Change viewpoint"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to author a Map in ArcGIS Runtime and save it to ArcGIS Online as a web map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "web map",
+        "create map",
+        "Map",
+        "Portal",
+        "Map::saveAs()"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-createandsavemap.htm",
+    "relevant_apis": [
+        "Map",
+        "Portal",
+        "Map::saveAs()"
+    ],
+    "snippets": [
+        "SaveOptionsWindow.qml",
+        "CreateAndSaveMap.qml",
+        "LayerWindow.qml"
+    ],
+    "title": "Create and save map"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how you can enable Location Display to display your current position on the map, as well as switch between different types of AutoPan Modes",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "GPS",
+        "navigate",
+        "route",
+        "MapView",
+        "Map",
+        "LocationDisplay"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaydevicelocation.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "LocationDisplay"
+    ],
+    "snippets": [
+        "DisplayDeviceLocation.qml"
+    ],
+    "title": "Display device location"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to use the DrawStatus value of the MapView to notify the user that the MapView is drawing",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "Viewpoint",
+        "Envelope"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaydrawingstatus.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "Viewpoint",
+        "Envelope"
+    ],
+    "snippets": [
+        "DisplayDrawingStatus.qml"
+    ],
+    "title": "Display drawing status"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to get the view status of a Layer in a Map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "status",
+        "load",
+        "MapView",
+        "Map",
+        "ArcGISTiledLayer",
+        "ArcGISMapImageLayer",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "ViewpointCenter",
+        "Point",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaylayerviewdrawstate.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "ArcGISTiledLayer",
+        "ArcGISMapImageLayer",
+        "FeatureLayer",
+        "ServiceFeatureTable",
+        "ViewpointCenter",
+        "Point",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "DisplayLayerViewDrawState.qml"
+    ],
+    "title": "Display layer view draw state"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to display a map view with a basemap",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displaymap.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "DisplayMap.qml"
+    ],
+    "title": "Display a map"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/README.metadata.json
@@ -1,0 +1,45 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to take a web map offline",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "offline",
+        "disconnected",
+        "Map",
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "MapView",
+        "EnveloperBuilder",
+        "AuthenticationView",
+        "AuthenticationManager",
+        "PortalItem",
+        "Portal",
+        "GeometryEngine"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-generateofflinemap.htm",
+    "relevant_apis": [
+        "Map",
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "MapView",
+        "EnveloperBuilder",
+        "AuthenticationView",
+        "AuthenticationManager",
+        "PortalItem",
+        "Portal",
+        "GeometryEngine"
+    ],
+    "snippets": [
+        "GenerateOfflineMap.qml",
+        "DownloadButton.qml",
+        "GenerateWindow.qml"
+    ],
+    "title": "Generate offline map"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Maps",
+    "description": "Use the `OfflineMapTask` to take a web map offline, but instead of downloading an online basemap, use one which is already on the device.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "Offline"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "OfflineMapTask",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult"
+    ],
+    "snippets": [        
+        "GenerateOfflineMapLocalBasemap.qml",
+        "DownloadButton.qml",
+        "GenerateWindow.qml"
+    ],
+    "title": "Generate offline map with local basemap"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Maps",
+    "description": "You can use the OfflineMapTask to take a webmap offline, and overrides allow you to adjust the settings used for taking each layer in the map offline",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "offline",
+        "OfflineMapTask",
+        "GenerateGeodatabaseParameters",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapParameterOverrides",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "ExportTileCacheParameters"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-generateofflinemapoverrides.htm",
+    "relevant_apis": [
+        "OfflineMapTask",
+        "GenerateGeodatabaseParameters",
+        "GenerateOfflineMapParameters",
+        "GenerateOfflineMapParameterOverrides",
+        "GenerateOfflineMapJob",
+        "GenerateOfflineMapResult",
+        "ExportTileCacheParameters"
+    ],
+    "snippets": [
+        "OverridesWindow.qml",
+        "DownloadButton.qml",
+        "GenerateWindow.qml",
+        "GenerateOfflineMap_Overrides.qml"
+    ],
+    "title": "Generate offline map (overrides)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to identify features on a map across the different layers in the map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "find",
+        "search",
+        "attribute",
+        "MapView",
+        "IdentifyLayerResult",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageSublayer",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-identifylayers.htm",
+    "relevant_apis": [
+        "MapView",
+        "IdentifyLayerResult",
+        "ArcGISMapImageLayer",
+        "ArcGISMapImageSublayer",
+        "ServiceFeatureTable",
+        "FeatureLayer"
+    ],
+    "snippets": [
+        "IdentifyLayers.qml"
+    ],
+    "title": "Identify layers"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/README.metadata.json
@@ -1,0 +1,35 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to access and add bookmarks to a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "area of interest",
+        "extent",
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "ViewpointExtent",
+        "Bookmark",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-managebookmarks.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "Viewpoint",
+        "ViewpointExtent",
+        "Bookmark",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "ManageBookmarks.qml"
+    ],
+    "title": "Manage bookmarks"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to determine the map's load status",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "state",
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-maploaded.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "MapLoaded.qml"
+    ],
+    "title": "Map loaded"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Maps",
+    "description": "Set the map's reference scale and which feature layers should honor the reference scale.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "FeatureLayer",
+        "Map",
+        "Maps & Scenes"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "FeatureLayer",
+        "Map"        
+    ],
+    "snippets": [
+        "MapReferenceScale.qml"
+    ],
+    "title": "Map reference scale"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to rotate a map view",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "rotation",
+        "MapView",
+        "Map",
+        "BasemapStreets",
+        "ViewpointCenter",
+        "Slider (Qt Quick control)"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-maprotation.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "BasemapStreets",
+        "ViewpointCenter",
+        "Slider (Qt Quick control)"
+    ],
+    "snippets": [
+        "MapRotation.qml"
+    ],
+    "title": "Map rotation"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to set the minimum and maximum scale of a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "extent",
+        "maps",
+        "2D",
+        "scale",
+        "setminScale",
+        "setmaxScale",
+        "zoom"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-minmaxscale.htm",
+    "relevant_apis": [
+        "Map.minScale",
+        "Map.maxScale"
+    ],
+    "snippets": [
+        "MinMaxScale.qml"
+    ],
+    "title": "Min-Max scale"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/README.metadata.json
@@ -1,0 +1,51 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to geocode and route using data in a map package",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "navigate",
+        "offline",
+        "MobileMapPackage",
+        "RouteTask",
+        "RouteParameters",
+        "RouteResult",
+        "Stop",
+        "LocatorTask",
+        "GeocodeResult",
+        "ReverseGeocodeParameters",
+        "Graphic",
+        "GraphicsOverlay",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "TextSymbol",
+        "SimpleRenderer",
+        "Callout"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-mobilemap-searchandroute.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "MobileMapPackage",
+        "RouteTask",
+        "RouteParameters",
+        "RouteResult",
+        "Stop",
+        "LocatorTask",
+        "GeocodeResult",
+        "ReverseGeocodeParameters",
+        "Graphic",
+        "GraphicsOverlay",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "TextSymbol",
+        "SimpleRenderer",
+        "Callout"
+    ],
+    "snippets": [
+        "MobileMap_SearchAndRoute.qml"
+    ],
+    "title": "Mobile map (search and route)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to open an existing map from a URL",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-openmapurl.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "OpenMapUrl.qml"
+    ],
+    "title": "Open map (URL)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to open and display a map from a Mobile Map Package",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "offline",
+        "disconnected",
+        "MapView",
+        "MobileMapPackage"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-openmobilemap-mappackage.htm",
+    "relevant_apis": [
+        "MapView",
+        "MobileMapPackage"
+    ],
+    "snippets": [
+        "OpenMobileMap_MapPackage.qml"
+    ],
+    "title": "Open mobile map (map package)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to read rasters and feature tables from GeoPackages to show them as layers in a map",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "offline",
+        "OGC",
+        "GeoPackage",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-readgeopackage.htm",
+    "relevant_apis": [
+        "GeoPackage"
+    ],
+    "snippets": [
+        "ReadGeoPackage.qml"
+    ],
+    "title": "Read GeoPackage"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to create a map with a predefined initial extent",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "viewpoint",
+        "area of interest",
+        "Basemap",
+        "ViewpointExtent",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-setinitialmaparea.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "ViewpointExtent",
+        "Envelope",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "SetInitialMapArea.qml"
+    ],
+    "title": "Set initial map area"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to create a map with a basemap, centered at a specific location and scale",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "viewpoint",
+        "area of interest",
+        "extent"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-setinitialmaplocation.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map"
+    ],
+    "snippets": [
+        "SetInitialMapLocation.qml"
+    ],
+    "title": "Set initial map location"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to set the initial spatial reference of a map so that all layers that support reprojection are projected into the map's spatial reference",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "projection",
+        "geographic",
+        "coordinate system",
+        "Basemap",
+        "SpatialReference"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-setmapspatialreference.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "SpatialReference"
+    ],
+    "snippets": [
+        "SetMapSpatialReference.qml"
+    ],
+    "title": "Set map spatial reference"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how you can tap and hold on a map to get the magnifier",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "magnify",
+        "display",
+        "zoom"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-showmagnifier.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap"
+    ],
+    "snippets": [
+        "ShowMagnifier.qml"
+    ],
+    "title": "Show magnifier"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Maps",
+    "description": "This sample demonstrates how to take a screenshot of the MapView",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "screenshot",
+        "screen capture",
+        "export",
+        "GeoView::exportImage"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-takescreenshot.htm",
+    "relevant_apis": [
+        "GeoView::exportImage"
+    ],
+    "snippets": [
+        "TakeScreenshot.qml"
+    ],
+    "title": "Take screenshot"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Routing",
+    "description": "This sample demonstrates how to solve a Closest Facility Task to find the closest route between a facility (hospital) and an incident (black cross)",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "network analysis",
+        "service area",
+        "ClosestFacilityTask",
+        "ClosestFacilityParameters",
+        "ClosestFacilityResult",
+        "Facility",
+        "Incident"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-closestfacility.htm",
+    "relevant_apis": [
+        "ClosestFacilityTask",
+        "ClosestFacilityParameters",
+        "ClosestFacilityResult",
+        "Facility",
+        "Incident"
+    ],
+    "snippets": [
+        "ClosestFacility.qml"
+    ],
+    "title": "Closest facility"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/README.metadata.json
@@ -1,0 +1,46 @@
+{
+    "category": "Routing",
+    "description": "This sample demonstrates how to get a route between two locations",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "network analysis",
+        "navigation",
+        "travel",
+        "directions",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "SimpleRenderer",
+        "RouteTask",
+        "RouteParameters",
+        "Stop",
+        "RouteResult",
+        "DirectionManeuverListModel"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-findroute.htm",
+    "relevant_apis": [
+        "MapView",
+        "Map",
+        "Basemap",
+        "GraphicsOverlay",
+        "Graphic",
+        "Point",
+        "PictureMarkerSymbol",
+        "SimpleLineSymbol",
+        "SimpleRenderer",
+        "RouteTask",
+        "RouteParameters",
+        "Stop",
+        "RouteResult",
+        "DirectionManeuverListModel"
+    ],
+    "snippets": [
+        "FindRoute.qml"
+    ],
+    "title": "Find route"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/README.metadata.json
@@ -1,0 +1,37 @@
+{
+    "category": "Routing",
+    "description": "Demonstrates how to find services areas around a point using the ServiceAreaTask",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "network analysis",
+        "service area",
+        "closest facility",
+        "PolylineBarrier",
+        "ServiceAreaFacility",
+        "ServiceAreaParameters",
+        "ServiceAreaPolygon",
+        "ServiceAreaResult",
+        "ServiceAreaTask",
+        "PolylineBuilder"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-servicearea.htm",
+    "relevant_apis": [
+        "Map",
+        "GraphicsOverlay",
+        "MapView",
+        "PolylineBarrier",
+        "ServiceAreaFacility",
+        "ServiceAreaParameters",
+        "ServiceAreaPolygon",
+        "ServiceAreaResult",
+        "ServiceAreaTask",
+        "PolylineBuilder"
+    ],
+    "snippets": [
+        "ServiceArea.qml"
+    ],
+    "title": "Service area"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Scenes",
+    "description": "View a point scene layer from a scene service.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "ArcGISSceneLayer",
+        "3D",
+        "point",
+        "scene layer",
+        "layers"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "ArcGISSceneLayer"
+    ],
+    "snippets": [
+        "AddAPointSceneLayer.qml"
+    ],
+    "title": "Add a point scene layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Scenes",
+    "description": "View an integrated mesh layer from a scene service",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "integrated mesh",
+        "layer",
+        "IntegratedMeshLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-addintegratedmeshlayer.htm",
+    "relevant_apis": [
+        "IntegratedMeshLayer"
+    ],
+    "snippets": [
+        "AddIntegratedMeshLayer.qml"
+    ],
+    "title": "Add an integrated mesh layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/README.metadata.json
@@ -1,0 +1,51 @@
+{
+    "category": "Scenes",
+    "description": "Demonstrates how to animate a graphic's position and rotation and follow it using an OrbitGeoElementCameraController",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "animation",
+        "camera controller",
+        "model scene symbol",
+        "Camera",
+        "GlobeCameraController",
+        "Graphic",
+        "GraphicsOverlay",
+        "SurfacePlacement",
+        "MapView",
+        "ModelSceneSymbol",
+        "OrbitGeoElementCameraController",
+        "Point",
+        "Polyline",
+        "Renderer",
+        "SceneProperties",
+        "SceneView",
+        "Viewpoint"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-animate3dsymbols.htm",
+    "relevant_apis": [
+        "Map",
+        "Scene",
+        "Camera",
+        "GlobeCameraController",
+        "Graphic",
+        "GraphicsOverlay",
+        "SurfacePlacement",
+        "MapView",
+        "ModelSceneSymbol",
+        "OrbitGeoElementCameraController",
+        "Point",
+        "Polyline",
+        "Renderer",
+        "SceneProperties",
+        "SceneView",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "Animate3DSymbols.qml",
+        "LabeledSlider.qml"
+    ],
+    "title": "Animate 3D symbols"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to display a scene with an elevation surface",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-basicsceneviewurl.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface"
+    ],
+    "snippets": [
+        "BasicSceneView.qml"
+    ],
+    "title": "Display a scene"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "Changes the appearance of the atmosphere in a scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "atmosphere",
+        "scene",
+        "atmosphere effect",
+        "Scene",
+        "AtmosphereEffect",
+        "SceneView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-change-atmosphere-effect.htm",
+    "relevant_apis": [
+        "Scene",
+        "AtmosphereEffect",
+        "SceneView"
+    ],
+    "snippets": [
+        "ChangeAtmosphereEffect.qml"
+    ],
+    "title": "Change atmosphere effect"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/README.metadata.json
@@ -1,0 +1,32 @@
+{
+    "category": "Scenes",
+    "description": "Control the behavior of the camera in a scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "camera controller",
+        "camera",
+        "3D",
+        "Scene",
+        "Camera",
+        "GlobeCameraController",
+        "OrbitGeoElementCameraController",
+        "OrbitLocationCameraController",
+        "SceneView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-choosecameracontroller.htm",
+    "relevant_apis": [
+        "Scene",
+        "Camera",
+        "GlobeCameraController",
+        "OrbitGeoElementCameraController",
+        "OrbitLocationCameraController",
+        "SceneView"
+    ],
+    "snippets": [
+        "ChooseCameraController.qml"
+    ],
+    "title": "Choose camera controller"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Scenes",
+    "description": "Use a terrain surface with elevation described by a raster file",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "raster",
+        "elevation surface",
+        "RasterElevationSource",
+        "Surface"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-createterrainsurfacefromlocalraster.htm",
+    "relevant_apis": [
+        "RasterElevationSource",
+        "Surface"
+    ],
+    "snippets": [
+        "CreateTerrainSurfaceFromLocalRaster.qml"
+    ],
+    "title": "Create terrain surface from a local raster"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Scenes",
+    "description": "Set the terrain surface with elevation described by a local tile package",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "tile cache",
+        "elevation surface"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-createterrainsurfacefromlocaltilepackage.htm",
+    "relevant_apis": [
+        "ArcGISTiledElevationSource",
+        "Surface"
+    ],
+    "snippets": [
+        "CreateTerrainSurfaceFromLocalTilePackage.qml"
+    ],
+    "title": "Create terrain surface from a local tile package"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/README.metadata.json
@@ -1,0 +1,29 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to display a scene service with a scene layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface",
+        "ArcGISSceneLayer",
+        "Camera"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-displayscenelayer.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "Basemap",
+        "Surface",
+        "ArcGISSceneLayer",
+        "Camera"
+    ],
+    "snippets": [
+        "DisplaySceneLayer.qml"
+    ],
+    "title": "Display a scene layer"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/README.metadata.json
@@ -1,0 +1,42 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to create a graphic using a distance composite scene symbol",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "distance",
+        "Scene",
+        "ArcGISTiledElevationSource",
+        "Camera",
+        "DistanceCompositeSceneSymbol",
+        "DistanceCompositeSceneSymbol.Range",
+        "Graphic",
+        "GraphicsOverlay",
+        "ModelSceneSymbol",
+        "Range",
+        "RangeCollection",
+        "SceneView",
+        "SimpleMarkerSceneSymbol"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-distancecompositesymbolurl.htm",
+    "relevant_apis": [
+        "Scene",
+        "ArcGISTiledElevationSource",
+        "Camera",
+        "DistanceCompositeSceneSymbol",
+        "DistanceCompositeSceneSymbol.Range",
+        "Graphic",
+        "GraphicsOverlay",
+        "ModelSceneSymbol",
+        "Range",
+        "RangeCollection",
+        "SceneView",
+        "SimpleMarkerSceneSymbol"
+    ],
+    "snippets": [
+        "DistanceCompositeSymbol.qml"
+    ],
+    "title": "Distance composite symbol"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to render graphics extruded in the Z direction",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "ArcGISScene",
+        "Graphic",
+        "GraphicsOverlay",
+        "Renderer",
+        "Renderer->SceneProperties"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-extrudegraphics.htm",
+    "relevant_apis": [
+        "ArcGISScene",
+        "Graphic",
+        "GraphicsOverlay",
+        "Renderer",
+        "Renderer->SceneProperties"
+    ],
+    "snippets": [
+        "ExtrudeGraphics.qml"
+    ],
+    "title": "Extrude graphics"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/README.metadata.json
@@ -1,0 +1,28 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to apply extrusion to a renderer on a feature layer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "vertically extrude",
+        "renderer",
+        "3D",
+        "FeatureLayer",
+        "ExtrusionMode",
+        "Renderer",
+        "SceneProperties"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-featurelayerextrusion.htm",
+    "relevant_apis": [
+        "FeatureLayer",
+        "ExtrusionMode",
+        "Renderer",
+        "SceneProperties"
+    ],
+    "snippets": [
+        "FeatureLayerExtrusion.qml"
+    ],
+    "title": "Feature layer extrusion"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Scenes",
+    "description": "Get the elevation for a given point on a surface",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "detect elevation",
+        "ArcGISTiledElevationSource",
+        "BaseSurface",
+        "ElevationSourceListModel",
+        "SceneView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-getelevationatpoint.htm",
+    "relevant_apis": [
+        "ArcGISTiledElevationSource",
+        "BaseSurface",
+        "ElevationSourceListModel",
+        "SceneView"
+    ],
+    "snippets": [
+        "GetElevationAtPoint.qml"
+    ],
+    "title": "Get elevation at point"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Scenes",
+    "description": "Opens and displays a scene from a Mobile Scene Package (specifically, basemaps and features) used to display an offline 3D scene",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "offline",
+        "3D",
+        "mobile scene package",
+        "mspk",
+        "Scene",
+        "MobileScenePackage",
+        "MobileScenePackageUtility",
+        "Scene",
+        "SceneView"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-openmobilescenepackage.htm",
+    "relevant_apis": [
+        "MobileScenePackage",
+        "MobileScenePackageUtility",
+        "Scene",
+        "SceneView"
+    ],
+    "snippets": [
+        "OpenMobileScenePackage.qml"
+    ],
+    "title": "Open mobile scene package"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to open a scene from a Portal item",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "web scene",
+        "portal",
+        "portal item"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-openscene.htm",
+    "relevant_apis": [
+        "Scene",
+        "PortalItem"
+    ],
+    "snippets": [
+        "OpenScene.qml"
+    ],
+    "title": "Open a scene (portal item)"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Scenes",
+    "description": "Fix the camera to point at and rotate around a target object.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "OrbitGeoElementCameraController",
+        "Camera",
+        "SceneView",
+        "3D"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "OrbitGeoElementCameraController"
+    ],
+    "snippets": [
+        "OrbitCameraAroundObject.qml"
+    ],
+    "title": "Orbit the camera around an object"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/README.metadata.json
@@ -1,0 +1,27 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to identify and select GeoElements in an ArcGISSceneLayer",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "geoelement",
+        "identify",
+        "ArcGISSceneLayer",
+        "ArcGISSceneLayer.selectFeature",
+        "SceneView.identifyLayer",
+        "IdentifyLayerResult"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-scenelayerselection.htm",
+    "relevant_apis": [
+        "ArcGISSceneLayer",
+        "ArcGISSceneLayer.selectFeature",
+        "SceneView.identifyLayer",
+        "IdentifyLayerResult"
+    ],
+    "snippets": [
+        "SceneLayerSelection.qml"
+    ],
+    "title": "Scene layer selection"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to update the orientation of a graphic using scene property rotation expressions",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "rotation",
+        "expressions",
+        "attributes",
+        "rotation",
+        "heading",
+        "pitch",
+        "SimpleRenderer",
+        "GraphicsOverlay",
+        "RendererSceneProperties"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-scenepropertiesexpressions.htm",
+    "relevant_apis": [
+        "SimpleRenderer",
+        "GraphicsOverlay",
+        "RendererSceneProperties"
+    ],
+    "snippets": [
+        "ScenePropertiesExpressions.qml"
+    ],
+    "title": "Scene properties expressions"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/README.metadata.json
@@ -1,0 +1,36 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to control the surface placement of a 3D graphic",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "vertical placement",
+        "SceneView",
+        "Scene",
+        "Viewpoint",
+        "Camera",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-surfaceplacement.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Scene",
+        "Viewpoint",
+        "Camera",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSymbol",
+        "TextSymbol",
+        "Point"
+    ],
+    "snippets": [
+        "Surface_Placement.qml"
+    ],
+    "title": "Surface placement"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/README.metadata.json
@@ -1,0 +1,26 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to create symbols with different 3D shapes",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "create 3D shapes",
+        "SceneView",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSceneSymbol"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-scenesymbols.htm",
+    "relevant_apis": [
+        "SceneView",
+        "Graphic",
+        "GraphicsOverlay",
+        "SimpleMarkerSceneSymbol"
+    ],
+    "snippets": [
+        "Symbols.qml"
+    ],
+    "title": "Scene symbols"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/README.metadata.json
@@ -1,0 +1,30 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to keep the viewpoints of multiple map or scene views in sync, so that navigating one view immediately updates the other",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "sync maps",
+        "multiple views",
+        "synchronization",
+        "GeoView",
+        "GeoView::viewpointChanged",
+        "GeoView::isNavigating",
+        "GeoView::currentViewpoint",
+        "GeoView::setViewpoint"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-syncmapviewsceneview.htm",
+    "relevant_apis": [
+        "GeoView",
+        "GeoView::viewpointChanged",
+        "GeoView::isNavigating",
+        "GeoView::currentViewpoint",
+        "GeoView::setViewpoint"
+    ],
+    "snippets": [
+        "SyncMapViewSceneView.qml"
+    ],
+    "title": "Sync map and scene views"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/README.metadata.json
@@ -1,0 +1,24 @@
+{
+    "category": "Scenes",
+    "description": "This sample demonstrates how to exaggerate a scene's terrain surface",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "elevation",
+        "exaggeration",
+        "Surface",
+        "Surface.elevationExaggeration"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-terrainexaggeration.htm",
+    "relevant_apis": [
+        "Surface",
+        "Surface.elevationExaggeration"
+    ],
+    "snippets": [
+        "TerrainExaggeration.qml"
+    ],
+    "title": "Terrain exaggeration"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/README.metadata.json
@@ -1,0 +1,25 @@
+{
+    "category": "Scenes",
+    "description": "See through terrain in a scene and move the camera underground.",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "Surface",
+        "Surface.navigationConstraint",
+        "3D",
+        "subsurface",
+        "underground",
+        "utilities"
+    ],
+    "redirect_from": "",
+    "relevant_apis": [
+        "Surface",
+        "Surface.navigationConstraint"
+    ],
+    "snippets": [
+        "ViewContentBeneathTerrainSurface.qml"
+    ],
+    "title": "View content beneath terrain surface"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/README.metadata.json
@@ -1,0 +1,22 @@
+{
+    "category": "Scenes",
+    "description": "Display local 3D point cloud data",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "3D",
+        "point cloud",
+        "lidar",
+        "PointCloudLayer"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-viewpointclouddataoffline.htm",
+    "relevant_apis": [
+        "PointCloudLayer"
+    ],
+    "snippets": [
+        "ViewPointCloudDataOffline.qml"
+    ],
+    "title": "View point cloud data offline"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/README.metadata.json
@@ -1,0 +1,33 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to geocode an address and show it on the map view",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "search for address",
+        "find address",
+        "geocode",
+        "find location",
+        "LocatorTask",
+        "GeocodeParameters",
+        "GeocodeResult",
+        "GraphicsOverlay",
+        "MapView",
+        "Map"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-findaddress.htm",
+    "relevant_apis": [
+        "LocatorTask",
+        "GeocodeParameters",
+        "GeocodeResult",
+        "GraphicsOverlay",
+        "MapView",
+        "Map"
+    ],
+    "snippets": [
+        "FindAddress.qml"
+    ],
+    "title": "Find address"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/README.metadata.json
@@ -1,0 +1,50 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to use geocode functionality to search for points of interest around a location or within an extent",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "point of interest",
+        "find location",
+        "LocatorTask",
+        "GeocodeParameters",
+        "GeocodeResult",
+        "SuggestListModel",
+        "SuggestParameters",
+        "Callout",
+        "GeometryEngine",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleRenderer",
+        "PictureMarkerSymbol",
+        "LocationDisplay",
+        "IdentifyGraphicsOverlayResult"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-findplace.htm",
+    "relevant_apis": [
+        "LocatorTask",
+        "GeocodeParameters",
+        "GeocodeResult",
+        "SuggestListModel",
+        "SuggestParameters",
+        "Callout",
+        "GeometryEngine",
+        "GraphicsOverlay",
+        "Graphic",
+        "SimpleRenderer",
+        "PictureMarkerSymbol",
+        "LocationDisplay",
+        "IdentifyGraphicsOverlayResult",
+        "MapView",
+        "Map"
+    ],
+    "snippets": [
+        "SearchBox.qml",
+        "SuggestionView.qml",
+        "FindPlace.qml",
+        "SearchButton.qml"
+    ],
+    "title": "Find a place"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/README.metadata.json
@@ -1,0 +1,43 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to geocode and reverse geocode addresses and locations without network connectivity",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "reverse geocode",
+        "offline geocode",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "GraphicsOverlay",
+        "PictureMarkerSymbol",
+        "Callout",
+        "LocatorTask",
+        "GeocodeParameters",
+        "ReverseGeocodeParameters",
+        "GeocodeResult",
+        "SuggestListModel",
+        "Viewpoint"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-offlinegeocode.htm",
+    "relevant_apis": [
+        "Map",
+        "MapView",
+        "ArcGISTiledLayer",
+        "TileCache",
+        "GraphicsOverlay",
+        "PictureMarkerSymbol",
+        "Callout",
+        "LocatorTask",
+        "GeocodeParameters",
+        "ReverseGeocodeParameters",
+        "GeocodeResult",
+        "SuggestListModel",
+        "Viewpoint"
+    ],
+    "snippets": [
+        "OfflineGeocode.qml"
+    ],
+    "title": "Offline geocode"
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/README.metadata.json
@@ -1,0 +1,23 @@
+{
+    "category": "Search",
+    "description": "This sample demonstrates how to search a DictionarySymbolStyle and return the results in a ListView",
+    "ignore": false,
+    "images": [
+        "screenshot.png"
+    ],
+    "keywords": [
+        "military symbology",
+        "symbol dictionary",
+        "DictionarySymbolStyle",
+        "SymbolStyleSearchParameters"
+    ],
+    "redirect_from": "/qt/latest/qml/sample-code/sample-qt-searchdictionarysymbolstyle.htm",
+    "relevant_apis": [
+        "DictionarySymbolStyle",
+        "SymbolStyleSearchParameters"
+    ],
+    "snippets": [
+        "SearchDictionarySymbolStyle.qml"
+    ],
+    "title": "Search dictionary symbol style"
+}


### PR DESCRIPTION
@tdunn please review/merge

The first commit is just a straight copy from master branch over to v.next. I don't think you need to re-review the content for these since you and others already did this - just make sure nothing looks out of place.

The second commit is adding new metadata for new samples we've written since the 100.5 release. Those include the following. I suggest a review of the contents of these since they have not yet been looked at by anyone other than myself. All of these should be for C++ and QML

  - [ ] DisplayInformation/ReadSymbolsFromMobileStyle 
  - [ ] Layers/AddEncExchangeSet
  - [ ] Layers/BrowseWfsLayers
  - [ ] Layers/DisplayWfsLayer
  - [ ] Layers/GroupLayers
  - [ ] Layers/LoadWfsXmlQuery
  - [ ] Layers/ManageOperationalLayers
  - [ ] Maps/GenerateOfflineMapLocalBasemap
  - [ ] Maps/MapReferenceScale
  - [ ] Scenes/AddAPointSceneLayer
  - [ ] Scenes/OrbitCameraAroundObject
  - [ ] Scenes/ViewContentBeneathTerrainSurface

cc @DonMoJa - please make sure to include a metadata.json file with any new samples you are working on. I will have a PR for updating the template shortly.