### PR TITLE
Remove redirect_from values check

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -171,7 +171,7 @@ class MetadataFile:
         elif key == "redirect_from":
             return self.check_redirect_from(self.metadata["redirect_from"])
         elif key == "relevant_apis":
-            return self.check_relevant_apis(self.metadata['relevant_apis'])
+            return []
         elif key == "snippets":
             return self.check_snippets(self.metadata["snippets"])
         elif key == "title":

--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -169,9 +169,9 @@ class MetadataFile:
         elif key == "keywords":
             return self.check_keywords(self.metadata['keywords'])
         elif key == "redirect_from":
-            return self.check_redirect_from(self.metadata["redirect_from"])
-        elif key == "relevant_apis":
             return []
+        elif key == "relevant_apis":
+            return self.check_relevant_apis(self.metadata['relevant_apis'])
         elif key == "snippets":
             return self.check_snippets(self.metadata["snippets"])
         elif key == "title":


### PR DESCRIPTION
Metadata JSON files do not need to contain "redirect_from" values. This change modifies the check so it still ensures that "redirect_from" is included among the JSON names, but it does not verify that it contains values. This initial commit is a quick fix; if we want to expand on this, checks could ensure that if redirect values are listed, that they are valid URLs.