### PR TITLE
Andrewbladon/change authentication

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -53,7 +53,7 @@ void GenerateOfflineMap::componentComplete()
   m_mapView = findChild<MapQuickView*>("mapView");
 
   // Create a Portal Item for use by the Map and OfflineMapTask
-  bool loginRequired = true;
+  bool loginRequired = false;
   Portal* portal = new Portal(loginRequired, this);
   m_portalItem = new PortalItem(portal, webMapId(), this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
@@ -30,15 +30,6 @@ TARGET = GenerateOfflineMap
 ARCGIS_RUNTIME_VERSION = 100.12
 include($$PWD/arcgisruntime.pri)
 
-# path of the toolkit relative to the sample
-TOOLKIT_PRI_PATH = $$PWD/../../../arcgis-runtime-toolkit-qt
-
-exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
-    include($$TOOLKIT_PRI_PATH/uitools/toolkitcpp.pri)
-} else {
-    error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
-}
-
 #-------------------------------------------------------------------------------
 
 HEADERS += \

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -18,7 +18,6 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.Samples 1.0
-import Esri.ArcGISRuntime.Toolkit 100.12
 
 GenerateOfflineMapSample {
     id: offlineMapSample
@@ -103,10 +102,4 @@ GenerateOfflineMapSample {
             }
         }
     }
-
-    /* Uncomment this section when running as standalone application
-    AuthenticationView {
-        anchors.fill: parent
-    }
-    */
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/README.md
@@ -10,7 +10,7 @@ Taking a web map offline allows users continued productivity when their network 
 
 ## How to use the sample
 
-When the app starts, you will be prompted to sign in using an ArcGIS Online account. Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Click the "Take Map Offline" button to start the offline map job. The progress bar will show the job's progress. When complete, the offline map will replace the online map in the map view.
+When the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Tap the "Generate offline map" button to start the offline map job. The progress view will show the job's progress. When complete, the offline map will replace the online map in the map view.
 
 ## How it works
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
@@ -17,7 +17,6 @@
 #include <QDir>
 #include <QQmlEngine>
 
-#include "Esri/ArcGISRuntime/Toolkit/register.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #ifdef Q_OS_WIN
@@ -73,8 +72,6 @@ int main(int argc, char *argv[])
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));
   // Add the Runtime and Extras path
   view.engine()->addImportPath(arcGISRuntimeImportPath);
-
-  Esri::ArcGISRuntime::Toolkit::registerComponents(*(view.engine()));
 
   // Set the source
   view.setSource(QUrl("qrc:/Samples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.pro
@@ -30,15 +30,6 @@ TARGET = GenerateOfflineMapLocalBasemap
 ARCGIS_RUNTIME_VERSION = 100.12
 include($$PWD/arcgisruntime.pri)
 
-# path of the toolkit relative to the sample
-TOOLKIT_PRI_PATH = $$PWD/../../../arcgis-runtime-toolkit-qt
-
-exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
-    include($$TOOLKIT_PRI_PATH/uitools/toolkitcpp.pri)
-} else {
-    error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
-}
-
 #-------------------------------------------------------------------------------
 
 HEADERS += \

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -18,7 +18,6 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.Samples 1.0
-import Esri.ArcGISRuntime.Toolkit 100.12
 
 GenerateOfflineMapLocalBasemapSample {
     id: offlineMapSample
@@ -148,10 +147,4 @@ GenerateOfflineMapLocalBasemapSample {
             }
         }
     }
-
-    /* Uncomment this section when running as standalone application
-    AuthenticationView {
-        anchors.fill: parent
-    }
-    */
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -23,9 +23,8 @@ The author of a web map can support the use of basemaps which are already on a d
 1. Click on "Generate Offline Map".
 2. You will be prompted to choose whether you wish to download the online basemap or use the "naperville_imagery.tpkx" basemap which is already on the device.
 3. If you choose to download the online basemap, the offline map will be generated with the same (topographic) basemap as the online web map.
-4. To download the Esri basemap, you may be prompted to sign in to ArcGIS.com.
-5. If you choose to use the basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.
-6. Since the application is not exporting online ArcGIS Online basemaps you will not need to log-in.
+4. If you choose to use the basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.
+5. Since the application is not exporting online ArcGIS Online basemaps you will not need to log-in.
 
 ## How it works
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -17,7 +17,6 @@
 #include <QDir>
 #include <QQmlEngine>
 
