### PR TITLE
Display utility TOC fix

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -176,7 +176,7 @@ Rectangle {
                     SimpleLineSymbol {
                         id: attachmentSymbol
                         style: Enums.SimpleLineSymbolStyleDot
-                        color: "red"
+                        color: "lime"
                         width: 5
 
                         // create swatch image for the legend
@@ -184,7 +184,7 @@ Rectangle {
                             createSwatch();
                         }
                         onSwatchImageChanged: {
-                            connectivityImage.source = swatchImage;
+                            attachmentImage.source = swatchImage;
                         }
                     }
                 }
@@ -195,7 +195,7 @@ Rectangle {
                     SimpleLineSymbol {
                         id: connectivitySymbol
                         style: Enums.SimpleLineSymbolStyleDot
-                        color: "lime"
+                        color: "red"
                         width: 5
 
                         // create swatch image for the legend
@@ -203,7 +203,7 @@ Rectangle {
                             createSwatch();
                         }
                         onSwatchImageChanged: {
-                            attachmentImage.source = swatchImage;
+                            connectivityImage.source = swatchImage;
                         }
                     }
                 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -176,7 +176,7 @@ Rectangle {
                     SimpleLineSymbol {
                         id: attachmentSymbol
                         style: Enums.SimpleLineSymbolStyleDot
-                        color: "lime"
+                        color: "red"
                         width: 5
 
                         // create swatch image for the legend
@@ -195,7 +195,7 @@ Rectangle {
                     SimpleLineSymbol {
                         id: connectivitySymbol
                         style: Enums.SimpleLineSymbolStyleDot
-                        color: "red"
+                        color: "lime"
                         width: 5
 
                         // create swatch image for the legend


### PR DESCRIPTION
The display utility associations samples differed between C++ and QML (see below). This updates the colors in the QML sample to be consistent with those of the C++ sample.

![b2877f00-38c1-11eb-9ea1-edbb471b4e7a](https://user-images.githubusercontent.com/48941951/107555428-047fa600-6b8c-11eb-9ff6-6789f55461de.png)