### PR TITLE
remove slide horizontal for just showing the popup. Simplies UI if us…

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.qml
@@ -20,8 +20,6 @@ import Esri.Samples 1.0
 import Esri.ArcGISRuntime.Toolkit.Controls 100.9
 
 Item {
-    property real adjustedX: parent.width - popupStackView.width
-    property real originX: parent.width
 
     // add a mapView component
     MapView {
@@ -34,6 +32,7 @@ Item {
         anchors {
             top: parent.top
             bottom: parent.bottom
+            right: parent.right
         }
         popupManagers: model.popupManagers
 
@@ -48,7 +47,7 @@ Item {
         id: model
         mapView: view
 
-        onPopupManagersChanged: popupStackView.slideHorizontal(originX, adjustedX);
+        onPopupManagersChanged: popupStackView.show();
     }
 
     BusyIndicator {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/ShowPopup.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/ShowPopup.qml
@@ -25,8 +25,6 @@ Rectangle {
     width: 800
     height: 600
 
-    property real adjustedX: rootRectangle.width - popupStackView.width
-    property real originX: rootRectangle.width
     property var popupManagers: []
     property var featureLayer: null
 
@@ -83,9 +81,10 @@ Rectangle {
         anchors {
             top: parent.top
             bottom: parent.bottom
+            right: parent.right
         }
 
-        onPopupManagersChanged: popupStackView.slideHorizontal(originX, adjustedX);
+        onPopupManagersChanged: popupStackView.show();
 
         onVisibleChanged: {
             if (!visible) {


### PR DESCRIPTION
@JamesMBallard Ready for review. Thanks.

Made some changes based on feedback from kathleen. The PopupStackView.slideHorizontal doesn't allow for it to be anchored to the left or right side, otherwise there is no slide animation. As a result if you resize the window once the popup is showed, it does not adjust and just stays where it was last placed which can look odd. So in favor of not complicating the UI further, I just switched to PopupStackView.show which does't have the slide animation but displays the popup all the same and avoids the issue of resizing the window.