### PR TITLE
removing component and changing visibility instead.

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -313,13 +313,12 @@ Rectangle {
                     Row {
                         Layout.alignment: Qt.AlignHCenter
                         Button {
+                            id: hideShowDirectionsBtn
                             text: "Hide directions"
                             onClicked: {
                                 if (text === "Hide directions") {
-                                    directionsView.visible = false;
                                     text = "Show directions";
                                 } else {
-                                    directionsView.visible = true;
                                     text = "Hide directions";
                                 }
                             }
@@ -343,6 +342,7 @@ Rectangle {
                     anchors.fill: parent
                     ListView {
                         id: directionsView
+                        visible: hideShowDirectionsBtn.text === "Show directions" ? true : false
                         anchors {
                             fill: parent
                             margins: 5

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -342,7 +342,7 @@ Rectangle {
                     anchors.fill: parent
                     ListView {
                         id: directionsView
-                        visible: hideShowDirectionsBtn.text === "Show directions" ? true : false
+                        visible: hideShowDirectionsBtn.text === "Hide directions" ? true : false
                         anchors {
                             fill: parent
                             margins: 5

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -316,10 +316,10 @@ Rectangle {
                             text: "Hide directions"
                             onClicked: {
                                 if (text === "Hide directions") {
-                                    directionsView.delegate = blankDelegate;
+                                    directionsView.visible = false;
                                     text = "Show directions";
                                 } else {
-                                    directionsView.delegate = directionDelegate;
+                                    directionsView.visible = true;
                                     text = "Hide directions";
                                 }
                             }
@@ -360,15 +360,6 @@ Rectangle {
                 }
             }
 
-        }
-    }
-
-    Component {
-        id: blankDelegate
-        Rectangle {
-            width: parent.width
-            height: 35
-            color: directionWindow.color
         }
     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -34,6 +34,7 @@ Rectangle {
     property var createAndDisplayRoute
     property var routeParameters: null
     property var directionListModel: null
+    property var myRoute: null
     property bool addStops: true
     property bool addBarriers: false
     property bool findBestSeq: false
@@ -155,12 +156,12 @@ Rectangle {
                     }
 
                     // get the first route and add to graphics overlay
-                    const route = solveRouteResult.routes[0];
-                    const routeGeometry = route.routeGeometry;
+                    myRoute = solveRouteResult.routes[0];
+                    const routeGeometry = myRoute.routeGeometry;
                     const routeGraphic = ArcGISRuntimeEnvironment.createObject("Graphic", {geometry: routeGeometry});
                     routeOverlay.graphics.append(routeGraphic);
 
-                    directionListModel = route.directionManeuvers;
+                    directionListModel = myRoute.directionManeuvers;
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -342,6 +342,7 @@ Rectangle {
                     anchors.fill: parent
                     ListView {
                         id: directionsView
+                        clip: true
                         visible: hideShowDirectionsBtn.text === "Hide directions" ? true : false
                         anchors {
                             fill: parent


### PR DESCRIPTION
@ldanzinger Ready for review. Thanks.

Fixes a problem where swapping out the delegate on a listview is invalidating the global property. Changing workflow to something a bit more readable and resolves the problem.