### PR TITLE
replace anchors with Layout.fillWidth

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -38,15 +38,11 @@ SearchDictionarySymbolStyleSample {
         }
 
         Column {
+            id: fieldColumn
             visible: !hideSearch.checked
             enabled: visible
-
-            id: fieldColumn
-            anchors {
-                left: parent.left
-                right: parent.right
-                margins: 8
-            }
+            Layout.fillWidth: true
+            Layout.margins: 8
 
             Repeater {
                 id: repeater
@@ -226,10 +222,7 @@ SearchDictionarySymbolStyleSample {
         Rectangle {
             id: bottomRectangle
             Layout.fillHeight: true
-            anchors {
-                left: parent.left
-                right: parent.right
-            }
+            Layout.fillWidth: true
 
             //Listview of results returned from Dictionary
             ListView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -60,11 +60,8 @@ Rectangle {
 
         Column {
             id: fieldColumn
-            anchors {
-                left: parent.left
-                right: parent.right
-                margins: 8
-            }
+            Layout.fillWidth: true
+            Layout.margins: 8
             visible: !hideSearch.checked
             enabled: visible
 
@@ -254,10 +251,7 @@ Rectangle {
         Rectangle {
             id: bottomRectangle
             Layout.fillHeight: true
-            anchors {
-                left: parent.left
-                right: parent.right
-            }
+            Layout.fillWidth: true
 
             //Listview of results returned from Dictionary
             ListView {


### PR DESCRIPTION
Removed inappropriate use of anchors and use Layout.fillWidth instead to remove QML errors. Thanks for taking a look.