### PR TITLE
Geotriggers add QUrl include/QML Curve comment cleanup

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.h
@@ -38,6 +38,7 @@ class SimulatedLocationDataSource;
 
 #include <QObject>
 #include <QMap>
+#include <QUrl>
 
 class Geotriggers : public QObject
 {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.qml
@@ -166,7 +166,6 @@ Rectangle {
         polygonGraphicsOverlay.graphics.append(polygonGraphic);
 
         // Create the heart graphic with curved line segments
-        // The geometry for the heart graphic is defined in heartGraphicGeometryBuilder.qml
         heartGraphic.geometry = createHeartGeometry(40e5, 5e5, 10e5, Factory.SpatialReference.createWebMercator());
         heartGraphicsOverlay.graphics.append(heartGraphic);
     }


### PR DESCRIPTION
Adds `#include <QUrl>` to the geotriggers.h file. The sample would run fine in the sample viewer but wouldn't build on its own without that include. 

I'm also including a quick comment cleanup in this PR for the QML curves sample--the file referenced was from an earlier iteration that no longer exists.