### PR TITLE
set temp path on local server samples

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
@@ -30,6 +30,7 @@
 #include "Viewpoint.h"
 
 #include <QDir>
+#include <QTemporaryDir>
 #include <QFile>
 
 using namespace Esri::ArcGISRuntime;
@@ -37,6 +38,15 @@ using namespace Esri::ArcGISRuntime;
 LocalServerFeatureLayer::LocalServerFeatureLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
+  // create temp/data path
+  const QString tempPath = LocalServerFeatureLayer::shortestTempPath() + "/EsriQtTemp";
+
+  // create the directory
+  m_tempDir = std::unique_ptr<QTemporaryDir>(new QTemporaryDir(tempPath));
+
+  // set the temp & app data path for the local server
+  LocalServer::instance()->setTempDataPath(m_tempDir->path());
+  LocalServer::instance()->setAppDataPath(m_tempDir->path());
 }
 
 LocalServerFeatureLayer::~LocalServerFeatureLayer() = default;
@@ -141,4 +151,17 @@ void LocalServerFeatureLayer::startFeatureService() const
 {
   if (m_localFeatureService->status() != LocalServerStatus::Started || m_localFeatureService->status() != LocalServerStatus::Starting)
     m_localFeatureService->start();
+}
+
+QString LocalServerFeatureLayer::shortestTempPath()
+{
+  // get tmp and home paths
+  const QString tmpPath = QDir::tempPath();
+  const QString homePath = QDir::homePath();
+
+  // return whichever is shorter, temp or home path
+  if (homePath.length() > tmpPath.length())
+    return tmpPath;
+  else
+    return homePath;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.h
@@ -29,6 +29,8 @@ namespace Esri
   }
 }
 
+class QTemporaryDir;
+
 #include <QQuickItem>
 #include <QStringListModel>
 
@@ -45,12 +47,14 @@ public:
 
 private:
   void connectSignals();
+  QString shortestTempPath();
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::LocalFeatureService* m_localFeatureService = nullptr;
   void startFeatureService() const;
+  std::unique_ptr<QTemporaryDir> m_tempDir;
 };
 
 #endif // LOCAL_SERVER_FEATURELAYER_H

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
@@ -29,12 +29,22 @@
 #include "Viewpoint.h"
 
 #include <QDir>
+#include <QTemporaryDir>
 
 using namespace Esri::ArcGISRuntime;
 
 LocalServerMapImageLayer::LocalServerMapImageLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
+  // create temp/data path
+  const QString tempPath = LocalServerMapImageLayer::shortestTempPath() + "/EsriQtTemp";
+
+  // create the directory
+  m_tempDir = std::unique_ptr<QTemporaryDir>(new QTemporaryDir(tempPath));
+
+  // set the temp & app data path for the local server
+  LocalServer::instance()->setTempDataPath(m_tempDir->path());
+  LocalServer::instance()->setAppDataPath(m_tempDir->path());
 }
 
 LocalServerMapImageLayer::~LocalServerMapImageLayer() = default;
@@ -103,4 +113,17 @@ void LocalServerMapImageLayer::connectSignals()
       m_map->operationalLayers()->append(mapImageLayer);
     }
   });
+}
+
+QString LocalServerMapImageLayer::shortestTempPath()
+{
+  // get tmp and home paths
+  const QString tmpPath = QDir::tempPath();
+  const QString homePath = QDir::homePath();
+
+  // return whichever is shorter, temp or home path
+  if (homePath.length() > tmpPath.length())
+    return tmpPath;
+  else
+    return homePath;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.h
@@ -28,6 +28,8 @@ namespace Esri
   }
 }
 
+class QTemporaryDir;
+
 #include <QQuickItem>
 
 class LocalServerMapImageLayer : public QQuickItem
@@ -43,11 +45,13 @@ public:
 
 private:
   void connectSignals();
+  QString shortestTempPath();
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::LocalMapService* m_localMapService = nullptr;
+  std::unique_ptr<QTemporaryDir> m_tempDir;
 };
 
 #endif // LOCAL_SERVER_MAPIMAGELAYER_H


### PR DESCRIPTION
Updates "Local server feature layer" and "Local server map image layer" to use temp directories, which is a better practice and should resolve a bug where the samples crash on Linux.