### PR TITLE
Update ListRelatedFeatures.cpp

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -143,7 +143,7 @@ void ListRelatedFeatures::connectSignals()
           // are only interested in the first (and only) feature.
           if (result->iterator().hasNext())
           {
-            ArcGISFeature* arcGISFeature = static_cast<ArcGISFeature*>(result->iterator().next());
+            ArcGISFeature* arcGISFeature = static_cast<ArcGISFeature*>(result->iterator().next(this));
 
             // zoom to the selected feature
             m_mapView->setViewpointGeometry(arcGISFeature->geometry().extent(), 100);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
@@ -57,6 +57,7 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_alaskaNationalParks = nullptr;  
   Esri::ArcGISRuntime::ArcGISFeatureTable* m_alaskaFeatureTable = nullptr;
+  Esri::ArcGISRuntime::ArcGISFeature* m_selectedFeature = nullptr;
   RelatedFeatureListModel* m_relatedFeaturesModel = nullptr;
 };
 


### PR DESCRIPTION
@JamesMBallard 

Fix lifetime of the ArcGISFeature object.
By default, the parent of ArcGISFeature is the FeatureQueryResult object and then the ArcGISFeature object is deleted at the end of the lambda function (with `unique_ptr`). Set the parent to `this` avoid the deletion of the object.