### PR TITLE
remove extra quotation marks

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
@@ -29,7 +29,7 @@
         "UtilityTraceFilter",
         "UtilityTraceParameters",
         "UtilityTraceResult",
-        "UtilityTraceType""
+        "UtilityTraceType"
     ],
     "snippets": [
         "PerformValveIsolationTrace.qml",

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
@@ -29,7 +29,7 @@
         "UtilityTraceFilter",
         "UtilityTraceParameters",
         "UtilityTraceResult",
-        "UtilityTraceType""
+        "UtilityTraceType"
     ],
     "snippets": [
         "PerformValveIsolationTrace.qml"


### PR DESCRIPTION
Removing extra quotation marks from README.metadata for PerformValveIsolationTrace so it's a valid JSON file