### PR TITLE
Android sample viewer find a place crash bug fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
@@ -66,10 +66,6 @@ void FindPlace::componentComplete()
   // Set map to map view
   m_mapView->setMap(m_map);
 
-  // turn on the location display
-  m_mapView->locationDisplay()->setAutoPanMode(LocationDisplayAutoPanMode::Recenter);
-  m_mapView->locationDisplay()->start();
-
   // create the locator
   createLocator();
 
@@ -78,7 +74,7 @@ void FindPlace::componentComplete()
 
   // initialize callout
   m_mapView->calloutData()->setVisible(false);
-  m_calloutData = m_mapView->calloutData();  
+  m_calloutData = m_mapView->calloutData();
 
   // connect mapview signals
   connectSignals();
@@ -86,6 +82,16 @@ void FindPlace::componentComplete()
 
 void FindPlace::connectSignals()
 {
+  connect(m_mapView, &MapQuickView::drawStatusChanged, this, [this](DrawStatus drawStatus)
+  {
+    if (drawStatus != DrawStatus::Completed || m_mapView->locationDisplay()->isStarted())
+      return;
+
+    // turn on the location display
+    m_mapView->locationDisplay()->setAutoPanMode(LocationDisplayAutoPanMode::Recenter);
+    m_mapView->locationDisplay()->start();
+  });
+
   connect(m_mapView, &MapQuickView::mousePressed, this, [this](QMouseEvent& /*event*/)
   {
     emit hideSuggestionView();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/FindPlace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/FindPlace.qml
@@ -33,18 +33,20 @@ Rectangle {
         id: mapView
         anchors.fill: parent
 
+        onDrawStatusChanged: {
+            if (drawStatus !== Enums.DrawStatusCompleted || mapView.locationDisplay.started)
+                return;
+
+            mapView.locationDisplay.autoPanMode = Enums.LocationDisplayAutoPanModeRecenter;
+            mapView.locationDisplay.start();
+        }
+
         Map {
             Basemap {
                 initStyle: Enums.BasemapStyleArcGISTopographic
             }
 
             // start the location display once the map loads
-            onLoadStatusChanged: {
-                if (loadStatus !== Enums.LoadStatusLoaded)
-                    return;
-
-                mapView.locationDisplay.start();
-            }
         }
 
         // add a graphics overlay to the mapview


### PR DESCRIPTION
Resolves an issue where the Android sample viewer crashes when loading the "Find a place" sample and the user has not already allowed location permissions. Originally the sample would attempt to get the user's location immediately, but this update makes the sample wait until it has finished drawing the map view to get the user's location.