### PR TITLE
Tan11389/set api key on basemap

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
@@ -34,24 +34,6 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeBasemap - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QStringLiteral("");
-  if (apiKey.isEmpty())
-  {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-  }
-  else
-  {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-  }
-
   // Initialize the sample
   ChangeBasemap::init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
@@ -25,8 +25,11 @@
 #include "Basemap.h"
 #include "ArcGISMapImageLayer.h"
 #include "Portal.h"
+#include "ArcGISRuntimeEnvironment.h"
 
 using namespace Esri::ArcGISRuntime;
+
+QString g_apiKey;
 
 CreateAndSaveMap::CreateAndSaveMap(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent)
@@ -98,6 +101,8 @@ void CreateAndSaveMap::createMap(const QString& basemap, const QStringList& oper
 
     const QString itemId = m_map->item()->itemId();
     emit saveMapCompleted(success, itemId);
+
+    ArcGISRuntimeEnvironment::setApiKey(g_apiKey);
   });
 
   // Handle Map error signal
@@ -135,6 +140,9 @@ void CreateAndSaveMap::saveMap(const QString& title, const QString& tags, const 
   constexpr bool forceSave = false;
   const PortalFolder folder;
   const QByteArray thumbnail;
+
+  g_apiKey = ArcGISRuntimeEnvironment::apiKey();
+  ArcGISRuntimeEnvironment::setApiKey("");
 
   // save the map
   m_map->saveAs(m_portal, title, tagsList, forceSave, folder, description, thumbnail);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
@@ -29,11 +29,13 @@
 
 using namespace Esri::ArcGISRuntime;
 
-QString g_apiKey;
-
 CreateAndSaveMap::CreateAndSaveMap(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent)
 {
+  // We store and unset the API key from the ArcGISRuntimeEnvironment here to ensure this sample works within the Qt Sample Viewer.
+  // In a standalone app, the API key can be set directly on the basemaps and never onto the Runtime environment.
+  m_apiKey = ArcGISRuntimeEnvironment::apiKey();
+  ArcGISRuntimeEnvironment::setApiKey("");
 }
 
 void CreateAndSaveMap::init()
@@ -75,6 +77,8 @@ void CreateAndSaveMap::createMap(const QString& basemap, const QStringList& oper
   else if (basemap == "Oceans")
     selectedBasemap = new Basemap(BasemapStyle::ArcGISOceans, this);
 
+  selectedBasemap->setApiKey(m_apiKey);
+
   // Create the Map with the basemap
   m_map = new Map(selectedBasemap, this);
 
@@ -101,8 +105,6 @@ void CreateAndSaveMap::createMap(const QString& basemap, const QStringList& oper
 
     const QString itemId = m_map->item()->itemId();
     emit saveMapCompleted(success, itemId);
-
-    ArcGISRuntimeEnvironment::setApiKey(g_apiKey);
   });
 
   // Handle Map error signal
@@ -140,9 +142,6 @@ void CreateAndSaveMap::saveMap(const QString& title, const QString& tags, const 
   constexpr bool forceSave = false;
   const PortalFolder folder;
   const QByteArray thumbnail;
-
-  g_apiKey = ArcGISRuntimeEnvironment::apiKey();
-  ArcGISRuntimeEnvironment::setApiKey("");
 
   // save the map
   m_map->saveAs(m_portal, title, tagsList, forceSave, folder, description, thumbnail);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.h
@@ -51,6 +51,7 @@ private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::Portal* m_portal = nullptr;
+  QString m_apiKey;
 };
 
 #endif // CREATEANDSAVEMAP_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.md
@@ -23,9 +23,9 @@ Maps can be created programatically in code and then serialized and saved as an 
 3. Once the user is authenticated, `Map::saveAs` is called and a new `Map` is saved with the specified title, tags, and folder.
 
 ## Relevant API
-- Map
-- Map::saveAs
-- Portal
+* Map
+* Map::saveAs
+* Portal
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.md
@@ -27,6 +27,10 @@ Maps can be created programatically in code and then serialized and saved as an 
 - Map::saveAs
 - Portal
 
+## Additional information
+
+In this sample, an API key is set directly on `Basemap` objects rather than on the whole app using the `ArcGISRuntimeEnvironment` class. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `BasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can set the organization's API key on the basemap, and log in to their own account when challenged. The individual can then save the final map to their own ArcGIS Online account.
+
 ## Tags
 
 ArcGIS Online, ArcGIS Pro, portal, publish, share, web map

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
@@ -35,24 +35,6 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("CreateAndSaveMap - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QStringLiteral("");
-  if (apiKey.isEmpty())
-  {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-  }
-  else
-  {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-  }
-
   // Initialize the sample
   CreateAndSaveMap::init();
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
@@ -18,6 +18,7 @@
 #include <QQmlEngine>
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
+#include "ArcGISRuntimeEnvironment.h"
 
 #ifdef Q_OS_WIN
 #include <Windows.h>
@@ -33,6 +34,24 @@ int main(int argc, char *argv[])
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName("CreateAndSaveMap - C++");
+
+  // Use of Esri location services, including basemaps and geocoding,
+  // requires authentication using either an ArcGIS identity or an API Key.
+  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
+  //    organization in ArcGIS Online or ArcGIS Enterprise.
+  // 2. API key: A permanent key that gives your application access to Esri
+  //    location services. Visit your ArcGIS Developers Dashboard create a new
+  //    API keys or access an existing API key.
+  const QString apiKey = QStringLiteral("");
+  if (apiKey.isEmpty())
+  {
+      qWarning() << "Use of Esri location services, including basemaps, requires"
+                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+  }
 
   // Initialize the sample
   CreateAndSaveMap::init();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -195,7 +195,7 @@ Rectangle {
     Component.onCompleted: {
         // We store and unset the API key from the ArcGISRuntimeEnvironment here to ensure this sample works within the Qt Sample Viewer.
         // In a standalone app, the API key can be set directly on the basemaps and never onto the Runtime environment.
-        apiKey = "AAPKc25504c4ceaa494b9d161113dab3fc38KIAA-QZy8lNVpp3K2rqUAgZGnaKWXKzXFzONkenePYcPyEnPzWmqk6vLxkBpx5sI"; //ArcGISRuntimeEnvironment.apiKey;
+        apiKey = ArcGISRuntimeEnvironment.apiKey;
         ArcGISRuntimeEnvironment.apiKey = "";
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -25,6 +25,9 @@ Rectangle {
     width: 800
     height: 600
 
+    // We manually track the Runtime Environment API key here to control which assets use the API key and which use the given named user credentials.
+    property var apiKey: ""
+
     StackView {
         id: stackView
         anchors.fill: parent
@@ -119,7 +122,6 @@ Rectangle {
         }
     }
 
-
     // Create Portal object that requires sign in
     Portal {
         id: portal
@@ -151,6 +153,8 @@ Rectangle {
             selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapTopographic");
         else if (basemap === "Oceans")
             selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapOceans");
+
+        selectedBasemap.apiKey = apiKey;
 
         // Create the Map with the basemap
         const map = ArcGISRuntimeEnvironment.createObject("Map", { basemap: selectedBasemap }, mapView);
@@ -186,5 +190,12 @@ Rectangle {
 
         // Return the Map
         return map;
+    }
+
+    Component.onCompleted: {
+        // We store and unset the API key from the ArcGISRuntimeEnvironment here to ensure this sample works within the Qt Sample Viewer.
+        // In a standalone app, the API key can be set directly on the basemaps and never onto the Runtime environment.
+        apiKey = "AAPKc25504c4ceaa494b9d161113dab3fc38KIAA-QZy8lNVpp3K2rqUAgZGnaKWXKzXFzONkenePYcPyEnPzWmqk6vLxkBpx5sI"; //ArcGISRuntimeEnvironment.apiKey;
+        ArcGISRuntimeEnvironment.apiKey = "";
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/README.md
@@ -23,9 +23,9 @@ Maps can be created programmatically in code and then serialized and saved as an
 3. Once the user is authenticated, `Map.saveAs` is called and a new `Map` is saved with the specified title, tags, and folder.
 
 ## Relevant API
-- Map
-- Map.saveAs
-- Portal
+* Map
+* Map.saveAs
+* Portal
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/README.md
@@ -27,6 +27,10 @@ Maps can be created programmatically in code and then serialized and saved as an
 - Map.saveAs
 - Portal
 
+## Additional information
+
+In this sample, an API key is set directly on `Basemap` objects rather than on the whole app using the `ArcGISRuntimeEnvironment` class. This is useful in a scenario where an individual developer is part of an organization within ArcGIS Online that uses an API key to access a range of `BasemapStyle`s. In the case that an individual member of the organization wants to save a map locally to their account, and not that of the organization, they can set the organization's API key on the basemap, and log in to their own account when challenged. The individual can then save the final map to their own ArcGIS Online account.
+
 ## Tags
 
 ArcGIS Online, ArcGIS Pro, portal, publish, share, web map


### PR DESCRIPTION
Demonstrates how a user can use both an API key and named user credentials to control which portals and resources are consumed.