### PR TITLE
Andrewbladon/fix ogc feature service crash (#1273)

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.h
@@ -43,6 +43,7 @@ class BrowseOGCAPIFeatureService : public QObject
   Q_PROPERTY(QString errorMessage READ errorMessage WRITE setErrorMessage NOTIFY errorMessageChanged)
   Q_PROPERTY(QUrl featureServiceUrl READ featureServiceUrl NOTIFY urlChanged)
   Q_PROPERTY(QStringList featureCollectionList READ featureCollectionList NOTIFY featureCollectionListChanged)
+  Q_PROPERTY(bool serviceOrFeatureLoading READ serviceOrFeatureLoading NOTIFY serviceOrFeatureLoadingChanged)
 
 public:
   explicit BrowseOGCAPIFeatureService(QObject* parent = nullptr);
@@ -58,6 +59,7 @@ signals:
   void errorMessageChanged();
   void urlChanged();
   void featureCollectionListChanged();
+  void serviceOrFeatureLoadingChanged();
 
 private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;
@@ -73,6 +75,7 @@ private:
   void createFeatureCollectionList();
   void clearExistingFeatureLayer();
   void addFeatureLayerToMap();
+  bool serviceOrFeatureLoading() const;
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -65,6 +65,7 @@ Item {
                 Button {
                     id: connectButton
                     text: "Load service"
+                    enabled: !model.serviceOrFeatureLoading
                     onClicked: model.loadService(serviceURLBox.text);
 
                 }
@@ -78,6 +79,7 @@ Item {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
+                    enabled: !model.serviceOrFeatureLoading
                     onClicked: model.loadFeatureCollection(featureList.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -78,6 +78,7 @@ Rectangle {
                 Button {
                     id: connectButton
                     text: "Load service"
+                    enabled: featureService.loadStatus !== Enums.LoadStatusLoading
                     onClicked: {
                         serviceURL = serviceURLBox.text;
                         loadFeatureService(serviceURL);
@@ -94,6 +95,7 @@ Rectangle {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
+                    enabled: featureLayer.loadStatus !== Enums.LoadStatusLoading
                     onClicked: loadFeatureCollection(featureCollectionListComboBox.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true


### PR DESCRIPTION
* Disable load buttons while loading in c++ sample

* Disable load buttons while loading in Qml sample

* Tan11389/ab/ogc feature service fix (#1275)

* Update loading handlers in C++

* loading logic cleanup

* remove unused member variable

* Change name of loading QPROPERTY in c++ sample

Co-authored-by: Tanner Yould <tyould@esri.com>
(cherry picked from commit d9b2173883f75ff84b7e1fdc6723f636583254a0)