### PR TITLE
Trace utility network color fix

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -193,14 +193,14 @@ Rectangle {
     SimpleMarkerSymbol {
         id: startingPointSymbol
         style: Enums.SimpleMarkerSymbolStyleCross
-        color: "Green"
+        color: "lime"
         size: 20
     }
 
     SimpleMarkerSymbol {
         id: barrierPointSymbol
         style: Enums.SimpleMarkerSymbolStyleX
-        color: "Red"
+        color: "red"
         size: 20
     }
 


### PR DESCRIPTION
The color of the starting location markers in the Trace Utilities Sample differed between C++ and QML. C++'s Qt::green is equivalent to QML's "lime" color.