### PR TITLE
Tan11389/utility network credentials

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -79,7 +79,7 @@ PerformValveIsolationTrace::PerformValveIsolationTrace(QObject* parent /* = null
   m_map->operationalLayers()->append(distributionLineLayer);
   m_map->operationalLayers()->append(deviceLayer);
 
-  m_utilityNetwork = new UtilityNetwork(featureServiceUrl, m_map, this);
+  m_utilityNetwork = new UtilityNetwork(featureServiceUrl, m_map, m_cred, this);
   connectSignals();
   m_utilityNetwork->load();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -97,7 +97,7 @@ TraceUtilityNetwork::TraceUtilityNetwork(QObject* parent /* = nullptr */):
     m_graphicsOverlay = new GraphicsOverlay(this);
     m_mapView->graphicsOverlays()->append(m_graphicsOverlay);
 
-    m_utilityNetwork = new UtilityNetwork(m_serviceUrl, m_map, this);
+    m_utilityNetwork = new UtilityNetwork(m_serviceUrl, m_map, m_cred, this);
 
     connect(m_utilityNetwork, &UtilityNetwork::errorOccurred, [this](Error e)
     {


### PR DESCRIPTION
Adds credentials to the initialization of Utility Networks - now required by SS7.