### PR TITLE
Tan11389/create load report qml fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -29,18 +29,16 @@ Item {
         id: sampleModel
     }
 
-    Rectangle {
+    ScrollView {
         id: rectangle
-        anchors.horizontalCenter: parent.horizontalCenter
-        width: grid.width
-        height: contents.height
-
+        anchors.centerIn: parent
+        width: children.width
+        height: parent.height
 
         Column {
             id: contents
-            anchors.fill: parent
-            padding: 10
-            spacing: 25
+            spacing: 10
+            padding: 20
 
             Row {
                 ButtonGroup {
@@ -52,7 +50,6 @@ Item {
                 GridLayout {
                     id: grid
                     rows: phases.length + 1
-                    rowSpacing: 5
                     flow: GridLayout.TopToBottom
 
                     CheckBox { id: parentBox; checkState: checkBoxes.checkState }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -37,8 +37,8 @@ Item {
 
         Column {
             id: contents
-            spacing: 10
             padding: 20
+            spacing: 10
 
             Row {
                 ButtonGroup {

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -120,7 +120,7 @@ Item {
                             break;
                         case CreateLoadReportSample.SampleReady: // SampleReady
                             if (checkBoxes.checkState === 0 && !reportHasRun) {
-                                "Select phases to run the load report with";
+                                "Select phases to include in the load report";
                             } else {
                                 "Tap the \"Run Report\" button to create the load report";
                             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -341,7 +341,7 @@ Rectangle {
 
                         case CreateLoadReport.SampleStatus.Ready:
                             if (checkBoxes.checkState === 0 && !reportHasRun) {
-                                "Select phases to run the load report with";
+                                "Select phases to include in the load report";
                             } else if (checkBoxes.checkState === 0 && reportHasRun) {
                                 "Tap the \"Reset\" button to reset the load report";
                             } else {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -244,8 +244,8 @@ Rectangle {
 
         Column {
             id: contents
-            spacing: 10
             padding: 20
+            spacing: 10
 
             Row {
                 ButtonGroup {
@@ -257,7 +257,6 @@ Rectangle {
                 GridLayout {
                     id: grid
                     rows: phaseNames.length + 1
-                    rowSpacing: 5
                     flow: GridLayout.TopToBottom
 
                     CheckBox { id: parentBox; checkState: checkBoxes.checkState }

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -236,17 +236,16 @@ Rectangle {
 
     // Load Report UI
 
-    Rectangle {
+    ScrollView {
         id: rectangle
-        anchors.horizontalCenter: parent.horizontalCenter
-        width: grid.width
-        height: contents.height
+        anchors.centerIn: parent
+        width: children.width
+        height: parent.height
 
         Column {
             id: contents
-            anchors.fill: parent
-            padding: 10
-            spacing: 25
+            spacing: 10
+            padding: 20
 
             Row {
                 ButtonGroup {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -29,7 +29,7 @@ Rectangle {
     property var utilityTier: null
     property var startingLocation: null
     property var phasesCurrentAttr: null
-    property var phaseCodedValuesList: []
+    property var phaseCodedValuesList: null
     property var baseCondition: null
 
     property var networkSourceName: "Electric Distribution Device"
@@ -214,7 +214,12 @@ Rectangle {
         phasesCurrentAttr = utilityNetwork.definition.networkAttribute(phasesNetworkAttributeName);
 
         if (phasesCurrentAttr.domain.domainType === Enums.DomainTypeCodedValueDomain) {
-            return phasesCurrentAttr.domain.codedValues;
+            let codedValues = [];
+            for (let i = 0; i < phasesCurrentAttr.domain.codedValues.length; i++) {
+                codedValues.push(phasesCurrentAttr.domain.codedValues[i]);
+            }
+
+            return codedValues;
         }
     }
 
@@ -301,19 +306,20 @@ Rectangle {
                         let runPhases = [];
                         phaseNames.forEach((phase) => {
                                                if (selectedPhases[phase])
-                                                    runPhases.push(phase)
+                                                   runPhases.push(phase)
                                            });
 
-                        for (let i = 0; i < phaseCodedValuesList.length; i++) {
-                            if (runPhases.includes(phaseCodedValuesList[i].name)) {
-                                phaseQueue.push(phaseCodedValuesList[i]);
-                            }
-                        }
+                        if (runPhases.length > 0) {
+                            phaseCodedValuesList.forEach(codedValue => {
+                                                             if (runPhases.includes(codedValue.name))
+                                                                 phaseQueue.push(codedValue);
+                                                         });
 
-                        if (phaseQueue.length > 0) {
-                            sampleStatus = CreateLoadReport.SampleStatus.Busy;
-                            currentPhase = phaseQueue.pop();
-                            createReportForPhase(currentPhase);
+                            if (phaseQueue.length > 0) {
+                                sampleStatus = CreateLoadReport.SampleStatus.Busy;
+                                currentPhase = phaseQueue.pop();
+                                createReportForPhase(currentPhase);
+                            }
                         }
 
                         reportHasRun = runPhases.length !== 0;

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/README.md
@@ -49,11 +49,11 @@ Select phases to be included in the report. Press the "Run Report" button to ini
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork*based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 
-Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license*user*type*extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish*services/windows/utility*network*services.htm).
+Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
 ## Tags
 


### PR DESCRIPTION
There's an issue with the way the list of QmlCodedValue when retrieved by `utilityNetwork.definition.networkAttribute(phasesNetworkAttributeName).domain.codedValues`. After repeated calls to get the attributes of the QmlCodedValue list, a Seg Fault was raised and the sample viewer crashed.

This fix constructs an array of coded values instead. This seems to be more stable and the sample viewer does not crash after repeated calls to the coded value array.