### PR TITLE
remove qml check and add empty check

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.cpp
@@ -83,6 +83,9 @@ void BrowseWfsLayers::setMapView(MapQuickView* mapView)
 
 void BrowseWfsLayers::createWfsFeatureTable(int index, bool swap)
 {
+  if (m_wfsLayersInfoList.isEmpty())
+    return;
+
   // if swapAxisOrder button is selected swap the axis otherwise reset to default(OgcAxisOrder::NoSwap or false)
   if (swap)
     m_swapAxis = !m_swapAxis;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -68,7 +68,6 @@ Item {
                 text: qsTr("Load Selected Layer")
                 Layout.fillWidth: true
                 Layout.margins: 3
-                enabled: layersComboBox.count > 0
                 onClicked: browseWfsLayersSampleModel.createWfsFeatureTable(layersComboBox.currentIndex, !swapAxis);
             }
 
@@ -77,7 +76,6 @@ Item {
                 text: qsTr("Swap Coordinate Order")
                 Layout.margins: 3
                 Layout.fillWidth: true
-                enabled: layersComboBox.count > 0
                 onClicked:{
                     browseWfsLayersSampleModel.createWfsFeatureTable(layersComboBox.currentIndex, swapAxis);
                 }


### PR DESCRIPTION
@anmacdonald please review. I added a QML check previously to disable the buttons until the service is loaded. This worked in 5.13 but 5.12 seems to have a bug with ComboBox.size not accurately reflecting the model data.

I opted to just move the check to the C++ code so it is safe and won't crash. The other option would be in QML to disable buttons unless the currentText.length > 0, but that seemed less elegant. 