### PR TITLE
Specify Android 21 as the minimum target

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/Android/AndroidManifest.xml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/Android/AndroidManifest.xml
@@ -53,7 +53,7 @@
             <!-- auto screen scale factor -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16"/>
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="21"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.


### PR DESCRIPTION
@GuillaumeBelz please review. This is for 100.8 requirement changes. Merging to v.next.