### PR TITLE
Ldanzinger/direct read

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
@@ -58,39 +58,6 @@ ControlAnnotationSublayerVisibility::ControlAnnotationSublayerVisibility(QObject
 {
   const QString dataPath = defaultDataPath() + sampleFileAnno;
 
-  // connect to the Mobile Map Package instance to determine if direct read is supported. Packages
-  // that contain raster data cannot be read directly and must be unpacked first.
-  connect(MobileMapPackage::instance(), &MobileMapPackage::isDirectReadSupportedCompleted,
-          this, [this, dataPath](QUuid, bool supported)
-  {
-    // if direct read is supported, load the package
-    if (supported)
-    {
-      createMapPackage(dataPath);
-    }
-    // otherwise, the package needs to be unpacked
-    else
-    {
-      MobileMapPackage::unpack(dataPath, m_unpackTempDir.path());
-    }
-  });
-
-  // connect to the Mobile Map Package instance to know when the data is unpacked
-  connect(MobileMapPackage::instance(), &MobileMapPackage::unpackCompleted,
-          this, [this](QUuid, bool success)
-  {
-    // if the unpack was successful, load the unpacked package
-    if (success)
-    {
-      createMapPackage(m_unpackTempDir.path());
-    }
-    // log that the upack failed
-    else
-    {
-      qDebug() << "failed to unpack";
-    }
-  });
-
   // connect to the Mobile Map Package instance to know when errors occur
   connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
           [](Error error)
@@ -101,8 +68,8 @@ ControlAnnotationSublayerVisibility::ControlAnnotationSublayerVisibility(QObject
     qDebug() << QString("Error: %1 %2").arg(error.message(), error.additionalMessage());
   });
 
-  // Check if the MMPK can be read directly
-  MobileMapPackage::isDirectReadSupported(dataPath);
+  // Load the MMPK
+  createMapPackage(dataPath);
 }
 
 ControlAnnotationSublayerVisibility::~ControlAnnotationSublayerVisibility() = default;

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h
@@ -31,7 +31,6 @@ class Layer;
 }
 
 #include <QObject>
