### PR TITLE
Jcaccamo/table ar zero opacity

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
@@ -121,8 +121,6 @@ void DisplayScenesInTabletopAR::setSceneView(SceneQuickView* sceneView)
   // Connect the mouse clicked events.
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, &DisplayScenesInTabletopAR::onMouseClicked);
 
-  m_sceneView->setArcGISScene(m_scene);
-
   emit sceneViewChanged();
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
@@ -78,8 +78,6 @@ DisplayScenesInTabletopAR::DisplayScenesInTabletopAR(QObject* parent /* = nullpt
   m_scene(new Scene(SceneViewTilingScheme::Geographic, this)),
   m_permissionsHelper(new PermissionsHelper(this))
 {
-  // Display an empty scene
-  m_scene->baseSurface()->setOpacity(0.0);
 
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/mspk/philadelphia.mspk";
 
@@ -178,6 +176,9 @@ void DisplayScenesInTabletopAR::onMouseClicked(QMouseEvent& event)
 
   // Set the clipping distance for the scene.
   m_arcGISArView->setClippingDistance(400);
+
+  // Set the surface opacity to 0.
+  m_arcGISArView->sceneView()->arcGISScene()->baseSurface()->setOpacity(0.0f);
 
   // Enable subsurface navigation. This allows you to look at the scene from below.
   m_sceneView->arcGISScene()->baseSurface()->setNavigationConstraint(NavigationConstraint::None);

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
@@ -53,14 +53,19 @@ Rectangle {
                 return;
 
             // Display the scene
-            if (sceneView.scene !== philadelphiaScene)
+            if (sceneView.scene !== philadelphiaScene) {
                 sceneView.scene = philadelphiaScene;
+                sceneView.scene.sceneViewTilingScheme = Enums.SceneViewTilingSchemeGeographic;
+            }
 
             // Set the clipping distance for the scene.
             arcGISArView.clippingDistance = 400;
 
+            // Set the surface opacity to 0.
+            arcGISArView.sceneView.scene.baseSurface.opacity = 0.0;
+
             // Enable subsurface navigation. This allows you to look at the scene from below.
-            sceneView.scene.baseSurface.navigationConstraint = Enums.NavigationConstraintNone;
+            arcGISArView.sceneView.scene.baseSurface.navigationConstraint = Enums.NavigationConstraintNone;
 
             // Set the initial transformation using the point clicked on the screen
             arcGISArView.setInitialTransformation(mouse.x, mouse.y);

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
@@ -48,12 +48,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        // Display an empty scene
-        Scene {
-            sceneViewTilingScheme: Enums.SceneViewTilingSchemeGeographic
-            baseSurface.opacity: 0.0
-        }
-
         onMouseClicked: {
             if (mspk.loadStatus !== Enums.LoadStatusLoaded || !arcGISArView.tracking || !philadelphiaScene)
                 return;


### PR DESCRIPTION
@ldanzinger Please review. Thanks!

During verification kathleen pointed out that the surface beyond the mspk was empty grey tiles. After looking at the other implementations using clipping distance I realized that I had miss-understood the change to the surface opacity and edited the wrong one. So this PR only effectively change the surface opacity of the mspk scene. Made a couple other changes here and there to simplify and keep things consistent. 