### PR TITLE
Revert "Merge pull request #983 from Esri/james/macOS_openGL"

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -42,12 +42,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -43,12 +43,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -36,14 +36,7 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("Distance Measurement Analysis - C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
@@ -29,20 +29,14 @@
 
 int main(int argc, char *argv[])
 {
+    
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("Line of Sight Location - C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
@@ -29,20 +29,14 @@
 
 int main(int argc, char *argv[])
 {
+  
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("Viewshed Camera - C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -29,20 +29,14 @@
 
 int main(int argc, char *argv[])
 {
+  
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("Viewshed Geoelement- C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
@@ -29,20 +29,14 @@
 
 int main(int argc, char *argv[])
 {
+  
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("Viewshed Location - C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -28,20 +28,14 @@
 
 int main(int argc, char *argv[])
 {
+  
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("GODictionary Renderer (3D) - C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
@@ -35,14 +35,7 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
     app.setApplicationName(QStringLiteral("DisplayKml - C++"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -35,14 +35,7 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayKmlNetworkLinks - C++"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -35,14 +35,7 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerRenderingModeMap - C++");

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -35,12 +35,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
@@ -41,12 +41,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
@@ -40,12 +40,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -36,12 +36,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -36,12 +36,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -38,12 +38,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -35,15 +35,9 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
     app.setApplicationName("FeatureLayerExtrusion - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -34,12 +34,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
@@ -35,12 +35,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
@@ -35,12 +35,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
@@ -35,12 +35,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
@@ -36,12 +36,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
@@ -35,12 +35,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -33,12 +33,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -34,12 +34,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/main.cpp
@@ -24,12 +24,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -43,12 +43,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -38,12 +38,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -23,17 +23,11 @@
 int main(int argc, char *argv[])
 {
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-  // Linux requires 3.2 OpenGL Context
-  // in order to instance 3D symbols
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setVersion(3, 2);
-  QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
+    // Linux requires 3.2 OpenGL Context
+    // in order to instance 3D symbols
+    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
+    fmt.setVersion(3, 2);
+    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -30,14 +30,7 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayKmlNetworkLinks - QML"));

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
     QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setVersion(3, 2);
     QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-    // macOS requires 4.1 OpenGL Context
-    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-    fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-    fmt.setVersion(4, 1);
-    QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -30,12 +30,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
This reverts commit e853f89f589b6885acd940933652f8e697b4eb8f, reversing
changes made to 1873c34f5ce9c9344214b9bab9e2c62d2adecf46.

@GuillaumeBelz please review. This reverts the previous changes to require OpenGL 4.1 on macOS.