### PR TITLE
Tan11389/scene animate img fix

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -215,8 +215,6 @@ Rectangle {
         id: imageFrameFolder
         url: dataPath
 
-        Component.onCompleted: {
-            fileNamesLength = imageFrameFolder.fileNames().length;
-        }
+        Component.onCompleted: fileNamesLength = imageFrameFolder.fileNames().length;
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -55,7 +55,7 @@ Rectangle {
             }
 
             // set image frame to image overlay
-            imageOverlay.imageFrame = imageFrameList[index]
+            imageOverlay.imageFrame = imageFrameList[index];
 
             // increment the index to keep track of which image to load next
             index++;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -30,6 +30,7 @@ Rectangle {
     readonly property var imageFrameRefreshRate: ["Fast","Medium","Slow"]
     readonly property url dataPath: System.userHomePath +  "/ArcGIS/Runtime/Data/3D/ImageOverlay/PacificSouthWest"
     property int fileNamesLength: 0
+    property var imageFrameList: []
 
     // Create new Timer and set the timeout interval to 68ms
     Timer {
@@ -45,13 +46,16 @@ Rectangle {
                 return;
 
             // create an image frame with the url to the image file and a extent
-            let imageFrame = ArcGISRuntimeEnvironment.createObject("ImageFrame", {
-                                                                       url: dataPath + "/" + imageFrameFolder.fileNames()[index],
-                                                                       extent: imageFrameExtent
-                                                                   });
+            if (imageFrameList.length !== fileNamesLength) {
+                console.log("Creating new ImageFrame at " + index + " of " + fileNamesLength);
+                imageFrameList.push(ArcGISRuntimeEnvironment.createObject("ImageFrame", {
+                                                                              url: dataPath + "/" + imageFrameFolder.fileNames()[index],
+                                                                              extent: imageFrameExtent
+                                                                          }));
+            }
 
             // set image frame to image overlay
-            imageOverlay.imageFrame = imageFrame;
+            imageOverlay.imageFrame = imageFrameList[index]
 
             // increment the index to keep track of which image to load next
             index++;
@@ -211,6 +215,8 @@ Rectangle {
         id: imageFrameFolder
         url: dataPath
 
-        Component.onCompleted: fileNamesLength = imageFrameFolder.fileNames().length;
+        Component.onCompleted: {
+            fileNamesLength = imageFrameFolder.fileNames().length;
+        }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -45,9 +45,9 @@ Rectangle {
             if (fileNamesLength === 0)
                 return;
 
-            // create an image frame with the url to the image file and a extent
+            // Create new ImageFrames from images in the folder
+            // Add them to a list so infinite ImageFrame objects are not created each loop
             if (imageFrameList.length !== fileNamesLength) {
-                console.log("Creating new ImageFrame at " + index + " of " + fileNamesLength);
                 imageFrameList.push(ArcGISRuntimeEnvironment.createObject("ImageFrame", {
                                                                               url: dataPath + "/" + imageFrameFolder.fileNames()[index],
                                                                               extent: imageFrameExtent


### PR DESCRIPTION
Fixes a bug where infinite `ImageFrame` objects were being created in the QML sample. Resolves this by adding the objects to a list and then referencing the list. Once the length of the list is equal to the length of the file list, it stops creating new objects and continues to loop through the completed list.

I do this as each `ImageFrame` is created rather than creating the list upon initialization of the `FileFolder` because the latter delays the app opening for about 3 to 4 seconds (on my machine) while loading the list. Creating the list as each image is created allows for a more seamless user experience.

I verified that the C++ sample is not affected by this logic bug.