### PR TITLE
reorder "snippets" in QML "Edit feature attachments" sample

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/README.metadata.json
@@ -38,8 +38,8 @@
         "AttachmentListModel"
     ],
     "snippets": [
-        "main.qml",
-        "EditFeatureAttachments.qml"
+        "EditFeatureAttachments.qml",
+        "main.qml"
     ],
     "title": "Edit feature attachments"
 }


### PR DESCRIPTION
Thanks for reviewing! 

This change addresses the problem in [common-samples issue #2011](https://devtopia.esri.com/runtime/common-samples/issues/2011) where when the "Edit feature attachments" sample was opened in the QML sample viewer, a new window would open that contained the sample. The ordering of the files in the "snippets" section of the metadata.json was rearranged to fix this issue.