### PR TITLE
Andrewbladon/fix ogc feature service crash

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
@@ -99,9 +99,7 @@ void BrowseOGCAPIFeatureService::handleError(const Esri::ArcGISRuntime::Error& e
 void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
 {
   if (m_featureService && m_featureService->loadStatus() == LoadStatus::Loading)
-  {
     return;
-  }
 
   clearExistingFeatureService();
 
@@ -114,8 +112,10 @@ void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
   // Connect errorOccurred to handleError()
   connect(m_featureService, &OgcFeatureService::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
+  // Connect to loadingChanged() to enable and disable UI buttons
+  connect(m_featureService, &OgcFeatureService::loadStatusChanged, this, &BrowseOGCAPIFeatureService::loadingChanged);
+
   m_featureService->load();
-  setLoading(true);
 }
 
 void BrowseOGCAPIFeatureService::clearExistingFeatureService()
@@ -131,14 +131,13 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureService()
     delete m_featureService;
     m_featureService = nullptr;
   }
+
   m_featureCollectionList.clear();
   emit featureCollectionListChanged();
 }
 
 void BrowseOGCAPIFeatureService::retrieveCollectionInfos()
 {
-  setLoading(false);
-
   // Assign OGC service metadata to m_serviceInfo property
   m_serviceInfo = m_featureService->serviceInfo();
 
@@ -196,7 +195,10 @@ void BrowseOGCAPIFeatureService::loadFeatureCollection(int selectedFeature)
   // Connect errorOccurred to handleError()
   connect(m_featureLayer, &FeatureLayer::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
-  setLoading(true);
+  // Connect to loadingChanged() to enable and disable UI buttons
+  connect(m_featureLayer, &FeatureLayer::loadStatusChanged, this, &BrowseOGCAPIFeatureService::loadingChanged);
+
+  m_featureLayer->load();
 }
 
 void BrowseOGCAPIFeatureService::clearExistingFeatureLayer()
@@ -216,8 +218,6 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureLayer()
 
 void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
 {
-  setLoading(false);
-
   // Adjust the viewpoint to match the extent of the layer
   m_mapView->setViewpointGeometry(m_featureLayer->fullExtent());
 
@@ -228,11 +228,11 @@ void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
 
 bool BrowseOGCAPIFeatureService::loading() const
 {
-  return isLoading;
-}
+  if (m_featureService && m_featureService->loadStatus() == LoadStatus::Loading)
+    return true;
 
-void BrowseOGCAPIFeatureService::setLoading(bool loading)
-{
-  isLoading = loading;
-  emit loadingChanged();
+  else if (m_featureLayer && m_featureLayer->loadStatus() == LoadStatus::Loading)
+    return true;
+
+  return false;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
@@ -113,7 +113,7 @@ void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
   connect(m_featureService, &OgcFeatureService::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
   // Connect to loadingChanged() to enable and disable UI buttons
-  connect(m_featureService, &OgcFeatureService::loadStatusChanged, this, &BrowseOGCAPIFeatureService::loadingChanged);
+  connect(m_featureService, &OgcFeatureService::loadStatusChanged, this, &BrowseOGCAPIFeatureService::serviceOrFeatureLoadingChanged);
 
   m_featureService->load();
 }
@@ -196,7 +196,7 @@ void BrowseOGCAPIFeatureService::loadFeatureCollection(int selectedFeature)
   connect(m_featureLayer, &FeatureLayer::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
   // Connect to loadingChanged() to enable and disable UI buttons
-  connect(m_featureLayer, &FeatureLayer::loadStatusChanged, this, &BrowseOGCAPIFeatureService::loadingChanged);
+  connect(m_featureLayer, &FeatureLayer::loadStatusChanged, this, &BrowseOGCAPIFeatureService::serviceOrFeatureLoadingChanged);
 
   m_featureLayer->load();
 }
@@ -226,7 +226,7 @@ void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
   m_map->operationalLayers()->append(m_featureLayer);
 }
 
-bool BrowseOGCAPIFeatureService::loading() const
+bool BrowseOGCAPIFeatureService::serviceOrFeatureLoading() const
 {
   if (m_featureService && m_featureService->loadStatus() == LoadStatus::Loading)
     return true;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
@@ -98,6 +98,11 @@ void BrowseOGCAPIFeatureService::handleError(const Esri::ArcGISRuntime::Error& e
 
 void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
 {
+  if (m_featureService && m_featureService->loadStatus() == LoadStatus::Loading)
+  {
+    return;
+  }
+
   clearExistingFeatureService();
 
   // Instantiate new OGCFeatureService object using url
@@ -110,6 +115,7 @@ void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
   connect(m_featureService, &OgcFeatureService::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
   m_featureService->load();
+  setLoading(true);
 }
 
 void BrowseOGCAPIFeatureService::clearExistingFeatureService()
@@ -131,6 +137,8 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureService()
 
 void BrowseOGCAPIFeatureService::retrieveCollectionInfos()
 {
+  setLoading(false);
+
   // Assign OGC service metadata to m_serviceInfo property
   m_serviceInfo = m_featureService->serviceInfo();
 
@@ -187,6 +195,8 @@ void BrowseOGCAPIFeatureService::loadFeatureCollection(int selectedFeature)
 
   // Connect errorOccurred to handleError()
   connect(m_featureLayer, &FeatureLayer::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
+
+  setLoading(true);
 }
 
 void BrowseOGCAPIFeatureService::clearExistingFeatureLayer()
@@ -206,10 +216,23 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureLayer()
 
 void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
 {
+  setLoading(false);
+
   // Adjust the viewpoint to match the extent of the layer
   m_mapView->setViewpointGeometry(m_featureLayer->fullExtent());
 
   // Clear any existing layers and add current layer to map
   m_map->operationalLayers()->clear();
   m_map->operationalLayers()->append(m_featureLayer);
+}
+
+bool BrowseOGCAPIFeatureService::loading() const
+{
+  return isLoading;
+}
+
+void BrowseOGCAPIFeatureService::setLoading(bool loading)
+{
+  isLoading = loading;
+  emit loadingChanged();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
@@ -43,6 +43,7 @@ class BrowseOGCAPIFeatureService : public QObject
   Q_PROPERTY(QString errorMessage READ errorMessage WRITE setErrorMessage NOTIFY errorMessageChanged)
   Q_PROPERTY(QUrl featureServiceUrl READ featureServiceUrl NOTIFY urlChanged)
   Q_PROPERTY(QStringList featureCollectionList READ featureCollectionList NOTIFY featureCollectionListChanged)
+  Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
 public:
   explicit BrowseOGCAPIFeatureService(QObject* parent = nullptr);
@@ -58,6 +59,7 @@ signals:
   void errorMessageChanged();
   void urlChanged();
   void featureCollectionListChanged();
+  void loadingChanged();
 
 private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;
@@ -73,6 +75,8 @@ private:
   void createFeatureCollectionList();
   void clearExistingFeatureLayer();
   void addFeatureLayerToMap();
+  bool loading() const;
+  void setLoading(bool loading);
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
@@ -84,6 +88,7 @@ private:
   QStringList m_featureCollectionList;
   Esri::ArcGISRuntime::OgcFeatureCollectionTable* m_featureCollectionTable = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
+  bool isLoading = false;
 };
 
 #endif // BROWSEOGCAPIFEATURESERVICE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
@@ -76,7 +76,6 @@ private:
   void clearExistingFeatureLayer();
   void addFeatureLayerToMap();
   bool loading() const;
-  void setLoading(bool loading);
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
@@ -88,7 +87,6 @@ private:
   QStringList m_featureCollectionList;
   Esri::ArcGISRuntime::OgcFeatureCollectionTable* m_featureCollectionTable = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
-  bool isLoading = false;
 };
 
 #endif // BROWSEOGCAPIFEATURESERVICE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
@@ -43,7 +43,7 @@ class BrowseOGCAPIFeatureService : public QObject
   Q_PROPERTY(QString errorMessage READ errorMessage WRITE setErrorMessage NOTIFY errorMessageChanged)
   Q_PROPERTY(QUrl featureServiceUrl READ featureServiceUrl NOTIFY urlChanged)
   Q_PROPERTY(QStringList featureCollectionList READ featureCollectionList NOTIFY featureCollectionListChanged)
-  Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+  Q_PROPERTY(bool serviceOrFeatureLoading READ serviceOrFeatureLoading NOTIFY serviceOrFeatureLoadingChanged)
 
 public:
   explicit BrowseOGCAPIFeatureService(QObject* parent = nullptr);
@@ -59,7 +59,7 @@ signals:
   void errorMessageChanged();
   void urlChanged();
   void featureCollectionListChanged();
-  void loadingChanged();
+  void serviceOrFeatureLoadingChanged();
 
 private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;
@@ -75,7 +75,7 @@ private:
   void createFeatureCollectionList();
   void clearExistingFeatureLayer();
   void addFeatureLayerToMap();
-  bool loading() const;
+  bool serviceOrFeatureLoading() const;
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -65,7 +65,7 @@ Item {
                 Button {
                     id: connectButton
                     text: "Load service"
-                    enabled: !model.loading
+                    enabled: !model.serviceOrFeatureLoading
                     onClicked: model.loadService(serviceURLBox.text);
 
                 }
@@ -79,7 +79,7 @@ Item {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
-                    enabled: !model.loading
+                    enabled: !model.serviceOrFeatureLoading
                     onClicked: model.loadFeatureCollection(featureList.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -65,6 +65,7 @@ Item {
                 Button {
                     id: connectButton
                     text: "Load service"
+                    enabled: model.loading ? false : true;
                     onClicked: model.loadService(serviceURLBox.text);
 
                 }
@@ -78,6 +79,7 @@ Item {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
+                    enabled: model.loading ? false : true;
                     onClicked: model.loadFeatureCollection(featureList.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -65,7 +65,7 @@ Item {
                 Button {
                     id: connectButton
                     text: "Load service"
-                    enabled: model.loading ? false : true;
+                    enabled: !model.loading
                     onClicked: model.loadService(serviceURLBox.text);
 
                 }
@@ -79,7 +79,7 @@ Item {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
-                    enabled: model.loading ? false : true;
+                    enabled: !model.loading
                     onClicked: model.loadFeatureCollection(featureList.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -30,7 +30,6 @@ Rectangle {
     property OgcFeatureService featureService: null
     property FeatureLayer featureLayer : null
     property string errorMessage: ""
-    property bool loading: false
 
     MapView {
         id: mapView
@@ -79,7 +78,7 @@ Rectangle {
                 Button {
                     id: connectButton
                     text: "Load service"
-                    enabled: loading ? false : true;
+                    enabled: featureService.loadStatus !== Enums.LoadStatusLoading
                     onClicked: {
                         serviceURL = serviceURLBox.text;
                         loadFeatureService(serviceURL);
@@ -96,7 +95,7 @@ Rectangle {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
-                    enabled: loading ? false : true;
+                    enabled: featureLayer.loadStatus !== Enums.LoadStatusLoading
                     onClicked: loadFeatureCollection(featureCollectionListComboBox.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
@@ -127,15 +126,7 @@ Rectangle {
         // Connect loaded signal to checkForLoadingErrors() function
         root.featureService.loadStatusChanged.connect(checkForLoadingErrors);
 
-        // Once loaded, return the loading property to false
-        root.featureService.loadStatusChanged.connect(function() {
-            if (root.featureService.loadStatus === Enums.LoadStatusLoaded)
-                loading = false;
-        }
-        );
-
         featureService.load();
-        loading = true;
     }
 
     function handleError(error) {
@@ -148,7 +139,6 @@ Rectangle {
     function checkForLoadingErrors() {
         if (root.featureService.loadStatus === Enums.LoadStatusFailedToLoad) {
             handleError(root.featureService.loadError);
-            loading = false;
         }
     }
 
@@ -172,20 +162,17 @@ Rectangle {
         root.featureLayer.loadStatusChanged.connect(checkIfLayerLoaded);
 
         root.featureLayer.load();
-        loading = true;
     }
 
     function checkIfLayerLoaded() {
         if (root.featureLayer.loadStatus === Enums.LoadStatusFailedToLoad) {
             handleError(root.featureLayer.loadError);
-            loading = false;
             return;
         }
         else if (root.featureLayer.loadStatus !== Enums.LoadStatusLoaded) {
             return;
         }
         addFeatureLayerToMap();
-        loading = false;
     }
 
     function addFeatureLayerToMap() {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -30,6 +30,7 @@ Rectangle {
     property OgcFeatureService featureService: null
     property FeatureLayer featureLayer : null
     property string errorMessage: ""
+    property bool loading: false
 
     MapView {
         id: mapView
@@ -78,6 +79,7 @@ Rectangle {
                 Button {
                     id: connectButton
                     text: "Load service"
+                    enabled: loading ? false : true;
                     onClicked: {
                         serviceURL = serviceURLBox.text;
                         loadFeatureService(serviceURL);
@@ -94,6 +96,7 @@ Rectangle {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
+                    enabled: loading ? false : true;
                     onClicked: loadFeatureCollection(featureCollectionListComboBox.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
@@ -124,7 +127,15 @@ Rectangle {
         // Connect loaded signal to checkForLoadingErrors() function
         root.featureService.loadStatusChanged.connect(checkForLoadingErrors);
 
+        // Once loaded, return the loading property to false
+        root.featureService.loadStatusChanged.connect(function() {
+            if (root.featureService.loadStatus === Enums.LoadStatusLoaded)
+                loading = false;
+        }
+        );
+
         featureService.load();
+        loading = true;
     }
 
     function handleError(error) {
@@ -137,6 +148,7 @@ Rectangle {
     function checkForLoadingErrors() {
         if (root.featureService.loadStatus === Enums.LoadStatusFailedToLoad) {
             handleError(root.featureService.loadError);
+            loading = false;
         }
     }
 
@@ -160,17 +172,20 @@ Rectangle {
         root.featureLayer.loadStatusChanged.connect(checkIfLayerLoaded);
 
         root.featureLayer.load();
+        loading = true;
     }
 
     function checkIfLayerLoaded() {
         if (root.featureLayer.loadStatus === Enums.LoadStatusFailedToLoad) {
             handleError(root.featureLayer.loadError);
+            loading = false;
             return;
         }
         else if (root.featureLayer.loadStatus !== Enums.LoadStatusLoaded) {
             return;
         }
         addFeatureLayerToMap();
+        loading = false;
     }
 
     function addFeatureLayerToMap() {


### PR DESCRIPTION
This PR is to fix crashes found during verification. Investigation into the cause suggested that if the load buttons were pressed while the feature service or a feature layer was loading, the sample viewer crashed. To prevent this, the load buttons have been disabled while the feature service or a feature layer is loading.

@ldanzinger and @JamesMBallard, could you confirm that, once approved, it is ok to merge these changes into the 100.12.0 release branch?