### PR TITLE
Fix missing commas in metadata json

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/README.metadata.json
@@ -7,7 +7,7 @@
     ],
     "keywords": [
         "FeatureLayer",
-        "WfsFeatureTable"
+        "WfsFeatureTable",
         "WfsFeatureTable.populateFromService",
         "OGC",
         "WFS",
@@ -20,7 +20,7 @@
     "redirect_from": "",
     "relevant_apis": [
         "FeatureLayer",
-        "WfsFeatureTable"
+        "WfsFeatureTable",
         "WfsFeatureTable.populateFromService"
     ],
     "snippets": [


### PR DESCRIPTION
Minor issue in metadata file for the LoadWfsXmlQuery sample. Noticed when running the developers website.