### PR TITLE
add space to "UtilityNetwork" category name

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Get a server-defined trace configuration for a given tier and modify its traversability scope, add new condition barriers and control what is included in the subnetwork trace result.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Create a simple electric distribution report that displays the count of customers and total load per phase by tracing downstream from a given point.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Create graphics for utility associations in a utility network.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Run a filtered trace to locate operable features that will isolate an area from the flow of network resources.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Discover connected features in a utility network using connected, subnetwork, upstream, and downstream traces.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Get a server-defined trace configuration for a given tier and modify its traversability scope, add new condition barriers and control what is included in the subnetwork trace result.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Create a simple electric distribution report that displays the count of customers and total load per phase by tracing downstream from a given point.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Create graphics for utility associations in a utility network.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Run a filtered trace to locate operable features that will isolate an area from the flow of network resources.",
     "ignore": false,
     "images": [

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "UtilityNetwork",
+    "category": "Utility network",
     "description": "Discover connected features in a utility network using connected, subnetwork, upstream, and downstream traces.",
     "ignore": false,
     "images": [

--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -475,7 +475,7 @@ metadata_categories = [
     'Routing',
     'Scenes',
     'Search',
-    'UtilityNetwork'
+    'Utility network'
 ]
 
 required_metadata_keys = [


### PR DESCRIPTION
Utility network samples currently display as "UtilityNetwork" and not "Utility network" - the latter of which is consistent with other categories like "Edit data". This PR updates the categories for utility network samples and the metadata checker script.