### PR TITLE
Tan11389/display subtype feature layer qml ceil round

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
@@ -203,7 +203,7 @@ Rectangle {
                     Layout.margins: 2
                     Layout.alignment: Qt.AlignLeft
                     enabled: subtypeFeatureLayer.loadStatus === Enums.LoadStatusLoaded ? true : false
-                    onClicked: subtypeSublayer ? subtypeSublayer.minScale = mapScale : null
+                    onClicked: subtypeSublayer ? subtypeSublayer.minScale = Math.ceil(mapScale) : null
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
@@ -29,8 +29,6 @@ Rectangle {
     property var subtypeSublayer
     property var originalRenderer
     property double mapScale: mapView ? mapView.mapScale : 0
-    property double sublayerMinScale
-
 
     MapView {
         id: mapView
@@ -94,7 +92,6 @@ Rectangle {
 
                     // set a default minimum scale
                     subtypeSublayer.minScale = 3000.0;
-                    sublayerMinScale = subtypeSublayer.minScale;
                 }
 
                 onErrorChanged: print("%1 - %2 - %3 - %4".arg(error.code, error.domain, error.message, error.additionalMessage));


### PR DESCRIPTION
Encountered an issue where one could set the sublayer minScale from the current mapScale, zoom out then zoom back in to that original mapScale, and then the sublayer wouldn't display. This was because the mapScale could be a tiny fraction larger when it returns to the original zoom level and thus the sublayer minScale would be smaller than mapScale and it wouldn't display. 

This PR adds Math.ceil() when setting the minScale from the mapScale to avoid this issue.