### PR TITLE
Build a legend - remove soil survey tile layer

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.cpp
@@ -76,9 +76,6 @@ void BuildLegend::componentComplete()
 
 void BuildLegend::addLayers()
 {
-  ArcGISTiledLayer* tiledLayer = new ArcGISTiledLayer(QUrl("https://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer"), this);
-  m_map->operationalLayers()->append(tiledLayer);
-
   ArcGISMapImageLayer* mapImageLayer = new ArcGISMapImageLayer(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"), this);
   m_map->operationalLayers()->append(mapImageLayer);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -36,12 +36,6 @@ Rectangle {
                 initStyle: Enums.BasemapStyleArcGISTopographic
             }
 
-            // Add a tiled layer as an operational layer
-            ArcGISTiledLayer {
-                id: tiledLayer
-                url: "https://services.arcgisonline.com/ArcGIS/rest/services/Specialty/Soil_Survey_Map/MapServer"
-            }
-
             // Add a map image layer as an operational layer
             ArcGISMapImageLayer {
                 id: mapImageLayer


### PR DESCRIPTION
The soil survey tile layer no longer exists, so we're removing it from the sample. The sample runs fine with the tile layer not existing, but we should remove it for code integrity.