### PR TITLE
Qt samples - Fix category in metadata json

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "DisplayInformation",
+    "category": "Display information",
     "description": "Use annotation sublayers to gain finer control of annotation layer subtypes.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Display Information",
+    "category": "Display information",
     "description": "Use a custom dictionary style (.stylx) to symbolize features using a variety of attribute values.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "DisplayInformation",
+    "category": "Display information",
     "description": "Use annotation sublayers to gain finer control of annotation layer subtypes.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Display Information",
+    "category": "Display information",
     "description": "Use a custom dictionary style (.stylx) to symbolize features using a variety of attribute values.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
Quick fix to category (should be Display information, not DisplayInformation or Display Informtion)
for these 4 Qt samples.
Thanks!

![image](https://user-images.githubusercontent.com/4381859/72119009-d89a4d00-3307-11ea-9df4-a552b58fdc34.png)