-#include "Esri/ArcGISRuntime/Toolkit/register.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #ifdef Q_OS_WIN
@@ -73,8 +72,6 @@ int main(int argc, char *argv[])
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));
   // Add the Runtime and Extras path
   view.engine()->addImportPath(arcGISRuntimeImportPath);
-
-  Esri::ArcGISRuntime::Toolkit::registerComponents(*(view.engine()));
 
   // Set the source
   view.setSource(QUrl("qrc:/Samples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 // [Legal]
 
+// AAPK
+
 #ifdef PCH_BUILD
 #include "pch.hpp"
 #endif // PCH_BUILD

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -59,7 +59,7 @@ void GenerateOfflineMap_Overrides::componentComplete()
   m_mapView = findChild<MapQuickView*>("mapView");
 
   // Create a Portal Item for use by the Map and OfflineMapTask
-  const bool loginRequired = true;
+  const bool loginRequired = false;
   Portal* portal = new Portal(loginRequired, this);
   m_portalItem = new PortalItem(portal, webMapId(), this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 // [Legal]
 
+// aapkx
+
 #ifdef PCH_BUILD
 #include "pch.hpp"
 #endif // PCH_BUILD

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -14,8 +14,6 @@
 // limitations under the License.
 // [Legal]
 
-// AAPK
-
 #ifdef PCH_BUILD
 #include "pch.hpp"
 #endif // PCH_BUILD

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -14,8 +14,6 @@
 // limitations under the License.
 // [Legal]
 
-// aapkx
-
 #ifdef PCH_BUILD
 #include "pch.hpp"
 #endif // PCH_BUILD

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.pro
@@ -30,15 +30,6 @@ TARGET = GenerateOfflineMap_Overrides
 ARCGIS_RUNTIME_VERSION = 100.12
 include($$PWD/arcgisruntime.pri)
 
-# path of the toolkit relative to the sample
-TOOLKIT_PRI_PATH = $$PWD/../../../arcgis-runtime-toolkit-qt
-
-exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
-    include($$TOOLKIT_PRI_PATH/uitools/toolkitcpp.pri)
-} else {
-    error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
-}
-
 #-------------------------------------------------------------------------------
 
 HEADERS += \

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -18,7 +18,6 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.Samples 1.0
-import Esri.ArcGISRuntime.Toolkit 100.12
 
 GenerateOfflineMap_OverridesSample {
     id: offlineMapOverridesSample
@@ -124,10 +123,4 @@ GenerateOfflineMap_OverridesSample {
         anchors.centerIn: parent
         running: taskBusy
     }
-
-    /* Uncomment this section when running as standalone application
-    AuthenticationView {
-        anchors.fill: parent
-    }
-    */
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
@@ -10,16 +10,15 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 
 ## How to use the sample
 
-1. When the sample starts, you may be prompted to sign into arcgis.com.
-2. Click on "Generate Offline Map (Overrides)".
-3. Use the range slider to adjust the min/max levelIds to be taken offline for the Streets basemap.
-4. Use the spin-box to set the buffer radius for the streets basemap.
-5. Click the buttons to skip the System Valves and Service Connections layers.
-4. Use the combo-box to select the maximum flow rate for the features from the Hydrant layer.
-5. Use the check-box to skip the geometry filter for the water pipes features.
-6. Click "Start Job"
-7. Wait for the progress bar to indicate that the task has completed.
-8. You should see that the basemap does not display when you zoom out past a certain range and is padded around the original area of interest. The network dataset should extend beyond the target area. The System Valves and Service Connections should be omitted from the offline map and the Hydrants layer should contain a subset of the original features.
+1. Click on "Generate Offline Map (Overrides)".
+2. Use the range slider to adjust the min/max levelIds to be taken offline for the Streets basemap.
+3. Use the spin-box to set the buffer radius for the streets basemap.
+4. Click the buttons to skip the System Valves and Service Connections layers.
+5. Use the combo-box to select the maximum flow rate for the features from the Hydrant layer.
+6. Use the check-box to skip the geometry filter for the water pipes features.
+7. Click "Start Job"
+8. Wait for the progress bar to indicate that the task has completed.
+9. You should see that the basemap does not display when you zoom out past a certain range and is padded around the original area of interest. The network dataset should extend beyond the target area. The System Valves and Service Connections should be omitted from the offline map and the Hydrants layer should contain a subset of the original features.
 
 # How it works
 The sample creates a `PortalItem` object using a web map’s ID. This portal item is also used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask::createDefaultGenerateOfflineMapParameters`. Once the parameters are retrieved, they are used to create a set of `GenerateOfflineMapParameterOverrides` by calling `OfflineMapTask::createGenerateOfflineMapParameterOverrides`. The overrides are then adjusted so that specific layers will be taken offline using custom settings.
@@ -40,8 +39,6 @@ Next, the hydrant layer is filtered to exclude certain features. This approach c
 Lastly, the water network dataset is adjusted so that the features are downloaded for the entire dataset - rather than clipped to the area of interest. Again, the key for the layer is constructed using the layer and the relevant `GenerateGeodatabaseParameters` are obtained from the overrides dictionary. The layer options are then adjusted to set `useGeometry` to false.
 
 Having adjusted the `GenerateOfflineMapParameterOverrides` to reflect the custom requirements for the offline map, the original parameters and the custom overrides, along with the download path for the offline map, are then used to create a `GenerateOfflineMapJob` object from the offline map task. This job is then started and on successful completion the offline map is added to the map view. To provide feedback to the user, the progress property of `GenerateOfflineMapJob` is displayed in a window.
-
-As the web map that is being taken offline contains an Esri basemap, this sample requires that you sign in with an ArcGIS Online organizational account.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
@@ -17,7 +17,7 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 5. Use the combo-box to select the maximum flow rate for the features from the Hydrant layer.
 6. Use the check-box to skip the geometry filter for the water pipes features.
 7. Click "Start Job"
-8. Wait for the progress bar to indicate that the task has completed.
+8. Wait for the progress view to indicate that the task has completed.
 9. You should see that the basemap does not display when you zoom out past a certain range and is padded around the original area of interest. The network dataset should extend beyond the target area. The System Valves and Service Connections should be omitted from the offline map and the Hydrants layer should contain a subset of the original features.
 
 ## How it works

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
@@ -20,22 +20,28 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 8. Wait for the progress bar to indicate that the task has completed.
 9. You should see that the basemap does not display when you zoom out past a certain range and is padded around the original area of interest. The network dataset should extend beyond the target area. The System Valves and Service Connections should be omitted from the offline map and the Hydrants layer should contain a subset of the original features.
 
-# How it works
+## How it works
+
 The sample creates a `PortalItem` object using a web map’s ID. This portal item is also used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask::createDefaultGenerateOfflineMapParameters`. Once the parameters are retrieved, they are used to create a set of `GenerateOfflineMapParameterOverrides` by calling `OfflineMapTask::createGenerateOfflineMapParameterOverrides`. The overrides are then adjusted so that specific layers will be taken offline using custom settings.
 
 ### Streets basemap (adjust scale range)
+
 In order to minimize the download size for offline map, this sample reduces the scale range for the "World Streets Basemap" layer by adjusting the relevant `ExportTileCacheParameters` in the `GenerateOfflineMapParameterOverrides`. The basemap layer is used to contsruct an `OfflineMapParametersKey`object. The key is then used to retrieve the specific `ExportTileCacheParameters` for the basemap and the `levelIds` are updated to skip unwanted levels of detail (based on the values selected in the UI). Note that the original "Streets" basemap is swapped for the "for export" version of the service - see https://www.arcgis.com/home/item.html?id=e384f5aa4eb1433c92afff09500b073d.
 
 ### Streets Basemap (buffer extent)
+
 To provide context beyond the study area, the extent for streets basemap is padded. Again, the key for the basemap layer is used to obtain the key and the default extent `Geometry` is retrieved. This extent is then padded (by the distance specified in the UI) using the `GeoemetryEngine::bufferGeodesic` function and applied to the `ExportTileCacheParameters`.
 
 ### System Valves and Service Connections (skip layers)
+
 In this example, the survey is primarily concerned with the Hydrants layer, so other information is not taken offline: this keeps the download smaller and reduces clutter in the offline map. The two layers "System Valves" and "Service Connections" are retrieved from the operational layers list of the map. They are then used to construct an `OfflineMapParametersKey`. This key is used to obtain the relevant `GenerateGeodatabaseParameters` from the `GenerateOfflineMapParameterOverrides::generateGeodatabaseParameters` property. The `GenerateLayerOption` for each of the layers is removed from the geodatabse parameters `layerOptions` by checking for the `FeatureLayer::serviceLayerId`. Note, that you could also choose to download only the schema for these layers by setting the `GenerateLayerOption::queryOption` to `GenerateLayerQueryOption::None`.
 
 ### Hydrant Layer (filter features)
+
 Next, the hydrant layer is filtered to exclude certain features. This approach could be taken if the offline map is intended for use with only certain data - for example, where a re-survey is required. To achieve this, a whereClause (for example, "Flow Rate (GPM) < 500") needs to be applied to the hydrant's `GenerateLayerOption` in the `GenerateGeodatabaseParameters`. The minimum flow rate value is obtained from the UI setting. The sample constructs a key object from the hydrant layer as in the previous step, and iterates over the available `GenerateGeodatabaseParameters` until the correct one is found and the `GenerateLayerOption` can be updated.
 
 ### Water Pipes Dataset (skip geometry filter)
+
 Lastly, the water network dataset is adjusted so that the features are downloaded for the entire dataset - rather than clipped to the area of interest. Again, the key for the layer is constructed using the layer and the relevant `GenerateGeodatabaseParameters` are obtained from the overrides dictionary. The layer options are then adjusted to set `useGeometry` to false.
 
 Having adjusted the `GenerateOfflineMapParameterOverrides` to reflect the custom requirements for the offline map, the original parameters and the custom overrides, along with the download path for the offline map, are then used to create a `GenerateOfflineMapJob` object from the offline map task. This job is then started and on successful completion the offline map is added to the map view. To provide feedback to the user, the progress property of `GenerateOfflineMapJob` is displayed in a window.

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -17,7 +17,6 @@
 #include <QDir>
 #include <QQmlEngine>
 
-#include "Esri/ArcGISRuntime/Toolkit/register.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #ifdef Q_OS_WIN
@@ -42,7 +41,7 @@ int main(int argc, char *argv[])
   // 2. API key: A permanent key that gives your application access to Esri
   //    location services. Visit your ArcGIS Developers Dashboard create a new
   //    API keys or access an existing API key.
-  const QString apiKey = QStringLiteral("");
+  const QString apiKey = QStringLiteral("AAPK6bba0a01a9d843b3b6b2cad0d063fd84E0RQmdykTwozMbL0bJbvTGQniM1w_Jj4mZojHXiIYM4F8nG_Ok4A2rjfEisOCc8n");
   if (apiKey.isEmpty())
   {
       qWarning() << "Use of Esri location services, including basemaps, requires"
@@ -73,8 +72,6 @@ int main(int argc, char *argv[])
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));
   // Add the Runtime and Extras path
   view.engine()->addImportPath(arcGISRuntimeImportPath);
-
-  Esri::ArcGISRuntime::Toolkit::registerComponents(*(view.engine()));
 
   // Set the source
   view.setSource(QUrl("qrc:/Samples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   // 2. API key: A permanent key that gives your application access to Esri
   //    location services. Visit your ArcGIS Developers Dashboard create a new
   //    API keys or access an existing API key.
-  const QString apiKey = QStringLiteral("AAPK6bba0a01a9d843b3b6b2cad0d063fd84E0RQmdykTwozMbL0bJbvTGQniM1w_Jj4mZojHXiIYM4F8nG_Ok4A2rjfEisOCc8n");
+  const QString apiKey = QStringLiteral("");
   if (apiKey.isEmpty())
   {
       qWarning() << "Use of Esri location services, including basemaps, requires"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
@@ -23,15 +23,6 @@ CONFIG += c++14
 ARCGIS_RUNTIME_VERSION = 100.12
 include($$PWD/arcgisruntime.pri)
 
-# path of the toolkit relative to the sample
-TOOLKIT_PRI_PATH = $$PWD/../../../arcgis-runtime-toolkit-qt
-
-exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
-    include($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri)
-} else {
-    error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
-}
-
 SOURCES += \
     main.cpp
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -19,7 +19,6 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.ArcGISRuntime 100.12
 import Esri.ArcGISExtras 1.1
-import Esri.ArcGISRuntime.Toolkit 100.12
 
 Rectangle {
     id: rootRectangle
@@ -43,7 +42,7 @@ Rectangle {
 
                 itemId: webMapId
                 Portal {
-                    loginRequired: true
+                    loginRequired: false
                 }
             }
         }
@@ -207,10 +206,4 @@ Rectangle {
             }
         }
     }
-
-    /* Uncomment this section when running as standalone application
-    AuthenticationView {
-        anchors.fill: parent
-    }
-    */
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/README.md
@@ -10,7 +10,7 @@ Taking a web map offline allows users continued productivity when their network 
 
 ## How to use the sample
 
-When the app starts, you will be prompted to sign in using an ArcGIS Online account. Once the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Click the "Take Map Offline" button to start the offline map job. The progress bar will show the job's progress. When complete, the offline map will replace the online map in the map view.
+When the map loads, zoom to the extent you want to take offline. The red border shows the extent that will be downloaded. Tap the "Generate offline map" button to start the offline map job. The progress view will show the job's progress. When complete, the offline map will replace the online map in the map view.
 
 ## How it works
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
@@ -18,8 +18,6 @@
 #include <QDir>
 #include <QQmlEngine>
 
-#include <Esri/ArcGISRuntime/Toolkit/register.h>
-
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
 
@@ -64,8 +62,6 @@ int main(int argc, char *argv[])
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));
   // Add the Runtime and Extras path
   view.engine()->addImportPath(arcGISRuntimeImportPath);