-#include <QTemporaryDir>
 
 class ControlAnnotationSublayerVisibility : public QObject
 {
@@ -72,7 +71,6 @@ private:
   Esri::ArcGISRuntime::LayerListModel* m_layerListModel = nullptr;
   Esri::ArcGISRuntime::Layer* m_annoLayer = nullptr;
 
-  QTemporaryDir m_unpackTempDir;
   QString m_openLayerText;
   QString m_closedLayerText;
   bool m_visibleAtCurrentExtent;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.cpp
@@ -53,39 +53,6 @@ HonorMobileMapPackageExpiration::HonorMobileMapPackageExpiration(QObject* parent
   QObject(parent),
   m_dataPath(defaultDataPath() + sampleMmpk)
 {
-  // connect to the Mobile Map Package instance to determine if direct read is supported. Packages
-  // that contain raster data cannot be read directly and must be unpacked first.
-  connect(MobileMapPackage::instance(), &MobileMapPackage::isDirectReadSupportedCompleted,
-          this, [this](QUuid, bool supported)
-  {
-    // if direct read is supported, load the package
-    if (supported)
-    {
-      createMapPackage(m_dataPath);
-    }
-    // otherwise, the package needs to be unpacked
-    else
-    {
-      MobileMapPackage::unpack(m_dataPath, m_unpackTempDir.path());
-    }
-  });
-
-  // connect to the Mobile Map Package instance to know when the data is unpacked
-  connect(MobileMapPackage::instance(), &MobileMapPackage::unpackCompleted,
-          this, [this](QUuid, bool success)
-  {
-    // if the unpack was successful, load the unpacked package
-    if (success)
-    {
-      createMapPackage(m_unpackTempDir.path());
-    }
-    // log that the upack failed
-    else
-    {
-      qDebug() << "failed to unpack";
-    }
-  });
-
   // connect to the Mobile Map Package instance to know when errors occur
   connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
           [](Error e)
@@ -124,8 +91,7 @@ void HonorMobileMapPackageExpiration::setMapView(MapQuickView* mapView)
 
   emit mapViewChanged();
 
-  // Check if the MMPK can be read directly
-  MobileMapPackage::isDirectReadSupported(m_dataPath);
+  createMapPackage(m_dataPath);
 }
 
 void HonorMobileMapPackageExpiration::createMapPackage(const QString& path)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.h
@@ -27,7 +27,6 @@ class MobileMapPackage;
 }
 
 #include <QObject>
-#include <QTemporaryDir>
 
 class HonorMobileMapPackageExpiration : public QObject
 {
@@ -54,7 +53,6 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;      
   Esri::ArcGISRuntime::MobileMapPackage* m_mobileMapPackage = nullptr;
 
-  QTemporaryDir m_unpackTempDir;
   QString m_dataPath;
   QString m_expirationString;
 };

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
@@ -55,45 +55,7 @@ const QString sampleFileYellowstone {"/ArcGIS/Runtime/Data/mmpk/Yellowstone.mmpk
 
 OpenMobileMap_MapPackage::OpenMobileMap_MapPackage(QQuickItem* parent) :
   QQuickItem(parent)
-{
-  // create the MMPK data path
-  // data is downloaded automatically by the sample viewer app. Instructions to download
-  // separately are specified in the readme.
-  const QString dataPath = defaultDataPath() + sampleFileYellowstone;
-
-  // connect to the Mobile Map Package instance to determine if direct read is supported. Packages
-  // that contain raster data cannot be read directly and must be unpacked first.
-  connect(MobileMapPackage::instance(), &MobileMapPackage::isDirectReadSupportedCompleted,
-          this, [this, dataPath](QUuid, bool supported)
-  {
-    // if direct read is supported, load the package
-    if (supported)
-    {
-      createMapPackage(dataPath);
-    }
-    // otherwise, the package needs to be unpacked
-    else
-    {
-      MobileMapPackage::unpack(dataPath, m_unpackTempDir.path());
-    }
-  });
-
-  // connect to the Mobile Map Package instance to know when the data is unpacked
-  connect(MobileMapPackage::instance(), &MobileMapPackage::unpackCompleted,
-          this, [this](QUuid, bool success)
-  {
-    // if the unpack was successful, load the unpacked package
-    if (success)
-    {
-      createMapPackage(m_unpackTempDir.path());
-    }
-    // log that the upack failed
-    else
-    {
-      qDebug() << "failed to unpack";
-    }
-  });
-
+{    
   // connect to the Mobile Map Package instance to know when errors occur
   connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
           [](Error e)
@@ -122,11 +84,13 @@ void OpenMobileMap_MapPackage::componentComplete()
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
 
-  // get the data path
+  // create the MMPK data path
+  // data is downloaded automatically by the sample viewer app. Instructions to download
+  // separately are specified in the readme.
   const QString dataPath = defaultDataPath() + sampleFileYellowstone;
 
-  // Check if the MMPK can be read directly
-  MobileMapPackage::isDirectReadSupported(dataPath);
+  // Load the MMPK
+  createMapPackage(dataPath);
 }
 
 // create map package

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.h
@@ -29,7 +29,6 @@ namespace Esri
 }
 
 #include <QQuickItem>
-#include <QTemporaryDir>
 
 class OpenMobileMap_MapPackage : public QQuickItem
 {
@@ -47,7 +46,6 @@ private:
 
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::MobileMapPackage* m_mobileMapPackage = nullptr;
-  QTemporaryDir m_unpackTempDir;
 };
 
 #endif // OPEN_MOBILE_MAP_MAP_PACKAGE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
@@ -22,7 +22,6 @@
 #include "SceneQuickView.h"
 
 #include <QDir>
-#include <QTemporaryDir>
 #include <QtCore/qglobal.h>
 
 #ifdef Q_OS_IOS
@@ -53,44 +52,10 @@ namespace
 OpenMobileScenePackage::OpenMobileScenePackage(QObject* parent /* = nullptr */):
   QObject(parent)
 {  
-
   // create the MSPK data path
   // data is downloaded automatically by the sample viewer app. Instructions to download
   // separately are specified in the readme.
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/mspk/philadelphia.mspk";
-
-  // connect to the Mobile Scene Package instance to determine if direct read is supported. Packages
-  // that contain raster data cannot be read directly and must be unpacked first.
-  connect(MobileScenePackage::instance(), &MobileScenePackage::isDirectReadSupportedCompleted,
-          this, [this, dataPath](QUuid, bool supported)
-  {
-    // if direct read is supported, load the package
-    if (supported)
-    {
-      createScenePackage(dataPath);
-    }
-    // otherwise, the package needs to be unpacked
-    else
-    {
-      MobileScenePackage::unpack(dataPath, m_unpackTempDir.path());
-    }
-  });
-
-  // connect to the Mobile Scene Package instance to know when the data is unpacked
-  connect(MobileScenePackage::instance(), &MobileScenePackage::unpackCompleted,
-          this, [this](QUuid, bool success)
-  {
-    // if the unpack was successful, load the unpacked package
-    if (success)
-    {
-      createScenePackage(m_unpackTempDir.path());
-    }
-    // log that the upack failed
-    else
-    {
-      qDebug() << "failed to unpack";
-    }
-  });
 
   // connect to the Mobile Scene Package instance to know when errors occur
   connect(MobileScenePackage::instance(), &MobileScenePackage::errorOccurred,
@@ -102,8 +67,8 @@ OpenMobileScenePackage::OpenMobileScenePackage(QObject* parent /* = nullptr */):
     qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
   });
 
-  // Check if the MSPK can be read directly
-  MobileScenePackage::isDirectReadSupported(dataPath);
+  // Create the Scene Package
+  createScenePackage(dataPath);
 }
 
 OpenMobileScenePackage::~OpenMobileScenePackage() = default;

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.h
@@ -29,9 +29,6 @@ class MobileScenePackage;
 }
 
 #include <QObject>
