### PR TITLE
Fixed mapView->locationDisplay() crash involving QTimers

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
@@ -38,7 +38,10 @@ DisplayDeviceLocation::DisplayDeviceLocation(QQuickItem* parent) :
 {
 }
 
-DisplayDeviceLocation::~DisplayDeviceLocation() = default;
+DisplayDeviceLocation::~DisplayDeviceLocation()
+{
+    m_mapView->locationDisplay()->stop();
+}
 
 void DisplayDeviceLocation::init()
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
@@ -44,6 +44,11 @@ FindPlace::FindPlace(QQuickItem* parent /* = nullptr */):
 {
 }
 
+FindPlace::~FindPlace()
+{
+    m_mapView->locationDisplay()->stop();
+}
+
 void FindPlace::init()
 {
   // Register the map view for QML

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.h
@@ -45,7 +45,7 @@ class FindPlace : public QQuickItem
 
 public:
   explicit FindPlace(QQuickItem* parent = nullptr);
-  ~FindPlace() override = default;
+  ~FindPlace() override;
 
   enum class SearchMode
   {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
@@ -54,6 +54,10 @@ Rectangle {
                 }
             }
         }
+
+        Component.onDestruction: {
+            mapView.locationDisplay.stop();
+        }
     }
 
     Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/FindPlace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/FindPlace.qml
@@ -41,6 +41,10 @@ Rectangle {
             mapView.locationDisplay.start();
         }
 
+        Component.onDestruction: {
+            mapView.locationDisplay.stop();
+        }
+
         Map {
             Basemap {
                 initStyle: Enums.BasemapStyleArcGISTopographic


### PR DESCRIPTION
Reloading samples involving the `locationDisplay()` caused a crash on the reload, from stopping QTimers from a different thread than they were constructed on. 

The underlying issue is being worked on, and this is a temporary fix to prevent the crash until it is complete.