-
-  Esri::ArcGISRuntime::Toolkit::registerComponents(*(view.engine()));
 
   // Set the source
   view.setSource(QUrl("qrc:/Samples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml"));

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.pro
@@ -23,15 +23,6 @@ CONFIG += c++14
 ARCGIS_RUNTIME_VERSION = 100.12
 include($$PWD/arcgisruntime.pri)
 
-# path of the toolkit relative to the sample
-TOOLKIT_PRI_PATH = $$PWD/../../../arcgis-runtime-toolkit-qt
-
-exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
-    include($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri)
-} else {
-    error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
-}
-
 SOURCES += \
     main.cpp
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -19,7 +19,6 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.ArcGISRuntime 100.12
 import Esri.ArcGISExtras 1.1
-import Esri.ArcGISRuntime.Toolkit 100.12
 
 Rectangle {
     id: rootRectangle
@@ -261,10 +260,4 @@ Rectangle {
             }
         }
     }
-
-    /* Uncomment this section when running as standalone application
-    AuthenticationView {
-        anchors.fill: parent
-    }
-    */
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/README.md
@@ -23,9 +23,8 @@ The author of a web map can support the use of basemaps which are already on a d
 1. Click on "Generate Offline Map".
 2. You will be prompted to choose whether you wish to download the online basemap or use the "naperville_imagery.tpkx" basemap which is already on the device.
 3. If you choose to download the online basemap, the offline map will be generated with the same (topographic) basemap as the online web map.
