### PR TITLE
Updated Offline Routing sample to be in "Routing" folder

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -1,4 +1,4 @@
-// [WriteFile Name=OfflineRouting, Category=Analysis]
+// [WriteFile Name=OfflineRouting, Category=Routing]
 // [Legal]
 // Copyright 2020 Esri.
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.h
@@ -1,4 +1,4 @@
-// [WriteFile Name=OfflineRouting, Category=Analysis]
+// [WriteFile Name=OfflineRouting, Category=Routing]
 // [Legal]
 // Copyright 2020 Esri.
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -1,4 +1,4 @@
-// [WriteFile Name=OfflineRouting, Category=Analysis]
+// [WriteFile Name=OfflineRouting, Category=Routing]
 // [Legal]
 // Copyright 2020 Esri.
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qrc
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/Samples/Analysis/OfflineRouting">
+    <qresource prefix="/Samples/Routing/OfflineRouting">
         <file alias="sample.json">OfflineRouting.json</file>        
         <file>OfflineRouting.qml</file>
         <file>OfflineRouting.h</file>

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 #endif
 
   // Set the source
-  engine.load(QUrl("qrc:/Samples/Analysis/OfflineRouting/main.qml"));
+  engine.load(QUrl("qrc:/Samples/Routing/OfflineRouting/main.qml"));
 
   return app.exec();
 }


### PR DESCRIPTION
Please review these changes - the sample was showing up in the "Analysis" section of the sample viewer due to a previous error