### PR TITLE
Removed default lambda captures from samples

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
@@ -119,7 +119,9 @@ void NearestVertex::setupGraphics()
   graphicsOverlay->graphics()->append(nearestVertexGraphic);
 
   // add graphic to clicked location
-  connect(m_mapView, &MapQuickView::mouseClicked, this, [nearestVertexGraphic, nearestCoordinateGraphic, polygonBuilder, clickedLocationGraphic, this](QMouseEvent& e)
+  connect(m_mapView, &MapQuickView::mouseClicked, this,
+          [nearestVertexGraphic, nearestCoordinateGraphic, polygonBuilder, clickedLocationGraphic, this]
+          (QMouseEvent& e)
   {
     const Point clickedLocation = m_mapView->screenToLocation(e.x(), e.y());
     // normalizing the geometry before performing geometric operations

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
@@ -119,7 +119,7 @@ void NearestVertex::setupGraphics()
   graphicsOverlay->graphics()->append(nearestVertexGraphic);
 
   // add graphic to clicked location
-  connect(m_mapView, &MapQuickView::mouseClicked, this, [=](QMouseEvent& e)
+  connect(m_mapView, &MapQuickView::mouseClicked, this, [nearestVertexGraphic, nearestCoordinateGraphic, polygonBuilder, clickedLocationGraphic, this](QMouseEvent& e)
   {
     const Point clickedLocation = m_mapView->screenToLocation(e.x(), e.y());
     // normalizing the geometry before performing geometric operations

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
@@ -203,7 +203,7 @@ void DisplayUtilityAssociations::connectSignals()
     {
 
       // check if the graphics overlay already contains the association
-      const bool uniqueGraphic = std::none_of(graphics->begin(), graphics->end(), [=](const Graphic* graphic)
+      const bool uniqueGraphic = std::none_of(graphics->begin(), graphics->end(), [association](const Graphic* graphic)
       {
         const AttributeListModel* attributes = graphic->attributes();
         return attributes->containsAttribute("GlobalId") && qvariant_cast<QUuid>((*graphic->attributes())["GlobalId"]) == association->globalId();

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/ManageBookmarks.cpp
@@ -58,7 +58,7 @@ ManageBookmarks::ManageBookmarks(QWidget* parent) :
     createInitialBookmarks();
 
     // Connect the combo box signal to lambda for switching between bookmarks
-    connect(m_bookmarkCombo, QOverload<const QString&>::of(&QComboBox::currentTextChanged), [=](const QString& name) {
+    connect(m_bookmarkCombo, QOverload<const QString&>::of(&QComboBox::currentTextChanged), [this](const QString& name) {
         // Use the map of bookmarks created to obtain the viewpoint of a given name
         m_mapView->setViewpoint(m_bookmarks.value(name));
     });


### PR DESCRIPTION
Lambda captures have been removed from the C++ and Widgets samples. These were removed as they can capture more data than necessary, and default captures of 'this' may be deprecated in the future.