### PR TITLE
Update display device location redirect

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
@@ -19,7 +19,7 @@
     ],
     "redirect_from": [
         "/qt/latest/cpp/sample-code/sample-qt-displaydevicelocation.htm",
-        "/qt/cpp/sample-code/display-device-location-with-autopan-modes/"
+        "/qt/cpp/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
@@ -18,7 +18,8 @@
         "MapView"
     ],
     "redirect_from": [
-        "/qt/latest/cpp/sample-code/sample-qt-displaydevicelocation.htm"
+        "/qt/latest/cpp/sample-code/sample-qt-displaydevicelocation.htm",
+        "/qt/cpp/sample-code/display-device-location-with-autopan-modes/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/README.metadata.json
@@ -18,7 +18,8 @@
         "MapView"
     ],
     "redirect_from": [
-        "/qt/latest/qml/sample-code/sample-qt-displaydevicelocation.htm"
+        "/qt/latest/qml/sample-code/sample-qt-displaydevicelocation.htm",
+        "/qt/qml/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",


### PR DESCRIPTION
Links pointing to the old name of the "Display device location using autopan modes" which was just "Display device location" (for example [here](https://developers.arcgis.com/qt/maps-2d/#samples)) are broken on the website. This PR adds the broken url to the metadata files' redirect lists.