-4. To download the Esri basemap, you may be prompted to sign in to ArcGIS.com.
-5. If you choose to use the basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.
-6. Since the application is not exporting online ArcGIS Online basemaps you will not need to log-in.
+4. If you choose to use the basemap from the device, the offline map will be generated with the local imagery basemap. The download will be quicker since no tiles are exported or downloaded.
+5. Since the application is not exporting online ArcGIS Online basemaps you will not need to log-in.
 
 ## How it works
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -18,8 +18,6 @@
 #include <QDir>
 #include <QQmlEngine>
 
-#include <Esri/ArcGISRuntime/Toolkit/register.h>
-
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
 
@@ -64,8 +62,6 @@ int main(int argc, char *argv[])
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));
   // Add the Runtime and Extras path
   view.engine()->addImportPath(arcGISRuntimeImportPath);
-
-  Esri::ArcGISRuntime::Toolkit::registerComponents(*(view.engine()));
 
   // Set the source
   view.setSource(QUrl("qrc:/Samples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml"));

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.pro
@@ -23,15 +23,6 @@ CONFIG += c++14
 ARCGIS_RUNTIME_VERSION = 100.12
 include($$PWD/arcgisruntime.pri)
 
-# path of the toolkit relative to the sample
-TOOLKIT_PRI_PATH = $$PWD/../../../arcgis-runtime-toolkit-qt
-
-exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
-    include($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri)
-} else {
-    error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
-}
-
 SOURCES += \
     main.cpp
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -20,7 +20,6 @@ import QtQuick.Layouts 1.3
 import QtQuick.Window 2.2
 import Esri.ArcGISRuntime 100.12
 import Esri.ArcGISExtras 1.1
