### PR TITLE
add spaces to roman numeral list

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/README.md
@@ -18,10 +18,15 @@ Pan the map and observe how new features are loaded from the OGC API feature ser
 2. Set the feature table's `FeatureRequestMode` to `ManualCache` so features requested from the server are cached locally.
 3. Create a `FeatureLayer` using the feature table and add it to the Map's `operationalLayers`.
 4. Every time the map view navigation completes:
+    
     i. Create `QueryParameters`
+    
     ii. Set the parameter's `Geometry` to the current extent of the map view. 
+    
     iii. Set the parameter's `SpatialRelationship` to `Intersects`.
+    
     iv. Set the `MaxFeatures` property to 5000 (some services have a low default value for maximum features).
+    
     v. Call `OgcFeatureCollectionTable::PopulateFromService()` using the query parameters from the previous steps.
 
 ## Relevant API

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/README.md
@@ -18,10 +18,13 @@ Pan the map and observe how new features are loaded from the OGC API feature ser
 2. Set the feature table's `featureRequestMode` to `Enums.FeatureRequestModeManualCache` so features requested from the server are cached locally.
 3. Create a `FeatureLayer` using the feature table and add it to the Map.
 4. Create a `QueryParameters` object with the following parameters:
+    
     i. Set the `geometry` to the current extent of the map view.
+    
     ii. Set the `SpatialRelationship` to `Enums.SpatialRelationshipIntersects`.
+    
     iii. Set the `MaxFeatures` property to 5000 (some services have a low default value for maximum features).
-4. When the feature table loads and thereafter every time time the map view navigation completes, call `OgcFeatureCollectionTable.populateFromService()` using the query parameters from the previous steps.
+5. When the feature table loads and thereafter every time time the map view navigation completes, call `OgcFeatureCollectionTable.populateFromService()` using the query parameters from the previous steps.
 
 ## Relevant API
 * OgcFeatureCollectionTable


### PR DESCRIPTION
The roman numeral lists in the sample viewer description views were not displaying correctly. This resolves the issue by adding extra line breaks between the list items.