### PR TITLE
Rename spinbox id

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -91,7 +91,7 @@ BlendRasterLayerSample {
             }
 
             SpinBox {
-                id: altSlider
+                id: altSpinBox
                 from: 0
                 to: 90
                 editable: true


### PR DESCRIPTION
Renames the altitude SpinBox id in the C++ sample to the correct id. Tested and works as expected now.