### PR TITLE
tan11389/Style check fix

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -590,4 +590,3 @@ def filter_string_for_alpha_numeric(string):
 
 if __name__ == '__main__':
     main()
-

--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -102,18 +102,25 @@ def check_files(file_list):
     exit(total_errors)
 
 def is_file_valid(directory_list: list)-> bool:
-    category_name = directory_list[-3]
+    try:
+        # directory structure is "folder/category/sample_name/file"
+        # If the file is not in a sample category folder, it does not need to be tested
+        category_name = directory_list[-3]
+        if category_name not in folder_names:
+            return False
+    except:
+        return False
+    
     if not os.path.exists("/".join(directory_list)):
         # The file is not present on the disk, either because it never existed or because it was deleted
         # If the file was modified by deleting it, then we do not need to check it
         return False
-    if category_name not in folder_names:
-        # If the file is not in a sample category folder, it does not need to be tested
-        return False
+
     
     if directory_list[-1].lower() not in  ['readme.metadata.json', 'readme.md']:
         # We are not testing files other than the ones above
         return False
+
     return True
 
 class MetadataFile:
@@ -583,3 +590,4 @@ def filter_string_for_alpha_numeric(string):
 
 if __name__ == '__main__':
     main()
+

--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -116,7 +116,6 @@ def is_file_valid(directory_list: list)-> bool:
         # If the file was modified by deleting it, then we do not need to check it
         return False
 
-    
     if directory_list[-1].lower() not in  ['readme.metadata.json', 'readme.md']:
         # We are not testing files other than the ones above
         return False
@@ -440,8 +439,6 @@ class READMEFile:
         errors = []
         return errors
 
-
-
 # ***** Large variable sets (from utilities.common_dicts) *****
 
 folder_names = [
@@ -529,7 +526,6 @@ def read_json_file(file_path):
     with open(file_path) as file:
         data = json.load(file)
     return data
-
 
 def read_readme_file(file_path):
     readme_text = ""


### PR DESCRIPTION
README/metadata checker was returning a false failure on the non-sample README file. This fix guards against list index out of range errors when checking file changes that are not within a sample folder.