### PR TITLE
Fix animate images sample

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -32,6 +32,12 @@ Rectangle {
     property int fileNamesLength: 0
     property var imageFrameList: []
 
+    // free up memory claimed by imageFrameList property
+    Component.onDestruction: {
+        while (imageFrameList.length !== 0)
+            imageFrameList.pop();
+    }
+
     // Create new Timer and set the timeout interval to 68ms
     Timer {
         id: timer


### PR DESCRIPTION
The sample viewer had high memory usage after running the sample "Animate Images with Overlay". This is because the `imageFrameList` is declared as a property, and was QML was not running the garbage collector on it until we restarted the sample.

This PR addresses this by freeing memory used by the image frames when the sample is navigated away from.