### PR TITLE
Refix colors

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -181,7 +181,7 @@ Rectangle {
                     SimpleLineSymbol {
                         id: attachmentSymbol
                         style: Enums.SimpleLineSymbolStyleDot
-                        color: "red"
+                        color: "lime"
                         width: 5
 
                         // create swatch image for the legend
@@ -200,7 +200,7 @@ Rectangle {
                     SimpleLineSymbol {
                         id: connectivitySymbol
                         style: Enums.SimpleLineSymbolStyleDot
-                        color: "lime"
+                        color: "red"
                         width: 5
 
                         // create swatch image for the legend


### PR DESCRIPTION
For whatever reason, the SS7 PR reverted the changes we made to these colors to make them the same as the C++ sample. This reapplies those changes.