### PR TITLE
Tan11389/export tiles add progress indicator

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.cpp
@@ -113,6 +113,12 @@ void ExportTiles::exportTileCacheFromCorners(double xCorner1, double yCorner1, d
     // check if there is a valid job
     if (exportJob)
     {
+      connect(exportJob, &ExportTileCacheJob::progressChanged, this, [this, exportJob]()
+      {
+        m_exportTilesProgress = exportJob->progress();
+        emit exportTilesProgressChanged();
+      });
+
       // connect to the job's status changed signal
       connect(exportJob, &ExportTileCacheJob::jobStatusChanged, this, [this, exportJob]()
       {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.h
@@ -45,19 +45,23 @@ public:
   void componentComplete() override;
   static void init();
   Q_INVOKABLE void exportTileCacheFromCorners(double xCorner1, double yCorner1, double xCorner2, double yCorner2);
+  Q_PROPERTY(int exportTilesProgress READ exportTilesProgress NOTIFY exportTilesProgressChanged)
 
 signals:
   void updateStatus(QString status);
   void hideWindow(int time, bool success);
+  void exportTilesProgressChanged();
 
 private:
   void createExportTileCacheTask();
   void displayOutputTileCache(Esri::ArcGISRuntime::TileCache* tileCache);
+  inline int exportTilesProgress() { return m_exportTilesProgress; }
 
   Esri::ArcGISRuntime::ExportTileCacheTask* m_exportTileCacheTask = nullptr;
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   QTemporaryDir m_tempPath;
+  int m_exportTilesProgress = 0;
 };
 
 #endif // EXPORT_TILES

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -128,8 +128,8 @@ ExportTilesSample {
 
         Rectangle {
             anchors.centerIn: parent
-            width: 125
-            height: 100
+            width: 140
+            height: 145
             color: "lightgrey"
             opacity: 0.8
             radius: 5
@@ -152,6 +152,12 @@ ExportTilesSample {
                 Text {
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: statusText
+                    font.pixelSize: 16
+                }
+
+                Text {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: exportTilesSample.exportTilesProgress + "% Completed"
                     font.pixelSize: 16
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
@@ -28,6 +28,7 @@ Rectangle {
     property Envelope tileCacheExtent: null
     property string statusText: ""
     property ExportTileCacheParameters params
+    property var exportTileCacheProgress: 0
 
     // Create MapView that contains a Map
     MapView {
@@ -90,6 +91,7 @@ Rectangle {
 
                 // connect to the job's status changed signal to know once it is done
                 exportJob.jobStatusChanged.connect(updateJobStatus);
+                exportJob.progressChanged.connect(updateExportProgress);
 
                 exportJob.start();
             } else {
@@ -124,6 +126,10 @@ Rectangle {
             }
         }
 
+        function updateExportProgress() {
+            exportTileCacheProgress = exportJob.progress;
+        }
+
         function displayOutputTileCache(tileCache) {
             // create a new tiled layer from the output tile cache
             const tiledLayer = ArcGISRuntimeEnvironment.createObject("ArcGISTiledLayer", { tileCache: tileCache } );
@@ -152,6 +158,7 @@ Rectangle {
         Component.onDestruction: {
             if (exportJob) {
                 exportJob.jobStatusChanged.disconnect(updateJobStatus);
+                exportJob.progressChanged.disconnect(updateExportProgress);
             }
         }
     }
@@ -248,8 +255,8 @@ Rectangle {
 
         Rectangle {
             anchors.centerIn: parent
-            width: 125
-            height: 100
+            width: 140
+            height: 145
             color: "lightgrey"
             opacity: 0.8
             radius: 5
@@ -274,12 +281,17 @@ Rectangle {
                     text: statusText
                     font.pixelSize: 16
                 }
+
+                Text {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: exportTileCacheProgress + "% Completed"
+                    font.pixelSize: 16
+                }
             }
         }
 
         Timer {
             id: hideWindowTimer
-
             onTriggered: exportWindow.visible = false;
         }
 


### PR DESCRIPTION
With the Export Tiles samples now using the BasemapStyle instead of the tile service, exporting the tile packages sometimes takes longer (especially at higher levels of detail). This PR adds a progress indicator to show the user the status, rather than it just ambiguously exporting which can actually take up to a few minutes. See below:

![Screen Shot 2021-06-30 at 11 38 07 AM](https://user-images.githubusercontent.com/48941951/124013994-d31b4180-d997-11eb-938a-301e07b4279a.png)
