### PR TITLE
Updated how imageFrameList is cleared

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -32,6 +32,12 @@ Rectangle {
     property int fileNamesLength: 0
     property var imageFrameList: []
 
+    // free up memory claimed by imageFrameList property
+    Component.onDestruction: {
+        while (imageFrameList.length !== 0)
+            imageFrameList.pop();
+    }
+
     // Create new Timer and set the timeout interval to 68ms
     Timer {
         id: timer

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -34,8 +34,7 @@ Rectangle {
 
     // free up memory claimed by imageFrameList property
     Component.onDestruction: {
-        while (imageFrameList.length !== 0)
-            imageFrameList.pop();
+        imageFrameList = []
     }
 
     // Create new Timer and set the timeout interval to 68ms

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -34,7 +34,7 @@ Rectangle {
 
     // free up memory claimed by imageFrameList property
     Component.onDestruction: {
-        imageFrameList = []
+        imageFrameList = [];
     }
 
     // Create new Timer and set the timeout interval to 68ms


### PR DESCRIPTION
Updated removing all elements from `imageFrameList` from using a while loop with `pop()` to just clearing it. 

This makes it more clear what is happening, and also might be faster.