-import Esri.ArcGISRuntime.Toolkit 100.12
 
 Rectangle {
     id: rootRectangle
@@ -47,7 +46,7 @@ Rectangle {
 
                 itemId: webMapId
                 Portal {
-                    loginRequired: true
+                    loginRequired: false
                 }
             }
         }
@@ -445,10 +444,4 @@ Rectangle {
         running: offlineMapTask.createGenerateOfflineMapParameterOverridesStatus === Enums.TaskStatusInProgress ||
                  offlineMapTask.createDefaultGenerateOfflineMapParameterStatus === Enums.TaskStatusInProgress
     }
-
-    /* Uncomment this section when running as standalone application
-    AuthenticationView {
-        anchors.fill: parent
-    }
-    */
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/README.md
@@ -10,16 +10,15 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 
 ## How to use the sample
 
-1. When the sample starts, you may be prompted to sign into arcgis.com.
-2. Click on "Generate Offline Map (Overrides)".
-3. Use the range slider to adjust the min/max levelIds to be taken offline for the Streets basemap.
-4. Use the spin-box to set the buffer radius for the streets basemap.
-5. Click the buttons to skip the System Valves and Service Connections layers.
-4. Use the combo-box to select the maximum flow rate for the features from the Hydrant layer.
-5. Use the check-box to skip the geometry filter for the water pipes features.
-6. Click "Start Job"
-7. Wait for the progress bar to indicate that the task has completed.
-8. You should see that the basemap does not display when you zoom out past a certain range and is padded around the original area of interest. The network dataset should extend beyond the target area. The System Valves and Service Connections should be omitted from the offline map and the Hydrants layer should contain a subset of the original features.
+1. Click on "Generate Offline Map (Overrides)".
+2. Use the range slider to adjust the min/max levelIds to be taken offline for the Streets basemap.
+3. Use the spin-box to set the buffer radius for the streets basemap.
+4. Click the buttons to skip the System Valves and Service Connections layers.
+5. Use the combo-box to select the maximum flow rate for the features from the Hydrant layer.
+6. Use the check-box to skip the geometry filter for the water pipes features.
+7. Click "Start Job"
+8. Wait for the progress bar to indicate that the task has completed.
+9. You should see that the basemap does not display when you zoom out past a certain range and is padded around the original area of interest. The network dataset should extend beyond the target area. The System Valves and Service Connections should be omitted from the offline map and the Hydrants layer should contain a subset of the original features.
 
 ## How it works
 
