### PR TITLE
Remove tile layer include

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.cpp
@@ -23,7 +23,6 @@
 #include "Map.h"
 #include "MapQuickView.h"
 #include "Basemap.h"
-#include "ArcGISTiledLayer.h"
 #include "ArcGISMapImageLayer.h"
 #include "FeatureLayer.h"
 #include "ServiceFeatureTable.h"


### PR DESCRIPTION
Removes the tile layer include from the cpp file. Now that we've removed the tile layer from the code, we no longer need to include the header file.