### PR TITLE
Update mpk destination to mpkx

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.md
@@ -20,7 +20,7 @@ A Local Server and Local Feature Service will automatically be started. Once sta
 2. Wait for server to be in the `LocalServerStatus::Started` state.
     * `LocalServer::statusChanged()` fires whenever the running status of the Local Server changes.
 3. Create and run a local service. For example, to run a `LocalMapService`:
-    * `new LocalFeatureService(Url)` creates a local feature service with the given URL path to the map package (`mpk` file).
+    * `new LocalFeatureService(Url)` creates a local feature service with the given URL path to the map package (`mpkx` file).
     * `LocalFeatureService::start()` starts the service asynchronously.
     * The service is added to the Local Server automatically.
 4. Wait for feature service to be in the `LocalServerStatus::Started` state.

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.metadata.json
@@ -3,7 +3,7 @@
     "dataItems": [
         {
             "itemId": "ab8647d60dfd413babffa815bbb12095",
-            "path": "~/ArcGIS/Runtime/Data/mpk/PointsofInterest.mpkx"
+            "path": "~/ArcGIS/Runtime/Data/mpkx/PointsofInterest.mpkx"
         }
     ],
     "description": "Start a local feature service and display its features in a map.",


### PR DESCRIPTION
The new .mpkx file was still downloading to a /mpk/ directory. This fixes the directory path to /mpkx/. It also fixes line in the README that still referenced a .mpk file. I did a search for all instances of 'mpk' to ensure that I haven't missed anything this time around.