### PR TITLE
Fix KML callout

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
@@ -30,7 +30,7 @@
 using namespace Esri::ArcGISRuntime;
 
 namespace  {
-const QUrl datasetUrl("https://www.wpc.ncep.noaa.gov/kml/noaa_chart/WPC_Day1_SigWx.kml");
+const QUrl datasetUrl("https://www.wpc.ncep.noaa.gov/kml/noaa_chart/WPC_Day1_SigWx_latest.kml");
 }
 
 IdentifyKmlFeatures::IdentifyKmlFeatures(QObject* parent /* = nullptr */):
@@ -85,6 +85,11 @@ void IdentifyKmlFeatures::setMapView(MapQuickView* mapView)
     {
       if (KmlPlacemark* placemark = dynamic_cast<KmlPlacemark*>(geoElement))
       {
+        // Google Earth only displays the placemarks with description or extended data. To
+        // match its behavior, add a description placeholder if the data source is empty
+        if (placemark->description().isEmpty())
+          placemark->setDescription("Weather condition");
+
         m_calloutText = placemark->balloonContent();
         m_mapView->calloutData()->setLocation(m_clickedPoint);
         m_mapView->calloutData()->setVisible(true);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -30,7 +30,7 @@ Item {
             id: callout
             calloutData: view.calloutData
             autoAdjustWidth: false
-            calloutWidth: 400
+            calloutWidth: 300
             accessoryButtonHidden: true
             leaderPosition: leaderPositionEnum.Top
             calloutContent: customComponent

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -26,7 +26,7 @@ Rectangle {
 
     property Point clickedPoint: null
     property string calloutText: ""
-    readonly property url layerUrl: "https://www.wpc.ncep.noaa.gov/kml/noaa_chart/WPC_Day1_SigWx.kml"
+    readonly property url layerUrl: "https://www.wpc.ncep.noaa.gov/kml/noaa_chart/WPC_Day1_SigWx_latest.kml"
 
     MapView {
         id: mapView
@@ -36,7 +36,7 @@ Rectangle {
             id: callout
             calloutData: parent.calloutData
             autoAdjustWidth: false
-            calloutWidth: 400
+            calloutWidth: 300
             accessoryButtonHidden: true
             leaderPosition: leaderPositionEnum.Top
             calloutContent: customComponent
@@ -81,6 +81,11 @@ Rectangle {
                     callout.dismiss();
                     return;
                 }
+                // Google Earth only displays the placemarks with description or extended data. To
+                // match its behavior, add a description placeholder if the data source is empty
+                if (!identifyLayerResult.geoElements[0].description)
+                    identifyLayerResult.geoElements[0].description = "Weather condition"
+
                 calloutText = identifyLayerResult.geoElements[0].balloonContent;
                 callout.calloutData.location = clickedPoint;
                 callout.showCallout();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/README.metadata.json
@@ -16,6 +16,7 @@
         "GeoView.identifyLayer(...)",
         "IdentifyLayerResult",
         "KmlLayer",
+        "KmlPlacemark",
         "KmlPlacemark.balloonContent()"
     ],
     "redirect_from": [


### PR DESCRIPTION
## Background
In U11, core introduced a condition to return an empty string for the balloons/KML nodes that doesn't have description or extended data. The data source in the Identify KML features doesn't provide a description for each significant weather condition, thus empty balloons are displayed in the callout.

Before: the popup for any feature in the map is empty
After: the popup should show HTML content

## Fix
If description is absent for a placemark, add a placeholder so that the content of the balloon can be displayed.