### PR TITLE
Create and save map basemap constructors

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -144,15 +144,16 @@ Rectangle {
         // Create the Basemap
         let selectedBasemap;
         if (basemap === "Streets")
-            selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapStreets");
+            selectedBasemap = Enums.BasemapStyleArcGISStreets;
         else if (basemap === "Imagery")
-            selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapImagery");
+            selectedBasemap = Enums.BasemapStyleArcGISImagery;
         else if (basemap === "Topographic")
-            selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapTopographic");
+            selectedBasemap = Enums.BasemapStyleArcGISTopographic;
         else if (basemap === "Oceans")
-            selectedBasemap = ArcGISRuntimeEnvironment.createObject("BasemapOceans");
+            selectedBasemap = Enums.BasemapStyleArcGISOceans;
 
         // Create the Map with the basemap
+        selectedBasemap = ArcGISRuntimeEnvironment.createObject("Basemap", {initStyle: selectedBasemap});
         const map = ArcGISRuntimeEnvironment.createObject("Map", { basemap: selectedBasemap }, mapView);
 
         map.saveStatusChanged.connect(()=> {


### PR DESCRIPTION
The "Create and save map" QML sample was using the old basemap constructor and not prompting the user for credentials upon loading the sample. This updates the constructors. Tested in the QML sample viewer on Mac and now runs as expected.