### PR TITLE
Tan11389/localserver temp path fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
@@ -38,6 +38,10 @@ using namespace Esri::ArcGISRuntime;
 LocalServerFeatureLayer::LocalServerFeatureLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
+  // Create a temporary directory for the local server if one has not already been created
+  if (LocalServer::appDataPath() != "")
+    return;
+
   // create temp/data path
   const QString tempPath = LocalServerFeatureLayer::shortestTempPath() + "/EsriQtTemp";
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
@@ -39,7 +39,7 @@ LocalServerFeatureLayer::LocalServerFeatureLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
+  if (!LocalServer::appDataPath().isEmpty() && !LocalServer::tempDataPath().isEmpty())
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.cpp
@@ -39,7 +39,7 @@ LocalServerFeatureLayer::LocalServerFeatureLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "")
+  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -45,7 +45,7 @@ LocalServerGeoprocessing::LocalServerGeoprocessing(QQuickItem* parent) :
   QQuickItem(parent)
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "")
+  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -44,6 +44,10 @@ using namespace Esri::ArcGISRuntime;
 LocalServerGeoprocessing::LocalServerGeoprocessing(QQuickItem* parent) :
   QQuickItem(parent)
 {
+  // Create a temporary directory for the local server if one has not already been created
+  if (LocalServer::appDataPath() != "")
+    return;
+
   // create temp/data path
   const QString tempPath = LocalServerGeoprocessing::shortestTempPath() + "/EsriQtTemp";
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.cpp
@@ -45,7 +45,7 @@ LocalServerGeoprocessing::LocalServerGeoprocessing(QQuickItem* parent) :
   QQuickItem(parent)
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
+  if (!LocalServer::appDataPath().isEmpty() && !LocalServer::tempDataPath().isEmpty())
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
@@ -37,7 +37,7 @@ LocalServerMapImageLayer::LocalServerMapImageLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "")
+  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
@@ -37,7 +37,7 @@ LocalServerMapImageLayer::LocalServerMapImageLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
+  if (!LocalServer::appDataPath().isEmpty() && !LocalServer::tempDataPath().isEmpty())
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.cpp
@@ -36,6 +36,10 @@ using namespace Esri::ArcGISRuntime;
 LocalServerMapImageLayer::LocalServerMapImageLayer(QQuickItem* parent) :
   QQuickItem(parent)
 {
+  // Create a temporary directory for the local server if one has not already been created
+  if (LocalServer::appDataPath() != "")
+    return;
+
   // create temp/data path
   const QString tempPath = LocalServerMapImageLayer::shortestTempPath() + "/EsriQtTemp";
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -37,7 +37,7 @@ LocalServerServices::LocalServerServices(QQuickItem* parent) :
   m_dataPath(QDir::homePath() + "/ArcGIS/Runtime/Data")
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
+  if (!LocalServer::appDataPath().isEmpty() && !LocalServer::tempDataPath().isEmpty())
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -37,7 +37,7 @@ LocalServerServices::LocalServerServices(QQuickItem* parent) :
   m_dataPath(QDir::homePath() + "/ArcGIS/Runtime/Data")
 {
   // Create a temporary directory for the local server if one has not already been created
-  if (LocalServer::appDataPath() != "")
+  if (LocalServer::appDataPath() != "" && LocalServer::tempDataPath() != "")
     return;
 
   // create temp/data path

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.cpp
@@ -36,6 +36,10 @@ LocalServerServices::LocalServerServices(QQuickItem* parent) :
   QQuickItem(parent),
   m_dataPath(QDir::homePath() + "/ArcGIS/Runtime/Data")
 {
+  // Create a temporary directory for the local server if one has not already been created
+  if (LocalServer::appDataPath() != "")
+    return;
+
   // create temp/data path
   const QString tempPath = LocalServerServices::shortestTempPath() + "/EsriQtSample";
 
@@ -203,10 +207,10 @@ void LocalServerServices::startService(const QString& serviceName, const QUrl& f
   {
     if (path.isEmpty())
     {
-    if (m_localGPService->status() == LocalServerStatus::Started)
-      return;
+      if (m_localGPService->status() == LocalServerStatus::Started)
+        return;
 
-    m_localGPService->start();
+      m_localGPService->start();
     }
     else
     {


### PR DESCRIPTION
Updates the LocalServer samples so they check to see if a temp path has already been set before creating a new one. This allows us to set a universal path for LocalServer in the sample viewer but still allows the samples to be built at the individual level without modification.