### PR TITLE
Update use of qmlRegisterType to remove compiler warning

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -62,7 +62,7 @@ void ListRelatedFeatures::init()
   // Register the map view for QML
   qmlRegisterType<MapQuickView>("Esri.Samples", 1, 0, "MapView");
   qmlRegisterType<ListRelatedFeatures>("Esri.Samples", 1, 0, "ListRelatedFeaturesSample");
-  qmlRegisterType<ViewInsets>();
+  qmlRegisterAnonymousType<ViewInsets>("Esri.Samples", 1);
   qmlRegisterUncreatableType<RelatedFeatureListModel>("Esri.ArcGISRuntimeSamples", 1, 0,
                                                       "RelatedFeatureListModel", "RelatedFeatureListModel is an uncreatable type");
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.h
@@ -21,6 +21,7 @@ namespace Esri
 {
   namespace ArcGISRuntime
   {
+    class ArcGISFeature;
     class ArcGISFeatureTable;
     class FeatureLayer;
     class Map;


### PR DESCRIPTION
Qt issue: https://devtopia.esri.com/runtime/qt-common/issues/5485

This PR updates the "List related features" sample to remove a compiler warning that resulted from `qmlRegisterType` being called without any arguments. It is replaced with `qmlRegisterAnonymousType`. 

Additionally, I encountered build errors due to a class not being forward declared in the header file, so I fixed that as well.

Thanks for reviewing. 