### PR TITLE
Tan11389/ab/ogc feature service fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
@@ -99,9 +99,7 @@ void BrowseOGCAPIFeatureService::handleError(const Esri::ArcGISRuntime::Error& e
 void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
 {
   if (m_featureService && m_featureService->loadStatus() == LoadStatus::Loading)
-  {
     return;
-  }
 
   clearExistingFeatureService();
 
@@ -114,8 +112,10 @@ void BrowseOGCAPIFeatureService::loadFeatureService(const QUrl& url)
   // Connect errorOccurred to handleError()
   connect(m_featureService, &OgcFeatureService::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
+  // Connect to loadingChanged() to enable and disable UI buttons
+  connect(m_featureService, &OgcFeatureService::loadStatusChanged, this, &BrowseOGCAPIFeatureService::loadingChanged);
+
   m_featureService->load();
-  setLoading(true);
 }
 
 void BrowseOGCAPIFeatureService::clearExistingFeatureService()
@@ -137,8 +137,6 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureService()
 
 void BrowseOGCAPIFeatureService::retrieveCollectionInfos()
 {
-  setLoading(false);
-
   // Assign OGC service metadata to m_serviceInfo property
   m_serviceInfo = m_featureService->serviceInfo();
 
@@ -196,7 +194,10 @@ void BrowseOGCAPIFeatureService::loadFeatureCollection(int selectedFeature)
   // Connect errorOccurred to handleError()
   connect(m_featureLayer, &FeatureLayer::errorOccurred, this, &BrowseOGCAPIFeatureService::handleError);
 
-  setLoading(true);
+  // Connect to loadingChanged() to enable and disable UI buttons
+  connect(m_featureLayer, &FeatureLayer::loadStatusChanged, this, &BrowseOGCAPIFeatureService::loadingChanged);
+
+  m_featureLayer->load();
 }
 
 void BrowseOGCAPIFeatureService::clearExistingFeatureLayer()
@@ -216,8 +217,6 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureLayer()
 
 void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
 {
-  setLoading(false);
-
   // Adjust the viewpoint to match the extent of the layer
   m_mapView->setViewpointGeometry(m_featureLayer->fullExtent());
 
@@ -228,11 +227,5 @@ void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
 
 bool BrowseOGCAPIFeatureService::loading() const
 {
-  return isLoading;
-}
-
-void BrowseOGCAPIFeatureService::setLoading(bool loading)
-{
-  isLoading = loading;
-  emit loadingChanged();
+  return m_featureService->loadStatus() == LoadStatus::Loading;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.cpp
@@ -131,6 +131,7 @@ void BrowseOGCAPIFeatureService::clearExistingFeatureService()
     delete m_featureService;
     m_featureService = nullptr;
   }
+
   m_featureCollectionList.clear();
   emit featureCollectionListChanged();
 }
@@ -227,5 +228,11 @@ void BrowseOGCAPIFeatureService::addFeatureLayerToMap()
 
 bool BrowseOGCAPIFeatureService::loading() const
 {
-  return m_featureService->loadStatus() == LoadStatus::Loading;
+  if (m_featureService && m_featureService->loadStatus() == LoadStatus::Loading)
+    return true;
+
+  else if (m_featureLayer && m_featureLayer->loadStatus() == LoadStatus::Loading)
+    return true;
+
+  return false;
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
@@ -87,7 +87,6 @@ private:
   QStringList m_featureCollectionList;
   Esri::ArcGISRuntime::OgcFeatureCollectionTable* m_featureCollectionTable = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
-  bool isLoading = false;
 };
 
 #endif // BROWSEOGCAPIFEATURESERVICE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
@@ -76,7 +76,6 @@ private:
   void clearExistingFeatureLayer();
   void addFeatureLayerToMap();
   bool loading() const;
-  void setLoading(bool loading);
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -65,7 +65,7 @@ Item {
                 Button {
                     id: connectButton
                     text: "Load service"
-                    enabled: model.loading ? false : true;
+                    enabled: !model.loading
                     onClicked: model.loadService(serviceURLBox.text);
 
                 }
@@ -79,7 +79,7 @@ Item {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
-                    enabled: model.loading ? false : true;
+                    enabled: !model.loading
                     onClicked: model.loadFeatureCollection(featureList.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -30,7 +30,6 @@ Rectangle {
     property OgcFeatureService featureService: null
     property FeatureLayer featureLayer : null
     property string errorMessage: ""
-    property bool loading: false
 
     MapView {
         id: mapView
@@ -79,7 +78,7 @@ Rectangle {
                 Button {
                     id: connectButton
                     text: "Load service"
-                    enabled: loading ? false : true;
+                    enabled: featureService.loadStatus !== Enums.LoadStatusLoading
                     onClicked: {
                         serviceURL = serviceURLBox.text;
                         loadFeatureService(serviceURL);
@@ -96,7 +95,7 @@ Rectangle {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
-                    enabled: loading ? false : true;
+                    enabled: featureLayer.loadStatus !== Enums.LoadStatusLoading
                     onClicked: loadFeatureCollection(featureCollectionListComboBox.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
@@ -127,15 +126,7 @@ Rectangle {
         // Connect loaded signal to checkForLoadingErrors() function
         root.featureService.loadStatusChanged.connect(checkForLoadingErrors);
 
-        // Once loaded, return the loading property to false
-        root.featureService.loadStatusChanged.connect(function() {
-            if (root.featureService.loadStatus === Enums.LoadStatusLoaded)
-                loading = false;
-        }
-        );
-
         featureService.load();
-        loading = true;
     }
 
     function handleError(error) {
@@ -148,7 +139,6 @@ Rectangle {
     function checkForLoadingErrors() {
         if (root.featureService.loadStatus === Enums.LoadStatusFailedToLoad) {
             handleError(root.featureService.loadError);
-            loading = false;
         }
     }
 
@@ -172,20 +162,17 @@ Rectangle {
         root.featureLayer.loadStatusChanged.connect(checkIfLayerLoaded);
 
         root.featureLayer.load();
-        loading = true;
     }
 
     function checkIfLayerLoaded() {
         if (root.featureLayer.loadStatus === Enums.LoadStatusFailedToLoad) {
             handleError(root.featureLayer.loadError);
-            loading = false;
             return;
         }
         else if (root.featureLayer.loadStatus !== Enums.LoadStatusLoaded) {
             return;
         }
         addFeatureLayerToMap();
-        loading = false;
     }
 
     function addFeatureLayerToMap() {


### PR DESCRIPTION
Binds the `LoadStatus` property of `m_featureService` and `m_featureLayer` to enable and disable the UI buttons rather than creating another member variable.