@@ -46,8 +45,6 @@ Next, the hydrant layer is filtered to exclude certain features. This approach c
 Lastly, the water network dataset is adjusted so that the features are downloaded for the entire dataset - rather than clipped to the area of interest. Again, the key for the layer is constructed using the layer and the relevant `GenerateGeodatabaseParameters` are obtained from the overrides dictionary. The layer options are then adjusted to set `useGeometry` to false.
 
 Having adjusted the `GenerateOfflineMapParameterOverrides` to reflect the custom requirements for the offline map, the original parameters and the custom overrides, along with the download path for the offline map, are then used to create a `GenerateOfflineMapJob` object from the offline map task. This job is then started and on successful completion the offline map is added to the map view. To provide feedback to the user, the progress property of `GenerateOfflineMapJob` is displayed in a window.
-
-As the web map that is being taken offline contains an Esri basemap, this sample requires that you sign in with an ArcGIS Online organizational account.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -18,8 +18,6 @@
 #include <QDir>
 #include <QQmlEngine>
 
-#include <Esri/ArcGISRuntime/Toolkit/register.h>
-
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
 
@@ -64,8 +62,6 @@ int main(int argc, char *argv[])
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));
   // Add the Runtime and Extras path
   view.engine()->addImportPath(arcGISRuntimeImportPath);
-
-  Esri::ArcGISRuntime::Toolkit::registerComponents(*(view.engine()));
 
   // Set the source
   view.setSource(QUrl("qrc:/Samples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml"));


### PR DESCRIPTION
The _**Generate offline basemap**_, _**Generate offline basemap (overrides)**_, and _**Generate offline basemap local basemap**_ samples have been adjusted for both C++ and QML to remove user authentication. These changes made all references to the toolkit unnecessary, so they were also removed. The README files have also been adjusted accordingly.

**Summary:**
- [x] _**Generate offline basemap**_
- [x] _**Generate offline basemap (overrides)**_
- [x] _**Generate offline basemap local basemap**_ - user authentication was not implemented, but references to the toolkit were removed and README files were adjusted.
- [ ] _**Navigate in AR**_ - This has not yet been implemented on Qt platform.