### PR TITLE
adding defensive code to stop from a crash potentially occurring

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -68,6 +68,7 @@ Item {
                 text: qsTr("Load Selected Layer")
                 Layout.fillWidth: true
                 Layout.margins: 3
+                enabled: layersComboBox.count > 0
                 onClicked: browseWfsLayersSampleModel.createWfsFeatureTable(layersComboBox.currentIndex, !swapAxis);
             }
 
@@ -76,6 +77,7 @@ Item {
                 text: qsTr("Swap Coordinate Order")
                 Layout.margins: 3
                 Layout.fillWidth: true
+                enabled: layersComboBox.count > 0
                 onClicked:{
                     browseWfsLayersSampleModel.createWfsFeatureTable(layersComboBox.currentIndex, swapAxis);
                 }


### PR DESCRIPTION
@jared-esri please review. This prevents the scenario where the load button is clicked before the various layers are retrieved from the service