### PR TITLE
Use TextSymbol instead of SimpleMarkerSymbol for stops

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -31,7 +31,6 @@
 #include "RouteParameters.h"
 #include "RouteResult.h"
 #include "RouteTask.h"
-#include "SimpleMarkerSymbol.h"
 #include "SimpleLineSymbol.h"
 #include "SimpleRenderer.h"
 #include "Stop.h"
@@ -189,7 +188,7 @@ void OfflineRouting::connectSignals()
         qWarning() << "Outside of routable area.";
         return;
       }
-      SimpleMarkerSymbol* stopLabel = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle::Circle, Qt::red, 20, this);
+      TextSymbol* stopLabel = new TextSymbol(QString::number(m_stopsOverlay->graphics()->size() + 1), Qt::red, 20, HorizontalAlignment::Right, VerticalAlignment::Top, this);
       Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.x(), e.y()), stopLabel, this);
       m_stopsOverlay->graphics()->append(stopGraphic);
       findRoute();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -104,13 +104,6 @@ Rectangle {
             }
         }
 
-        SimpleMarkerSymbol {
-            id: stopLabel
-            style: Enums.SimpleMarkerSymbolStyleCircle
-            color: "red"
-            size: 20
-        }
-
         RouteTask {
             id: routeTask
             url: dataPath + "san_diego/sandiego.geodatabase"
@@ -201,6 +194,10 @@ Rectangle {
                     console.warn("Outside of routable area");
                     return;
                 }
+                const stopLabel = ArcGISRuntimeEnvironment.createObject("TextSymbol", {color: "red",
+                                                                            horizontalAlignment: Enums.HorizontalAlignmentRight,
+                                                                            verticalAlignment: Enums.VerticalAlignmentTop,
+                                                                            size: 20, text: stopsOverlay.graphics.count + 1});
                 const stopGraphic = ArcGISRuntimeEnvironment.createObject("Graphic", {geometry: clickedPoint, symbol: stopLabel});
                 stopsOverlay.graphics.append(stopGraphic);
                 routeTask.findRoute();


### PR DESCRIPTION
Ready for review, thanks! Just a small change in the "Offline routing" sample to mark clicked points with a `TextSymbol` instead of a `SimpleMarkerSymbol` so that the Qt implementation matches the sample design.