### PR TITLE
Tan11389/sketch delete button fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchOnMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchOnMap.cpp
@@ -159,12 +159,13 @@ void SketchOnMap::createSymbols()
   m_multiPointSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle::Square, QColor(0, 0, 255), 10, this);
   m_lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(144, 238, 144), 3, this);
   m_polygonSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor(67, 166, 198, 119),
-                                        new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(67, 166, 198), 2.0, this), this);
+                                         new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(67, 166, 198), 2.0, this), this);
 }
 
 void SketchOnMap::deleteVertex()
 {
-  m_sketchEditor->removeSelectedVertex();
+  if (m_sketchEditor->geometry().extent().isValid())
+    m_sketchEditor->removeSelectedVertex();
 }
 
 void SketchOnMap::clearGraphics()

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
@@ -56,8 +56,9 @@ Item {
 
         Menu {
             id: contextMenu
-            width: 75
+            width: actionComponent.width
             Action {
+                id: actionComponent
                 text: "Delete"
                 onTriggered: model.deleteVertex();
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
@@ -81,7 +81,10 @@ Rectangle {
             width: 75
             Action {
                 text: "Delete"
-                onTriggered: sketchEditor.removeSelectedVertex();
+                onTriggered: {
+                    if (sketchEditor.geometry.extent.center.x)
+                        sketchEditor.removeSelectedVertex();
+                }
             }
         }
     }
@@ -257,7 +260,11 @@ Rectangle {
                     enabled: sketchEditor.started
 
                     onClicked: {
-                        sketchEditor.removeSelectedVertex();
+                        console.log(sketchEditor.geometry.extent.center.x);
+                        if (!isNaN(sketchEditor.geometry.extent.center.x)) {
+                            console.log("deleting");
+                            sketchEditor.removeSelectedVertex();
+                        }
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
@@ -78,11 +78,12 @@ Rectangle {
 
         Menu {
             id: contextMenu
-            width: 75
+            width: actionComponent.width
             Action {
+                id: actionComponent
                 text: "Delete"
                 onTriggered: {
-                    if (sketchEditor.geometry.extent.center.x)
+                    if (!sketchEditor.geometry.extent.empty)
                         sketchEditor.removeSelectedVertex();
                 }
             }
@@ -260,9 +261,7 @@ Rectangle {
                     enabled: sketchEditor.started
 
                     onClicked: {
-                        console.log(sketchEditor.geometry.extent.center.x);
-                        if (!isNaN(sketchEditor.geometry.extent.center.x)) {
-                            console.log("deleting");
+                        if (!sketchEditor.geometry.extent.empty) {
                             sketchEditor.removeSelectedVertex();
                         }
                     }


### PR DESCRIPTION
The sketch on map sample would crash if "delete selected vertex" was called on an empty sketch.
The delete button popup also displayed incorrectly in the Sample Viewer - this change sets the width to allow the box to resize to fit the inner text.