-#include <QTemporaryDir>
-
-
 
 class OpenMobileScenePackage : public QObject
 {
@@ -58,8 +55,7 @@ private:
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
-  Esri::ArcGISRuntime::MobileScenePackage* m_scenePackage = nullptr;  
-  QTemporaryDir m_unpackTempDir;
+  Esri::ArcGISRuntime::MobileScenePackage* m_scenePackage = nullptr;   
 };
 
 #endif // OPENMOBILESCENEPACKAGE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/README.md
@@ -8,12 +8,10 @@ Opens and displays a scene from a Mobile Scene Package (.mspk).
 An .mspk file is an archive containing the data (specifically, basemaps and features), used to display an offline 3D scene.
 
 ## How it works
-1. Use `MobileScenePackage::isDirectReadSupported` to check whether the package can be read in the archived form (.mspk) or whether it needs to be unpacked.
-2. If the mobile scene package requires unpacking, call `MobileScenePackage::unpack` and wait for this to complete.
-3. Create a `MobileScenePackage` using the path to the local `.mspk` file or the unpacked directory.
-4. Call `MobileScenePackage::load` and check for any errors.
-5. When the `MobileScenePackage` is loaded, obtain the first `Scene` from the `MobileScenePackage::scenes` list.
-6. Create a `SceneView` and set the scene on the view for display.
+1. Create a `MobileScenePackage` using the path to the local `.mspk` file.
+2. Call `MobileScenePackage::load` and check for any errors.
+3. When the `MobileScenePackage` is loaded, obtain the first `Scene` from the `MobileScenePackage::scenes` list.
+4. Create a `SceneView` and set the scene on the view for display.
 
 ## Relevant API
 - MobileScenePackage

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
@@ -115,8 +115,7 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        // check if direct read is supported before proceeding
-        MobileMapPackageUtility.isDirectReadSupported(mmpk.path);
+        mmpk.load();
     }
 
     MobileMapPackage {
@@ -155,38 +154,6 @@ Rectangle {
 
         onErrorChanged: {
             console.log("Mobile Map Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
-        }
-    }
-
-    // Connect to the various signals on MobileMapPackageUtility
-    // to determine if direct read is supported or if an unpack
-    // is needed.
-    Connections {
-        target: MobileMapPackageUtility
-
-        onIsDirectReadSupportedStatusChanged: {
-            if (MobileMapPackageUtility.isDirectReadSupportedStatus !== Enums.TaskStatusCompleted) {
-                return;
-            }
-
-            // if direct read is supported, load the MobileMapPackage
-            if (MobileMapPackageUtility.isDirectReadSupportedResult) {
-                mmpk.load();
-            } else {
-                // direct read is not supported, and the data must be unpacked
-                MobileMapPackageUtility.unpack(mmpk.path, unpackPath)
-            }
-        }
-
-        onUnpackStatusChanged: {
-            if (MobileMapPackageUtility.unpackStatus !== Enums.TaskStatusCompleted)
-                return;
-
-            // set the new path to the unpacked mobile map package
-            mmpk.path = unpackPath;
-
-            // load the mobile map package
-            mmpk.load();
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
@@ -22,8 +22,7 @@ Rectangle {
     width: 800
     height: 600
 
-    property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/mmpk/"
-    property url unpackPath: System.temporaryFolder.url + "/MmpkQml_%1.mmpk".arg(new Date().getTime().toString())
+    property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/mmpk/"    
     property string expirationDate
     property string expirationTime
     property string expirationMessage

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
@@ -35,8 +35,7 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        // check if direct read is supported before proceeding
-        MobileMapPackageUtility.isDirectReadSupported(mmpk.path);
+        mmpk.load();
     }
 
     // Create a Mobile Map Package and set the path
@@ -75,38 +74,6 @@ Rectangle {
 
         onErrorChanged: {
             console.log("Mobile Map Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
-        }
-    }
-
-    // Connect to the various signals on MobileMapPackageUtility
-    // to determine if direct read is supported or if an unpack
-    // is needed.
-    Connections {
-        target: MobileMapPackageUtility
-
-        onIsDirectReadSupportedStatusChanged: {
-            if (MobileMapPackageUtility.isDirectReadSupportedStatus !== Enums.TaskStatusCompleted) {
-                return;
-            }
-
-            // if direct read is supported, load the MobileMapPackage
-            if (MobileMapPackageUtility.isDirectReadSupportedResult) {
-                mmpk.load();
-            } else {
-                // direct read is not supported, and the data must be unpacked
-                MobileMapPackageUtility.unpack(mmpk.path, unpackPath)
-            }
-        }
-
-        onUnpackStatusChanged: {
-            if (MobileMapPackageUtility.unpackStatus !== Enums.TaskStatusCompleted)
-                return;
-
-            // set the new path to the unpacked mobile map package
-            mmpk.path = unpackPath;
-
-            // load the mobile map package
-            mmpk.load();
         }
     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -24,7 +24,6 @@ Rectangle {
 
     //! [open mobile map package qml api snippet]
     readonly property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/mmpk/"
-    readonly property url unpackPath: System.temporaryFolder.url + "/MmpkQml_%1.mmpk".arg(new Date().getTime().toString())
 
     // Create MapView
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -33,8 +33,7 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        // check if direct read is supported before proceeding
-        MobileMapPackageUtility.isDirectReadSupported(mmpk.path);
+        mmpk.load();
     }
 
     // Create a Mobile Map Package and set the path
@@ -59,38 +58,6 @@ Rectangle {
 
         onErrorChanged: {
             console.log("Mobile Map Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
-        }
-    }
-
-    // Connect to the various signals on MobileMapPackageUtility
-    // to determine if direct read is supported or if an unpack
-    // is needed.
-    Connections {
-        target: MobileMapPackageUtility
-
-        onIsDirectReadSupportedStatusChanged: {
-            if (MobileMapPackageUtility.isDirectReadSupportedStatus !== Enums.TaskStatusCompleted) {
-                return;
-            }
-
-            // if direct read is supported, load the MobileMapPackage
-            if (MobileMapPackageUtility.isDirectReadSupportedResult) {
-                mmpk.load();
-            } else {
-                // direct read is not supported, and the data must be unpacked
-                MobileMapPackageUtility.unpack(mmpk.path, unpackPath)
-            }
-        }
-
-        onUnpackStatusChanged: {
-            if (MobileMapPackageUtility.unpackStatus !== Enums.TaskStatusCompleted)
-                return;
-
-            // set the new path to the unpacked mobile map package
-            mmpk.path = unpackPath;
-
-            // load the mobile map package
-            mmpk.load();
         }
     }
     //! [open mobile map package qml api snippet]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
@@ -25,7 +25,6 @@ Rectangle {
     height: 600
 
     readonly property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/mspk"
-    readonly property url unpackPath: System.temporaryFolder.url + "/MspkQml_%1.mspk".arg(new Date().getTime().toString())
 
     SceneView {
         id: sceneView

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
@@ -33,8 +33,7 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        // check if direct read is supported before proceeding
-        MobileScenePackageUtility.isDirectReadSupported(mspk.path);
+        mspk.load();
     }
 
     MobileScenePackage {
@@ -58,37 +57,6 @@ Rectangle {
 
         onErrorChanged: {
             console.log("Mobile Scene Package Error: %1 %2".arg(error.message).arg(error.additionalMessage));
-        }
-    }
-
-    // Connect to the various signals on MobileScenePackageUtility
-    // to determine if direct read is supported and if an unpack
-    // is needed.
-    Connections {
-        target: MobileScenePackageUtility
-
-        onIsDirectReadSupportedStatusChanged: {
-            if (MobileScenePackageUtility.isDirectReadSupportedStatus !== Enums.TaskStatusCompleted)
-                return;
-
-            // if direct read is supported, load the MobileScenePackage
-            if (MobileScenePackageUtility.isDirectReadSupportedResult) {
-                mspk.load();
-            } else {
-                // direct read is not supported, and the data must be unpacked
-                MobileScenePackageUtility.unpack(mspk.path, unpackPath)
-            }
-        }
-
-        onUnpackStatusChanged: {
-            if (MobileScenePackageUtility.unpackStatus !== Enums.TaskStatusCompleted)
-                return;
-
-            // set the new path to the unpacked mobile scene package
-            mspk.path = unpackPath;
-
-            // load the mspk
-            mspk.load();
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/README.md
@@ -8,7 +8,7 @@ Opens and displays a scene from a Mobile Scene Package (.mspk).
 An .mspk file is an archive containing the data (specifically, basemaps and features), used to display an offline 3D scene.
 
 ## How it works
-1. Create a `MobileScenePackage` using the path to the local `.mspk` file or the unpacked directory.
+1. Create a `MobileScenePackage` using the path to the local `.mspk` file.
 2. Call `MobileScenePackage.load` and check for any errors.
 3. When the `MobileScenePackage` is loaded, obtain the first `Scene` from the `MobileScenePackage.scenes` list.
 4. Create a `SceneView` and set the scene on the view for display.

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/README.md
@@ -8,16 +8,13 @@ Opens and displays a scene from a Mobile Scene Package (.mspk).
 An .mspk file is an archive containing the data (specifically, basemaps and features), used to display an offline 3D scene.
 
 ## How it works
-1. Use `MobileScenePackageUtility.isDirectReadSupported` to check whether the package can be read in the archived form (.mspk) or whether it needs to be unpacked.
-2. If the mobile scene package requires unpacking, call `MobileScenePackageUtility.unpack` and wait for this to complete.
-3. Create a `MobileScenePackage` using the path to the local `.mspk` file or the unpacked directory.
-4. Call `MobileScenePackage.load` and check for any errors.
-5. When the `MobileScenePackage` is loaded, obtain the first `Scene` from the `MobileScenePackage.scenes` list.
-6. Create a `SceneView` and set the scene on the view for display.
+1. Create a `MobileScenePackage` using the path to the local `.mspk` file or the unpacked directory.
+2. Call `MobileScenePackage.load` and check for any errors.
+3. When the `MobileScenePackage` is loaded, obtain the first `Scene` from the `MobileScenePackage.scenes` list.
+4. Create a `SceneView` and set the scene on the view for display.
 
 ## Relevant API
 - MobileScenePackage
-- MobileScenePackageUtility
 - Scene
 - SceneView
 


### PR DESCRIPTION
@DonMoJa please review. The directReadSupported function is deprecated with 100.7 - all MMPK/MSPK data sources can be direct read, so the samples can be greatly simplified to just automatically load/access the package data and no need to check for unpacking