### PR TITLE
Tan11389/tpkx update

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
@@ -92,7 +92,7 @@ void EditAndSyncFeatures::componentComplete()
   m_mapView->setWrapAroundMode(WrapAroundMode::Disabled);
 
   // Create a map using a local tile package
-  TileCache* tileCache = new TileCache(m_dataPath + "tpk/SanFrancisco.tpk", this);
+  TileCache* tileCache = new TileCache(m_dataPath + "tpkx/SanFrancisco.tpkx", this);
   ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(tileCache, this);
   Basemap* basemap = new Basemap(tiledLayer, this);
   m_map = new Map(basemap, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.md
@@ -39,7 +39,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[San Francisco Streets TPK](https://www.arcgis.com/home/item.html?id=3f1bbf0ec70b409a975f5c91f363fe7d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk |
+|[San Francisco Streets TPKX](https://www.arcgis.com/home/item.html?id=e4a398afe9a945f3b0f4dca1e4faccb5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Edit data",
     "dataItems": [
         {
-            "itemId": "3f1bbf0ec70b409a975f5c91f363fe7d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk"
+            "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx"
         }
     ],
     "description": "Synchronize offline edits with a feature service.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/GenerateGeodatabase.cpp
@@ -87,7 +87,7 @@ void GenerateGeodatabase::componentComplete()
   m_mapView->setWrapAroundMode(WrapAroundMode::Disabled);
 
   //! [Create a map using a local tile package]
-  TileCache* tileCache = new TileCache(m_dataPath + "tpk/SanFrancisco.tpk", this);
+  TileCache* tileCache = new TileCache(m_dataPath + "tpkx/SanFrancisco.tpkx", this);
   ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(tileCache, this);
   Basemap* basemap = new Basemap(tiledLayer, this);
   m_map = new Map(basemap, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.md
@@ -33,7 +33,7 @@ Read more about how to set up the sample's offline data [here](https://github.co
 
 Link | Local Location
 ---------|-------|
-|[San Francisco Streets TPK](https://www.arcgis.com/home/item.html?id=3f1bbf0ec70b409a975f5c91f363fe7d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk |
+|[San Francisco Streets TPKX](https://www.arcgis.com/home/item.html?id=e4a398afe9a945f3b0f4dca1e4faccb5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx |
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Features",
     "dataItems": [
         {
-            "itemId": "3f1bbf0ec70b409a975f5c91f363fe7d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk"
+            "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx"
         }
     ],
     "description": "Generate a local geodatabase from an online feature service.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.cpp
@@ -98,7 +98,7 @@ void ExportTiles::exportTileCacheFromCorners(double xCorner1, double yCorner1, d
 
     //! [ExportTiles start job]
     // execute the task and obtain the job
-    ExportTileCacheJob* exportJob = m_exportTileCacheTask->exportTileCache(m_parameters, m_tempPath.path() + "/offlinemap.tpk");
+    ExportTileCacheJob* exportJob = m_exportTileCacheTask->exportTileCache(m_parameters, m_tempPath.path() + "/offlinemap.tpkx");
 
     // check if there is a valid job
     if (exportJob)
@@ -122,7 +122,7 @@ void ExportTiles::exportTileCacheFromCorners(double xCorner1, double yCorner1, d
           emit updateStatus("In progress...");
           break;
         case JobStatus::Succeeded:
-          emit updateStatus("Adding TPK...");
+          emit updateStatus("Adding TPKX...");
           emit hideWindow(1500, true);
           displayOutputTileCache(exportJob->result());
           break;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.md
@@ -32,7 +32,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[San Francisco Streets TPK](https://www.arcgis.com/home/item.html?id=3f1bbf0ec70b409a975f5c91f363fe7d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk |
+|[San Francisco Streets TPKX](https://www.arcgis.com/home/item.html?id=e4a398afe9a945f3b0f4dca1e4faccb5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.md
@@ -21,9 +21,9 @@ Launch the app to view the "San Francisco offline tile package" as the basemap.
 
 ## Relevant API
 
-* Map
 * ArcGISTiledLayer
 * Basemap
+* Map
 * TileCache
 
 ## Offline Data

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Layers",
     "dataItems": [
         {
-            "itemId": "3f1bbf0ec70b409a975f5c91f363fe7d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk"
+            "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx"
         }
     ],
     "description": "Load an offline copy of a tiled map service as a basemap.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/TileCacheLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/TileCacheLayer.cpp
@@ -51,7 +51,7 @@ namespace
 TileCacheLayer::TileCacheLayer(QObject* parent /* = nullptr */):
   QObject(parent)
 {
-  const QString fileLocation = QString("%1/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk").arg(defaultDataPath());
+  const QString fileLocation = QString("%1/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx").arg(defaultDataPath());
   TileCache* tileCache = new TileCache(fileLocation, this);
   ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(tileCache, this);
   Basemap* basemap = new Basemap(tiledLayer, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -80,7 +80,7 @@ void LocalServerGeoprocessing::componentComplete()
   // Set map to map view
   m_mapView->setMap(m_map);
 
-  TileCache* tileCache = new TileCache(dataPath + "/tpk/RasterHillshade.tpk", this);
+  TileCache* tileCache = new TileCache(dataPath + "/tpkx/RasterHillshade.tpkx", this);
   m_tiledLayer = new ArcGISTiledLayer(tileCache, this);
   m_map->operationalLayers()->append(m_tiledLayer);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.qml
@@ -82,6 +82,7 @@ LocalServerGeoprocessingSample {
                             verticalCenter: parent.verticalCenter
                             margins: 5
                         }
+                        width: 100
                         text: "200"
                         selectByMouse: true
                         validator: DoubleValidator {bottom: 100; top: 500}

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.md
@@ -60,7 +60,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 Link | Local Location
 ---------|-------|
 |[Contour geoprocessing package](https://www.arcgis.com/home/item.html?id=a680362d6a7447e8afe2b1eb85fcde30)| `<userhome>`/ArcGIS/Runtime/Data/gpkx/Contour.gpkx |
-|[Raster Hillshade TPK](https://www.arcgis.com/home/item.html?id=f7c7b4a30fb9415896ba0d1921fe014b)| `<userhome>`/ArcGIS/Runtime/Data/tpk/RasterHillshade.tpk |
+|[Raster Hillshade TPKX](https://www.arcgis.com/home/item.html?id=3f38e1ae7c5948cc95334ba3a142a4ec)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/RasterHillshade.tpkx |
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.metadata.json
@@ -6,8 +6,8 @@
             "path": "~/ArcGIS/Runtime/Data/gpkx/Contour.gpkx"
         },
         {
-            "itemId": "f7c7b4a30fb9415896ba0d1921fe014b",
-            "path": "~/ArcGIS/Runtime/Data/tpk/RasterHillshade.tpk"
+            "itemId": "3f38e1ae7c5948cc95334ba3a142a4ec",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/RasterHillshade.tpkx"
         }
     ],
     "description": "Create contour lines from local raster data using a local geoprocessing package `.gpkx` and the contour geoprocessing tool.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
@@ -118,7 +118,7 @@ void GenerateOfflineMapLocalBasemap::generateMapByExtent(double xCorner1, double
   const Point corner2 = m_mapView->screenToLocation(xCorner2, yCorner2);
   const Envelope extent = Envelope(corner1, corner2);
   const Envelope mapExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
-  const QString tempPath = m_tempDir.path() + "/OfflineMap.mmpkx";
+  const QString tempPath = m_tempDir.path() + "/OfflineMap.mmpk";
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/tpkx";
 
   // connect to the signal for when the default parameters are generated

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
@@ -119,7 +119,7 @@ void GenerateOfflineMapLocalBasemap::generateMapByExtent(double xCorner1, double
   const Envelope extent = Envelope(corner1, corner2);
   const Envelope mapExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
   const QString tempPath = m_tempDir.path() + "/OfflineMap.mmpk";
-  const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/tpk";
+  const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/tpkx";
 
   // connect to the signal for when the default parameters are generated
   connect(m_offlineMapTask, &OfflineMapTask::createDefaultGenerateOfflineMapParametersCompleted,

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -116,7 +116,7 @@ GenerateOfflineMapLocalBasemapSample {
                 width: parent.width
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.Wrap
-                text: "This web map references a local basemap with the name 'naperville_imagery.tpk'.\nYou can use the basemap already on disk or download the basemap again"
+                text: "This web map references a local basemap with the name 'naperville_imagery.tpkx'.\nYou can use the basemap already on disk or download the basemap again"
             }
 
             Button {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -36,8 +36,8 @@ The author of a web map can support the use of basemaps which are already on a d
 
 ## Relevant API
 
-* GenerateOfflineMapParameters
 * GenerateOfflineMapJob
+* GenerateOfflineMapParameters
 * GenerateOfflineMapResult
 * OfflineMapTask
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -30,7 +30,7 @@ The author of a web map can support the use of basemaps which are already on a d
 ## How it works
 
 1. The sample creates a `PortalItem` object using a web map's ID. This portal item is used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask::createDefaultGenerateOfflineMapParameters`.
-2. If the user chooses to use the basemap on the device, the `GenerateOfflineMapParameters::referenceBasemapDirectory` is set to the absolute path of the directory which contains the .tpk file.
+2. If the user chooses to use the basemap on the device, the `GenerateOfflineMapParameters::referenceBasemapDirectory` is set to the absolute path of the directory which contains the .tpkx file.
 3. A `GenerateOfflineMapJob` is created by calling `OfflineMapTask::generateOfflineMap` passing the parameters and the download location for the offline map.
 4. When the `GenerateOfflineMapJob` is started it will check whether `GenerateOfflineMapParameters::referenceBasemapDirectory` has been set. If this property is set, no online basemap will be downloaded and instead, the mobile map will be created with a reference to the .tpk on the device.
 
@@ -47,7 +47,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[Yellowstone Mobile Map Package](https://www.arcgis.com/home/item.html?id=628e8e3521cf45e9a28a12fe10c02c4d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/naperville_imagery.tpk |
+|[Naperville Imagery Tile Package](https://www.arcgis.com/home/item.html?id=85282f2aaa2844d8935cdb8722e22a93)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/naperville_imagery.tpkx |
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -36,10 +36,10 @@ The author of a web map can support the use of basemaps which are already on a d
 
 ## Relevant API
 
-* OfflineMapTask
 * GenerateOfflineMapParameters
 * GenerateOfflineMapJob
 * GenerateOfflineMapResult
+* OfflineMapTask
 
 ## Offline data
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -32,7 +32,7 @@ The author of a web map can support the use of basemaps which are already on a d
 1. The sample creates a `PortalItem` object using a web map's ID. This portal item is used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask::createDefaultGenerateOfflineMapParameters`.
 2. If the user chooses to use the basemap on the device, the `GenerateOfflineMapParameters::referenceBasemapDirectory` is set to the absolute path of the directory which contains the .tpkx file.
 3. A `GenerateOfflineMapJob` is created by calling `OfflineMapTask::generateOfflineMap` passing the parameters and the download location for the offline map.
-4. When the `GenerateOfflineMapJob` is started it will check whether `GenerateOfflineMapParameters::referenceBasemapDirectory` has been set. If this property is set, no online basemap will be downloaded and instead, the mobile map will be created with a reference to the .tpk on the device.
+4. When the `GenerateOfflineMapJob` is started it will check whether `GenerateOfflineMapParameters::referenceBasemapDirectory` has been set. If this property is set, no online basemap will be downloaded and instead, the mobile map will be created with a reference to the .tpkx on the device.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -21,7 +21,7 @@ The author of a web map can support the use of basemaps which are already on a d
 ## How to use the sample
 
 1. Click on "Generate Offline Map".
-2. You will be prompted to choose whether you wish to download the online basemap or use the "naperville_imagery.tpk" basemap which is already on the device.
+2. You will be prompted to choose whether you wish to download the online basemap or use the "naperville_imagery.tpkx" basemap which is already on the device.
 3. If you choose to download the online basemap, the offline map will be generated with the same (topographic) basemap as the online web map.
 4. To download the Esri basemap, you may be prompted to sign in to ArcGIS.com.
 5. If you choose to use the basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Maps",
     "dataItems": [
         {
-            "itemId": "628e8e3521cf45e9a28a12fe10c02c4d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/naperville_imagery.tpk"
+            "itemId": "85282f2aaa2844d8935cdb8722e22a93",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/naperville_imagery.tpkx"
         }
     ],
     "description": "Use the `OfflineMapTask` to take a web map offline, but instead of downloading an online basemap, use one which is already on the device.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -71,14 +71,14 @@ OfflineRouting::OfflineRouting(QObject* parent /* = nullptr */):
   m_stopsOverlay(new GraphicsOverlay(this)),
   m_routeOverlay(new GraphicsOverlay(this))
 {
-  const QString folderLocation = QString("%1/ArcGIS/Runtime/Data/tpk/san_diego").arg(defaultDataPath());
+  const QString folderLocation = QString("%1/ArcGIS/Runtime/Data/tpkx/san_diego").arg(defaultDataPath());
   if (!QFileInfo::exists(folderLocation))
   {
     qWarning() << "Please download required data.";
     return;
   }
 
-  const QString fileLocation = folderLocation + QString("/streetmap_SD.tpk");
+  const QString fileLocation = folderLocation + QString("/streetmap_SD.tpkx");
   TileCache* tileCache = new TileCache(fileLocation, this);
   ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(tileCache, this);
   Basemap* basemap = new Basemap(tiledLayer, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/README.md
@@ -37,7 +37,7 @@ The data used by this sample is available on [ArcGIS Online](https://arcgisrunti
 
 Link | Local Location
 ---------|-------|
-|[San Diego Streets TPK](https://arcgisruntime.maps.arcgis.com/home/item.html?id=567e14f3420d40c5a206e5c0284cf8fc)| `<userhome>`/ArcGIS/Runtime/Data/tpk/san_diego |
+|[San Diego Streets TPKX](https://arcgisruntime.maps.arcgis.com/home/item.html?id=567e14f3420d40c5a206e5c0284cf8fc)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/san_diego |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/README.metadata.json
@@ -3,7 +3,7 @@
     "dataItems": [
         {
             "itemId": "567e14f3420d40c5a206e5c0284cf8fc",
-            "path": "~/ArcGIS/Runtime/Data/tpk/san_diego/san_diego.zip"
+            "path": "~/ArcGIS/Runtime/Data/tpkx/san_diego/san_diego.zip"
         }
     ],
     "description": "This sample demonstrates how to solve a route on-the-fly using offline data.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.cpp
@@ -61,7 +61,7 @@ CreateTerrainSurfaceFromLocalTilePackage::CreateTerrainSurfaceFromLocalTilePacka
   // create the MontereyElevation data path
   // data is downloaded automatically by the sample viewer app. Instructions to download
   // separately are specified in the readme.
-  const QString montereyTileElevationPath = QString{defaultDataPath() + "/ArcGIS/Runtime/Data/tpk/MontereyElevation.tpk"};
+  const QString montereyTileElevationPath = QString{defaultDataPath() + "/ArcGIS/Runtime/Data/tpkx/MontereyElevation.tpkx"};
 
   // Before attempting to add any layers, check that the file for the elevation source exists at all.
   const bool srcElevationFileExists = QFileInfo::exists(montereyTileElevationPath);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.md
@@ -15,7 +15,7 @@ When loaded, the sample will show a scene with a terrain surface applied. Pan an
 ## How it works
 
 1. Create a `Scene` and add it to a `SceneView`.
-2. Create an `ArcGISTiledElevationSource`  from a local tile package (.tpk)
+2. Create an `ArcGISTiledElevationSource`  from a local tile package (.tpkx)
 3. Add this source to the scene's base surface: `Scene::baseSurface::elevationSources::append(tileElevationSource)`
 
 ## Relevant API

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Scenes",
     "dataItems": [
         {
-            "itemId": "cce37043eb0440c7a5c109cf8aad5500",
-            "path": "~/ArcGIS/Runtime/Data/tpk/MontereyElevation.tpk"
+            "itemId": "52ca74b4ba8042b78b3c653696f34a9c",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/MontereyElevation.tpkx"
         }
     ],
     "description": "Set the terrain surface with elevation described by a local tile package.",

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -90,8 +90,8 @@ void OfflineGeocode::componentComplete()
   m_mapView = findChild<MapQuickView*>("mapView");
   m_mapView->setWrapAroundMode(WrapAroundMode::Disabled);
 
-  // create a tiled layer using a local .tpk file
-  TileCache* tileCache = new TileCache(m_dataPath + "tpk/streetmap_SD.tpk", this);
+  // create a tiled layer using a local .tpkx file
+  TileCache* tileCache = new TileCache(m_dataPath + "tpkx/streetmap_SD.tpkx", this);
   connect(tileCache, &TileCache::errorOccurred, this, &OfflineGeocode::logError);
 
   m_tiledLayer = new ArcGISTiledLayer(tileCache, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.md
@@ -30,7 +30,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[SanDiego tpk File](https://www.arcgis.com/home/item.html?id=7277419732964266b909bf2bae1ddb54)| `<userhome>`/ArcGIS/Runtime/Data/tpk/streetmap_SD.tpk |
+|[SanDiego tpkx File](https://www.arcgis.com/home/item.html?id=22c3083d4fa74e3e9b25adfc9f8c0496)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/streetmap_SD.tpkx |
 |[SanDiego loc Files](https://www.arcgis.com/home/item.html?id=c88c170e18f74740a0e4c660a5ff51c4)| `<userhome>`/ArcGIS/Runtime/Data/Locators/SanDiegoStreetAddress/SanDiego_StreetAddress.loc |
 
 ## Tags

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Search",
     "dataItems": [
         {
-            "itemId": "7277419732964266b909bf2bae1ddb54",
-            "path": "~/ArcGIS/Runtime/Data/tpk/streetmap_SD.tpk"
+            "itemId": "22c3083d4fa74e3e9b25adfc9f8c0496",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/streetmap_SD.tpkx"
         },
         {
             "itemId": "c88c170e18f74740a0e4c660a5ff51c4",

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -45,7 +45,7 @@ Rectangle {
             Basemap {
                 ArcGISTiledLayer {
                     TileCache {
-                        path: dataPath + "tpk/SanFrancisco.tpk"
+                        path: dataPath + "tpkx/SanFrancisco.tpkx"
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/README.md
@@ -39,7 +39,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[San Francisco Streets TPK](https://www.arcgis.com/home/item.html?id=3f1bbf0ec70b409a975f5c91f363fe7d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk |
+|[San Francisco Streets TPKX](https://www.arcgis.com/home/item.html?id=e4a398afe9a945f3b0f4dca1e4faccb5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Edit data",
     "dataItems": [
         {
-            "itemId": "3f1bbf0ec70b409a975f5c91f363fe7d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk"
+            "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx"
         }
     ],
     "description": "Synchronize offline edits with a feature service.",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/GenerateGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/GenerateGeodatabase.qml
@@ -43,7 +43,7 @@ Rectangle {
             Basemap {
                 ArcGISTiledLayer {
                     TileCache {
-                        path: dataPath + "tpk/SanFrancisco.tpk"
+                        path: dataPath + "tpkx/SanFrancisco.tpkx"
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/README.md
@@ -32,7 +32,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[San Francisco Streets TPK](https://www.arcgis.com/home/item.html?id=3f1bbf0ec70b409a975f5c91f363fe7d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk |
+|[San Francisco Streets TPKX](https://www.arcgis.com/home/item.html?id=e4a398afe9a945f3b0f4dca1e4faccb5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx |
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Features",
     "dataItems": [
         {
-            "itemId": "3f1bbf0ec70b409a975f5c91f363fe7d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk"
+            "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx"
         }
     ],
     "description": "Generate a local geodatabase from an online feature service.",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
@@ -24,7 +24,7 @@ Rectangle {
     width: 800
     height: 600
     
-    readonly property url outputTileCache: System.temporaryFolder.url + "/TileCacheQml_%1.tpk".arg(new Date().getTime().toString())
+    readonly property url outputTileCache: System.temporaryFolder.url + "/TileCacheQml_%1.tpkx".arg(new Date().getTime().toString())
     readonly property string tiledServiceUrl: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
     property Envelope tileCacheExtent: null
     property string statusText: ""
@@ -116,7 +116,7 @@ Rectangle {
                 statusText = "In progress...";
                 break;
             case Enums.JobStatusSucceeded:
-                statusText = "Adding TPK...";
+                statusText = "Adding TPKX...";
                 exportWindow.hideWindow(1500);
                 displayOutputTileCache(exportJob.result);
                 break;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.md
@@ -31,7 +31,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[San Francisco Streets TPK](https://www.arcgis.com/home/item.html?id=3f1bbf0ec70b409a975f5c91f363fe7d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk |
+|[San Francisco Streets TPKX](https://www.arcgis.com/home/item.html?id=e4a398afe9a945f3b0f4dca1e4faccb5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.md
@@ -20,14 +20,14 @@ Launch the app to view the "San Francisco offline tile package" as the basemap.
 
 ## Relevant API
 
- - ArcGISTiledLayer
- - Basemap
- - Map
- - TileCache
+* ArcGISTiledLayer
+* Basemap
+* Map
+* TileCache
 
 ## Offline data
 
-Read more about how to set up the sample's offline data [here](http://links.esri.com/ArcGISRuntimeQtSamples#use-offline-data-in-the-samples).
+Read more about how to set up the sample's offline data [here](http://links.esri.com/ArcGISRuntimeQtSamples#use*offline*data*in*the*samples).
 
 Link | Local Location
 ---------|-------|

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.md
@@ -20,10 +20,10 @@ Launch the app to view the "San Francisco offline tile package" as the basemap.
 
 ## Relevant API
 
- * ArcGISTiledLayer
- * Basemap
- * Map
- * TileCache
+ - ArcGISTiledLayer
+ - Basemap
+ - Map
+ - TileCache
 
 ## Offline data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Layers",
     "dataItems": [
         {
-            "itemId": "3f1bbf0ec70b409a975f5c91f363fe7d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/SanFrancisco.tpk"
+            "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/SanFrancisco.tpkx"
         }
     ],
     "description": "Load an offline copy of a tiled map service as a basemap.",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/TileCacheLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/TileCacheLayer.qml
@@ -24,7 +24,7 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/tpk/"
+    readonly property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/tpkx/"
 
     MapView {
         id: mapView
@@ -35,7 +35,7 @@ Rectangle {
             Basemap {
                 ArcGISTiledLayer {
                     tileCache: TileCache {
-                        path: dataPath + "SanFrancisco.tpk"
+                        path: dataPath + "SanFrancisco.tpkx"
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -28,7 +28,7 @@ Rectangle {
     height: 600
 
     readonly property url outputMapPackage: System.temporaryFolder.url + "/OfflineMap_%1.mmpk".arg(new Date().getTime().toString())
-    readonly property url basemapDirectory: System.userHomePath + "/ArcGIS/Runtime/Data/tpk"
+    readonly property url basemapDirectory: System.userHomePath + "/ArcGIS/Runtime/Data/tpkx"
     readonly property string webMapId: "acc027394bc84c2fb04d1ed317aac674"
     property bool useLocalBasemap: false
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -27,8 +27,8 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property url outputMapPackage: System.temporaryFolder.url + "/OfflineMap_%1.mmpk".arg(new Date().getTime().toString())
-    readonly property url basemapDirectory: System.userHomePath + "/ArcGIS/Runtime/Data/tpk"
+    readonly property url outputMapPackage: System.temporaryFolder.url + "/OfflineMap_%1.mmpkx".arg(new Date().getTime().toString())
+    readonly property url basemapDirectory: System.userHomePath + "/ArcGIS/Runtime/Data/tpkx"
     readonly property string webMapId: "acc027394bc84c2fb04d1ed317aac674"
     property bool useLocalBasemap: false
 
@@ -102,8 +102,10 @@ Rectangle {
             // this will prevent new tiles from being generated on the server
             // and will reduce generation and download time/
             if (useLocalBasemap) {
-                // set the path where 'naperville_imagery.tpk' exists
+                // set the path where 'naperville_imagery.tpkx' exists
                 parameters.referenceBasemapDirectory = System.resolvedPath(basemapDirectory);
+                // A default reference basemap filename can be specified by the source portal item's advanced offline options.
+                parameters.referenceBasemapFilename = "naperville_imagery.tpkx";
             }
 
             // Take the map offline
@@ -229,7 +231,7 @@ Rectangle {
                 width: parent.width
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.Wrap
-                text: "This web map references a local basemap with the name 'naperville_imagery.tpk'.\nYou can use the basemap already on disk or download the basemap again"
+                text: "This web map references a local basemap with the name 'naperville_imagery.tpkx'.\nYou can use the basemap already on disk or download the basemap again"
             }
 
             Button {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -27,8 +27,8 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property url outputMapPackage: System.temporaryFolder.url + "/OfflineMap_%1.mmpkx".arg(new Date().getTime().toString())
-    readonly property url basemapDirectory: System.userHomePath + "/ArcGIS/Runtime/Data/tpkx"
+    readonly property url outputMapPackage: System.temporaryFolder.url + "/OfflineMap_%1.mmpk".arg(new Date().getTime().toString())
+    readonly property url basemapDirectory: System.userHomePath + "/ArcGIS/Runtime/Data/tpk"
     readonly property string webMapId: "acc027394bc84c2fb04d1ed317aac674"
     property bool useLocalBasemap: false
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -32,7 +32,7 @@ The author of a web map can support the use of basemaps which are already on a d
 1. The sample creates a `PortalItem` object using a web map's ID. This portal item is used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask.createDefaultGenerateOfflineMapParameters`.
 2. If the user chooses to use the basemap on the device, the `GenerateOfflineMapParameters.referenceBasemapDirectory` is set to the absolute path of the directory which contains the .tpkx file.
 3. A `GenerateOfflineMapJob` is created by calling `OfflineMapTask.generateOfflineMap` passing the parameters and the download location for the offline map.
-4. When the `GenerateOfflineMapJob` is started it will check whether `GenerateOfflineMapParameters.referenceBasemapDirectory` has been set. If this property is set, no online basemap will be downloaded and instead, the mobile map will be created with a reference to the .tpk on the device.
+4. When the `GenerateOfflineMapJob` is started it will check whether `GenerateOfflineMapParameters.referenceBasemapDirectory` has been set. If this property is set, no online basemap will be downloaded and instead, the mobile map will be created with a reference to the .tpkx on the device.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -36,8 +36,8 @@ The author of a web map can support the use of basemaps which are already on a d
 
 ## Relevant API
 
-* GenerateOfflineMapParameters
 * GenerateOfflineMapJob
+* GenerateOfflineMapParameters
 * GenerateOfflineMapResult
 * OfflineMapTask
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -30,7 +30,7 @@ The author of a web map can support the use of basemaps which are already on a d
 ## How it works
 
 1. The sample creates a `PortalItem` object using a web map's ID. This portal item is used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask.createDefaultGenerateOfflineMapParameters`.
-2. If the user chooses to use the basemap on the device, the `GenerateOfflineMapParameters.referenceBasemapDirectory` is set to the absolute path of the directory which contains the .tpk file.
+2. If the user chooses to use the basemap on the device, the `GenerateOfflineMapParameters.referenceBasemapDirectory` is set to the absolute path of the directory which contains the .tpkx file.
 3. A `GenerateOfflineMapJob` is created by calling `OfflineMapTask.generateOfflineMap` passing the parameters and the download location for the offline map.
 4. When the `GenerateOfflineMapJob` is started it will check whether `GenerateOfflineMapParameters.referenceBasemapDirectory` has been set. If this property is set, no online basemap will be downloaded and instead, the mobile map will be created with a reference to the .tpk on the device.
 
@@ -47,7 +47,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[Yellowstone Mobile Map Package](https://www.arcgis.com/home/item.html?id=628e8e3521cf45e9a28a12fe10c02c4d)| `<userhome>`/ArcGIS/Runtime/Data/tpk/naperville_imagery.tpk |
+|[Naperville Imagery Tile Package](https://www.arcgis.com/home/item.html?id=85282f2aaa2844d8935cdb8722e22a93)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/naperville_imagery.tpkx |
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -36,10 +36,10 @@ The author of a web map can support the use of basemaps which are already on a d
 
 ## Relevant API
 
-* OfflineMapTask
 * GenerateOfflineMapParameters
 * GenerateOfflineMapJob
 * GenerateOfflineMapResult
+* OfflineMapTask
 
 ## Offline data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -21,7 +21,7 @@ The author of a web map can support the use of basemaps which are already on a d
 ## How to use the sample
 
 1. Click on "Generate Offline Map".
-2. You will be prompted to choose whether you wish to download the online basemap or use the "naperville_imagery.tpk" basemap which is already on the device.
+2. You will be prompted to choose whether you wish to download the online basemap or use the "naperville_imagery.tpkx" basemap which is already on the device.
 3. If you choose to download the online basemap, the offline map will be generated with the same (topographic) basemap as the online web map.
 4. To download the Esri basemap, you may be prompted to sign in to ArcGIS.com.
 5. If you choose to use the basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Maps",
     "dataItems": [
         {
-            "itemId": "628e8e3521cf45e9a28a12fe10c02c4d",
-            "path": "~/ArcGIS/Runtime/Data/tpk/naperville_imagery.tpk"
+            "itemId": "85282f2aaa2844d8935cdb8722e22a93",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/naperville_imagery.tpkx"
         }
     ],
     "description": "Use the OfflineMapTask to take a web map offline, but instead of downloading an online basemap, use one which is already on the device.",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -27,7 +27,7 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/tpk/"
+    readonly property url dataPath: System.userHomePath + "/ArcGIS/Runtime/Data/tpkx/"
     readonly property url pinUrl: "qrc:/Samples/Routing/OfflineRouting/orange_symbol.png"
     property var findRoute;
     property Graphic selectedGraphic: null;
@@ -65,7 +65,7 @@ Rectangle {
             Basemap {
                 ArcGISTiledLayer {
                     TileCache {
-                        path: dataPath + "san_diego/streetmap_SD.tpk"
+                        path: dataPath + "san_diego/streetmap_SD.tpkx"
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.md
@@ -4,6 +4,10 @@ This sample demonstrates how to solve a route on-the-fly using offline data.
 
 ![](screenshot.png)
 
+## Use case
+
+You can use an offline network to enable routing in disconnected scenarios. For example, you could provide offline location capabilities to field workers repairing critical infrastructure in a disaster when network availability is limited.
+
 ## How to use the sample
 
 Click near a road to start adding a stop to the route, click again to place it on the map. A number graphic will show its order in the route. After adding at least 2 stops, a route will display. Choose "Fastest" or "Shortest" to control how the route is optimized. To move a stop, click on the graphic, and while continuing to press on the graphic, move the mouse to reposition. Release the mouse to set the new position. The route will update on-the-fly while moving stops. The green box marks the boundary of the route geodatabase.
@@ -41,4 +45,4 @@ This sample uses a pre-packaged sample dataset consisting of a geodatabase with 
 
 ## Tags
 
-connectivity, disconnected, fastest, locator, navigation, network analysis, offline, routing, routing, shortest, turn-by-turn
+connectivity, disconnected, fastest, locator, navigation, network analysis, offline, routing, shortest, turn-by-turn

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.md
@@ -33,7 +33,7 @@ The data used by this sample is available on [ArcGIS Online](https://arcgisrunti
 
 Link | Local Location
 ---------|-------|
-|[San Diego Streets TPK](https://arcgisruntime.maps.arcgis.com/home/item.html?id=567e14f3420d40c5a206e5c0284cf8fc)| `<userhome>`/ArcGIS/Runtime/Data/tpk/san_diego |
+|[San Diego Streets TPKX](https://arcgisruntime.maps.arcgis.com/home/item.html?id=567e14f3420d40c5a206e5c0284cf8fc)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/san_diego |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.metadata.json
@@ -3,7 +3,7 @@
     "dataItems": [
         {
             "itemId": "567e14f3420d40c5a206e5c0284cf8fc",
-            "path": "~/ArcGIS/Runtime/Data/tpk/san_diego/san_diego.zip"
+            "path": "~/ArcGIS/Runtime/Data/tpkx/san_diego/san_diego.zip"
         }
     ],
     "description": "This sample demonstrates how to solve a route on-the-fly using offline data.",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/README.metadata.json
@@ -20,7 +20,6 @@
         "network analysis",
         "offline",
         "routing",
-        "routing",
         "shortest",
         "turn-by-turn",
         "RouteParameters",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
@@ -24,7 +24,7 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string montereyTpkElevationPath: System.userHomePath + "/ArcGIS/Runtime/Data/tpk/MontereyElevation.tpk"
+    readonly property string montereyTpkElevationPath: System.userHomePath + "/ArcGIS/Runtime/Data/tpkx/MontereyElevation.tpkx"
 
     SceneView {
         id: sceneView

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.md
@@ -15,7 +15,7 @@ When loaded, the sample will show a scene with a terrain surface applied. Pan an
 ## How it works
 
 1. Create a `Scene` and add it to a `SceneView`.
-2. Create an `ArcGISTiledElevationSource` from a local tile package (.tpk) by setting the url to the local file.
+2. Create an `ArcGISTiledElevationSource` from a local tile package (.tpkx) by setting the url to the local file.
 3. Add the tiled elevation source to the scene's base surface.
 
 ## Relevant API

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Scenes",
     "dataItems": [
         {
-            "itemId": "cce37043eb0440c7a5c109cf8aad5500",
-            "path": "~/ArcGIS/Runtime/Data/tpk/MontereyElevation.tpk"
+            "itemId": "52ca74b4ba8042b78b3c653696f34a9c",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/MontereyElevation.tpkx"
         }
     ],
     "description": "Set the terrain surface with elevation described by a local tile package.",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.qml
@@ -49,7 +49,7 @@ Rectangle {
             Basemap {
                 ArcGISTiledLayer {
                     TileCache {
-                        path: dataPath + "/tpk/streetmap_SD.tpk"
+                        path: dataPath + "/tpkx/streetmap_SD.tpkx"
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/README.md
@@ -30,7 +30,7 @@ Read more about how to set up the sample's offline data [here](http://links.esri
 
 Link | Local Location
 ---------|-------|
-|[SanDiego tpk File](https://www.arcgis.com/home/item.html?id=7277419732964266b909bf2bae1ddb54)| `<userhome>`/ArcGIS/Runtime/Data/tpk/streetmap_SD.tpk |
+|[SanDiego tpkx file](https://www.arcgis.com/home/item.html?id=22c3083d4fa74e3e9b25adfc9f8c0496)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/streetmap_SD.tpkx |
 |[SanDiego loc Files](https://www.arcgis.com/home/item.html?id=c88c170e18f74740a0e4c660a5ff51c4)| `<userhome>`/ArcGIS/Runtime/Data/Locators/SanDiegoStreetAddress/SanDiego_StreetAddress.loc |
 
 ## Tags

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/README.metadata.json
@@ -2,8 +2,8 @@
     "category": "Search",
     "dataItems": [
         {
-            "itemId": "7277419732964266b909bf2bae1ddb54",
-            "path": "~/ArcGIS/Runtime/Data/tpk/streetmap_SD.tpk"
+            "itemId": "22c3083d4fa74e3e9b25adfc9f8c0496",
+            "path": "~/ArcGIS/Runtime/Data/tpkx/streetmap_SD.tpkx"
         },
         {
             "itemId": "c88c170e18f74740a0e4c660a5ff51c4",


### PR DESCRIPTION
Updates our tile packages to use the pro version. The new tile packages are on the Runtime AGOL portal. All the affected samples work when building the sample viewer.