### PR TITLE
Tan11389/extruded kml fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/ListKmlContents.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/ListKmlContents.cpp
@@ -56,7 +56,7 @@ QString defaultDataPath()
 
 ListKmlContents::ListKmlContents(QObject* parent /* = nullptr */):
   QObject(parent),
-  m_scene(new Scene(Basemap::imageryWithLabels(this), this))
+  m_scene(new Scene(BasemapStyle::ArcGISImagery, this))
 {
   // create a new elevation source from Terrain3D REST service
   ArcGISTiledElevationSource* elevationSource = new ArcGISTiledElevationSource(
@@ -383,9 +383,9 @@ void ListKmlContents::setSceneView(SceneQuickView* sceneView)
         }
         else
         {
-          // add buffer of 1m to zMax
           target = Envelope(lookAtExtent.xMin(), lookAtExtent.yMin(),
                             lookAtExtent.xMax(), lookAtExtent.yMax(),
+                            // set the camera slightly above the placemark by adding one meter
                             elevation, lookAtExtent.depth() + elevation + 1,
                             lookAtExtent.spatialReference());
         }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
@@ -47,12 +47,12 @@ int main(int argc, char *argv[])
   const QString apiKey = QStringLiteral("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
+                  "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
   }
 
   // Initialize the sample

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/ListKmlContents.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/ListKmlContents.qml
@@ -328,7 +328,9 @@ Rectangle {
 
         Scene {
             id: scene
-            BasemapImageryWithLabels {}
+            Basemap {
+                initStyle: Enums.BasemapStyleArcGISImagery
+            }
 
             Surface {
                 ArcGISTiledElevationSource {
@@ -373,7 +375,8 @@ Rectangle {
                                                                                        xMax: lookAtExtent.xMax,
                                                                                        yMax: lookAtExtent.yMax,
                                                                                        zMin: locationToElevationResult,
-                                                                                       zMax: lookAtExtent.depth + locationToElevationResult,
+                                                                                       // set the camera slightly above the placemark by adding one meter
+                                                                                       zMax: lookAtExtent.depth + locationToElevationResult + 1,
                                                                                        spatialReference: lookAtExtent.spatialReference
                                                                                    });
                             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/ListKmlContents.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/ListKmlContents.qml
@@ -138,7 +138,7 @@ Rectangle {
                                                                           roll: kmlViewpoint.roll
                                                                       });
                 currentViewpoint = ArcGISRuntimeEnvironment.createObject("ViewpointCenter", {center: kmlViewpoint.location,
-                                                                         camera: currentCamera});
+                                                                             camera: currentCamera});
                 return;
             case Enums.KmlViewpointTypeCamera:
                 currentCamera = ArcGISRuntimeEnvironment.createObject("Camera", {
@@ -148,7 +148,7 @@ Rectangle {
                                                                           roll: kmlViewpoint.roll
                                                                       });
                 currentViewpoint = ArcGISRuntimeEnvironment.createObject("ViewpointCenter", {center: kmlViewpoint.location,
-                                                                         camera: currentCamera});
+                                                                             camera: currentCamera});
                 return;
             default:
                 console.warn("Unexpected KmlViewpointType");
@@ -360,36 +360,36 @@ Rectangle {
                             // if depth of extent = 0, add 100m to the elevation to get zMax
                             if (lookAtExtent.depth === 0) {
                                 target = ArcGISRuntimeEnvironment.createObject("Envelope",{
-                                                                                       xMin: lookAtExtent.xMin,
-                                                                                       yMin: lookAtExtent.yMin,
-                                                                                       xMax: lookAtExtent.xMax,
-                                                                                       yMax: lookAtExtent.yMax,
-                                                                                       zMin: locationToElevationResult,
-                                                                                       zMax: locationToElevationResult + 100,
-                                                                                       spatialReference: lookAtExtent.spatialReference
-                                                                                   });
-                            } else {
-                                target = ArcGISRuntimeEnvironment.createObject("Envelope",{
-                                                                                       xMin: lookAtExtent.xMin,
-                                                                                       yMin: lookAtExtent.yMin,
-                                                                                       xMax: lookAtExtent.xMax,
-                                                                                       yMax: lookAtExtent.yMax,
-                                                                                       zMin: locationToElevationResult,
-                                                                                       // set the camera slightly above the placemark by adding one meter
-                                                                                       zMax: lookAtExtent.depth + locationToElevationResult + 1,
-                                                                                       spatialReference: lookAtExtent.spatialReference
-                                                                                   });
-                            }
-                        } else {
-                            target = ArcGISRuntimeEnvironment.createObject("Envelope",{
                                                                                    xMin: lookAtExtent.xMin,
                                                                                    yMin: lookAtExtent.yMin,
                                                                                    xMax: lookAtExtent.xMax,
                                                                                    yMax: lookAtExtent.yMax,
-                                                                                   zMin: lookAtExtent.zMin + locationToElevationResult,
-                                                                                   zMax: lookAtExtent.zMax + locationToElevationResult,
+                                                                                   zMin: locationToElevationResult,
+                                                                                   zMax: locationToElevationResult + 100,
                                                                                    spatialReference: lookAtExtent.spatialReference
                                                                                });
+                            } else {
+                                target = ArcGISRuntimeEnvironment.createObject("Envelope",{
+                                                                                   xMin: lookAtExtent.xMin,
+                                                                                   yMin: lookAtExtent.yMin,
+                                                                                   xMax: lookAtExtent.xMax,
+                                                                                   yMax: lookAtExtent.yMax,
+                                                                                   zMin: locationToElevationResult,
+                                                                                   // set the camera slightly above the placemark by adding one meter
+                                                                                   zMax: lookAtExtent.depth + locationToElevationResult + 1,
+                                                                                   spatialReference: lookAtExtent.spatialReference
+                                                                               });
+                            }
+                        } else {
+                            target = ArcGISRuntimeEnvironment.createObject("Envelope",{
+                                                                               xMin: lookAtExtent.xMin,
+                                                                               yMin: lookAtExtent.yMin,
+                                                                               xMax: lookAtExtent.xMax,
+                                                                               yMax: lookAtExtent.yMax,
+                                                                               zMin: lookAtExtent.zMin + locationToElevationResult,
+                                                                               zMax: lookAtExtent.zMax + locationToElevationResult,
+                                                                               spatialReference: lookAtExtent.spatialReference
+                                                                           });
                         }
 
                         // if node has viewpoint specified, return adjusted geometry with adjusted camera

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
@@ -43,12 +43,12 @@ int main(int argc, char *argv[])
   const QString apiKey = QStringLiteral("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
+                  "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else
   {
-      QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
+    QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
   // Initialize application view


### PR DESCRIPTION
Adds a buffer of one meter to fix the QML extruded placemark not displaying correctly. The camera was previously being set _in_ the placemark so it wasn't displaying correctly. C++ had a fix for this, but I added the fix to QML as well.

This also updates the basemap to use BasemapStyles and updates the formatting of the QML implementation.

Line 379 in the QML implementation is the only significant change and fixes the issue.