### PR TITLE
Tan11389/blend raster sample zero fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -108,9 +108,9 @@ BlendRasterLayerSample {
             }
 
             SpinBox {
-                id: azimuthSlider
+                id: azimuthSpinBox
                 from: 0
-                to: 90
+                to: 360
                 editable: true
                 textFromValue: function(value) {
                     return value.toFixed(0) + "\u00B0";
@@ -172,8 +172,8 @@ BlendRasterLayerSample {
                 Layout.alignment: Qt.AlignHCenter
                 onClicked: {
                     editingRenderer = false;
-                    applyRenderSettings(altSlider.value,
-                                        azimuthSlider.value,
+                    applyRenderSettings(altSpinBox.value,
+                                        azimuthSpinBox.value,
                                         slopeTypeModel.get(slopeCombo.currentIndex).value,
                                         colorRampModel.get(colorCombo.currentIndex).value);
                 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -95,8 +95,11 @@ BlendRasterLayerSample {
                 from: 0
                 to: 90
                 editable: true
-                textFromValue: function(v) {
-                    return v.toFixed(0) + "\u00B0";
+                textFromValue: function(value) {
+                    return value.toFixed(0) + "\u00B0";
+                }
+                valueFromText: function(text) {
+                    return parseInt(text);
                 }
             }
 
@@ -109,8 +112,11 @@ BlendRasterLayerSample {
                 from: 0
                 to: 90
                 editable: true
-                textFromValue: function(v) {
-                    return v.toFixed(0) + "\u00B0";
+                textFromValue: function(value) {
+                    return value.toFixed(0) + "\u00B0";
+                }
+                valueFromText: function(text) {
+                    return parseInt(text);
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -131,7 +131,7 @@ BlendRasterLayerSample {
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel
-               Component.onCompleted : {
+                Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
                         modelWidth = Math.max(modelWidth, metrics.width);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -122,7 +122,7 @@ Rectangle {
             }
 
             SpinBox {
-                id: altSlider
+                id: altSpinBox
                 from: 0
                 to: 90
                 editable: true
@@ -139,9 +139,9 @@ Rectangle {
             }
 
             SpinBox {
-                id: azimuthSlider
+                id: azimuthSpinBox
                 from: 0
-                to: 90
+                to: 360
                 editable: true
                 textFromValue: function(value) {
                     return value.toFixed(0) + "\u00B0";
@@ -216,8 +216,8 @@ Rectangle {
     function applyRendererSettings() {
         const blendRenderer = ArcGISRuntimeEnvironment.createObject("BlendRenderer");
         blendRenderer.elevationRaster = elevationRaster;
-        blendRenderer.altitude = altSlider.value;
-        blendRenderer.azimuth = azimuthSlider.value;
+        blendRenderer.altitude = altSpinBox.value;
+        blendRenderer.azimuth = azimuthSpinBox.value;
         blendRenderer.slopeType = slopeTypeModel.get(slopeCombo.currentIndex).value;
         blendRenderer.colorRamp = getColorRamp();
         blendRenderer.outputBitDepth = 8;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -28,7 +28,6 @@ Rectangle {
 
     readonly property string dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/raster"
     property bool editingRenderer: false
-    property bool useColorRamp: colorCombo.currentText !== "none"
 
     SlopeTypeModel {
         id: slopeTypeModel
@@ -42,10 +41,7 @@ Rectangle {
         anchors.fill: parent
         Map {
             id: map
-            basemap: useColorRamp ?
-                         basemapColorRamp :
-                         basemap
-
+            basemap: basemap
         }
     }
 
@@ -235,6 +231,8 @@ Rectangle {
         blendRenderer.sourceMinValues = [];
 
         applyRenderer(blendRenderer);
+
+        map.basemap = (colorCombo.currentText !== "none") ? basemapColorRamp : basemap;
     }
 
     function applyRenderer(blendRenderer) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -151,7 +151,6 @@ Rectangle {
                 }
             }
 
-
             Text {
                 text: "slope type"
             }
@@ -175,7 +174,6 @@ Rectangle {
                     font: slopeCombo.font
                 }
             }
-
 
             Text {
                 text: "color ramp"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -130,8 +130,11 @@ Rectangle {
                 from: 0
                 to: 90
                 editable: true
-                textFromValue: function(v) {
-                    return v.toFixed(0) + "\u00B0";
+                textFromValue: function(value) {
+                    return value.toFixed(0) + "\u00B0";
+                }
+                valueFromText: function(text) {
+                    return parseInt(text);
                 }
             }
 
@@ -144,8 +147,11 @@ Rectangle {
                 from: 0
                 to: 90
                 editable: true
-                textFromValue: function(v) {
-                    return v.toFixed(0) + "\u00B0";
+                textFromValue: function(value) {
+                    return value.toFixed(0) + "\u00B0";
+                }
+                valueFromText: function(text) {
+                    return parseInt(text);
                 }
             }
 


### PR DESCRIPTION
* Resolves a bug where typed values would revert to zero after the user clicks away. The SpinBox errored when converting text with a degree symbol back into a value. This PR adds an additional function to parse the string into an int.
* Resolves a bug in QML where the basemap changes when the user selects a new color ramp from the ComboBox rather than when the user presses the "Render" button.
* Fixes some formatting