### PR TITLE
Fix QML subtype feature layer not displaying when minScale equals mapScale

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
@@ -28,7 +28,7 @@ Rectangle {
 
     property var subtypeSublayer
     property var originalRenderer
-    property double mapScale: mapView ? Math.round(mapView.mapScale) : 0
+    property double mapScale: mapView ? mapView.mapScale : 0
     property double sublayerMinScale
 
 
@@ -187,13 +187,13 @@ Rectangle {
                 }
 
                 Text {
-                    text: qsTr("Current map scale: 1:%1".arg(mapScale))
+                    text: qsTr("Current map scale: 1:%1".arg(Math.round(mapScale)))
                     Layout.margins: 2
                     Layout.alignment: Qt.AlignLeft
                 }
 
                 Text {
-                    text: subtypeSublayer ? qsTr("Sublayer min scale: 1:%1".arg(subtypeSublayer.minScale)) : qsTr("Sublayer min scale:")
+                    text: subtypeSublayer ? qsTr("Sublayer min scale: 1:%1".arg(Math.round(subtypeSublayer.minScale))) : qsTr("Sublayer min scale:")
                     Layout.margins: 2
                     Layout.alignment: Qt.AlignLeft
                 }


### PR DESCRIPTION
Currently in the QML Display subtype feature layer sample the subtype feature layer will not display when minScale "appears to equal" mapScale.

This issue is caused because when updating the subtype feature layer's minScale value, the minScale value was being floor-rounded. Therefore, for example, if mapScale was 10.1 minScale would be set at 10(.0) and the subtype feature layer wouldn't display because the mapScale was outside of the bounds of minScale.

This PR updates the sample so the back-end variable isn't rounded but rather the value displayed in the UI is rounded.