### PR TITLE
Fix category for Nearest vertex sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "geometry",
+    "category": "Geometry",
     "description": "Get the vertex of a geometry closest to a point.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
Lower case "geometry" is resulting in a separate TOC category in the web page.