### PR TITLE
Andrewbladon/add mesh layer service issue handling

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.cpp
@@ -44,9 +44,9 @@ AddIntegratedMeshLayer::AddIntegratedMeshLayer(QObject* parent /* = nullptr */):
   setIntegratedMeshViewpoint();
 }
 
-void AddIntegratedMeshLayer::handleError(Error error)
+void AddIntegratedMeshLayer::handleError(const Error& error)
 {
-  // If the doneLoading error message is not empty, an error has been thrown.
+  // If the doneLoading error message is not empty, an error has been encountered.
   if (!error.isEmpty())
   {
     if (error.additionalMessage().isEmpty())
@@ -97,7 +97,7 @@ QString AddIntegratedMeshLayer::errorMessage() const
   return m_errorMessage;
 }
 
-void AddIntegratedMeshLayer::setErrorMessage(QString message)
+void AddIntegratedMeshLayer::setErrorMessage(const QString& message)
 {
   m_errorMessage = message;
   emit errorMessageChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.cpp
@@ -26,15 +26,11 @@
 #include "IntegratedMeshLayer.h"
 
 using namespace Esri::ArcGISRuntime;
-namespace
-{
-  const QUrl meshLyrUrl("https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer");
-}
 
 AddIntegratedMeshLayer::AddIntegratedMeshLayer(QObject* parent /* = nullptr */):
   QObject(parent),
   m_scene(new Scene(this)),
-  m_integratedMeshLyr(new IntegratedMeshLayer(meshLyrUrl, this))
+  m_integratedMeshLyr(new IntegratedMeshLayer(QUrl("https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer"), this))
 {
   // Connect the doneLoading signal to the handleError() method.
   connect(m_integratedMeshLyr, &IntegratedMeshLayer::doneLoading, this, &AddIntegratedMeshLayer::handleError);
@@ -50,10 +46,12 @@ void AddIntegratedMeshLayer::handleError(const Error& error)
   if (!error.isEmpty())
   {
     if (error.additionalMessage().isEmpty())
-      setErrorMessage(error.message());
+      m_errorMessage = error.message();
     else
-      setErrorMessage(error.message() + "\n" + error.additionalMessage());
+      m_errorMessage = error.message() + "\n" + error.additionalMessage();
   }
+
+  emit errorMessageChanged();
 }
 
 void AddIntegratedMeshLayer::setIntegratedMeshViewpoint()
@@ -90,15 +88,4 @@ void AddIntegratedMeshLayer::setSceneView(SceneQuickView* sceneView)
   m_sceneView->setArcGISScene(m_scene);
 
   emit sceneViewChanged();
-}
-
-QString AddIntegratedMeshLayer::errorMessage() const
-{
-  return m_errorMessage;
-}
-
-void AddIntegratedMeshLayer::setErrorMessage(const QString& message)
-{
-  m_errorMessage = message;
-  emit errorMessageChanged();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
@@ -29,14 +29,13 @@ class Error;
 }
 
 #include <QObject>
-/*FOR TESTING*/#include <MapTypes.h>
 
 class AddIntegratedMeshLayer : public QObject
 {
   Q_OBJECT
 
   Q_PROPERTY(Esri::ArcGISRuntime::SceneQuickView* sceneView READ sceneView WRITE setSceneView NOTIFY sceneViewChanged)
-  Q_PROPERTY(bool errorWhileLoading READ errorWhileLoading WRITE seterrorWhileLoading NOTIFY errorWhileLoadingStatusChanged)
+  Q_PROPERTY(QString errorMessage READ errorMessage WRITE setErrorMessage NOTIFY errorMessageChanged)
 
 public:
   explicit AddIntegratedMeshLayer(QObject* parent = nullptr);
@@ -46,23 +45,21 @@ public:
 
 signals:
   void sceneViewChanged();
-  void errorWhileLoadingStatusChanged();
+  void errorMessageChanged();
 
 private:
   Esri::ArcGISRuntime::SceneQuickView* sceneView() const;
   void setSceneView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
-  bool errorWhileLoading() const;
-  void seterrorWhileLoading(bool errorWhileLoadingStatus);
+  QString errorMessage() const;
+  void setErrorMessage(QString message);
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
   Esri::ArcGISRuntime::IntegratedMeshLayer* m_integratedMeshLyr = nullptr;
-  bool m_errorWhileLoading = false;
+  QString m_errorMessage = "";
 
-  void handleLoadingCompleted(Esri::ArcGISRuntime::Error error);
-  void createSceneForIntegratedMesh();
+  void handleError(Esri::ArcGISRuntime::Error error);
   void setIntegratedMeshViewpoint();
-  void createDefaultScene();
 };
 
 #endif // ADDINTEGRATEDMESHLAYER_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
@@ -21,10 +21,10 @@ namespace Esri
 {
 namespace ArcGISRuntime
 {
+class Error;
+class IntegratedMeshLayer;
 class Scene;
 class SceneQuickView;
-class IntegratedMeshLayer;
-class Error;
 }
 }
 
@@ -51,14 +51,14 @@ private:
   Esri::ArcGISRuntime::SceneQuickView* sceneView() const;
   void setSceneView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
   QString errorMessage() const;
-  void setErrorMessage(QString message);
+  void setErrorMessage(const QString& message);
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
   Esri::ArcGISRuntime::IntegratedMeshLayer* m_integratedMeshLyr = nullptr;
-  QString m_errorMessage = "";
+  QString m_errorMessage;
 
-  void handleError(Esri::ArcGISRuntime::Error error);
+  void handleError(const Esri::ArcGISRuntime::Error& error);
   void setIntegratedMeshViewpoint();
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
@@ -35,7 +35,7 @@ class AddIntegratedMeshLayer : public QObject
   Q_OBJECT
 
   Q_PROPERTY(Esri::ArcGISRuntime::SceneQuickView* sceneView READ sceneView WRITE setSceneView NOTIFY sceneViewChanged)
-  Q_PROPERTY(QString errorMessage READ errorMessage WRITE setErrorMessage NOTIFY errorMessageChanged)
+  Q_PROPERTY(QString errorMessage MEMBER m_errorMessage NOTIFY errorMessageChanged)
 
 public:
   explicit AddIntegratedMeshLayer(QObject* parent = nullptr);
@@ -50,8 +50,6 @@ signals:
 private:
   Esri::ArcGISRuntime::SceneQuickView* sceneView() const;
   void setSceneView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
-  QString errorMessage() const;
-  void setErrorMessage(const QString& message);
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.h
@@ -23,16 +23,20 @@ namespace ArcGISRuntime
 {
 class Scene;
 class SceneQuickView;
+class IntegratedMeshLayer;
+class Error;
 }
 }
 
 #include <QObject>
+/*FOR TESTING*/#include <MapTypes.h>
 
 class AddIntegratedMeshLayer : public QObject
 {
   Q_OBJECT
 
   Q_PROPERTY(Esri::ArcGISRuntime::SceneQuickView* sceneView READ sceneView WRITE setSceneView NOTIFY sceneViewChanged)
+  Q_PROPERTY(bool errorWhileLoading READ errorWhileLoading WRITE seterrorWhileLoading NOTIFY errorWhileLoadingStatusChanged)
 
 public:
   explicit AddIntegratedMeshLayer(QObject* parent = nullptr);
@@ -42,13 +46,23 @@ public:
 
 signals:
   void sceneViewChanged();
+  void errorWhileLoadingStatusChanged();
 
 private:
   Esri::ArcGISRuntime::SceneQuickView* sceneView() const;
   void setSceneView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
+  bool errorWhileLoading() const;
+  void seterrorWhileLoading(bool errorWhileLoadingStatus);
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
+  Esri::ArcGISRuntime::IntegratedMeshLayer* m_integratedMeshLyr = nullptr;
+  bool m_errorWhileLoading = false;
+
+  void handleLoadingCompleted(Esri::ArcGISRuntime::Error error);
+  void createSceneForIntegratedMesh();
+  void setIntegratedMeshViewpoint();
+  void createDefaultScene();
 };
 
 #endif // ADDINTEGRATEDMESHLAYER_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -15,9 +15,8 @@
 // [Legal]
 
 import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
 import QtQuick.Controls 2.5
+import Esri.Samples 1.0
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -34,8 +34,8 @@ Item {
 
     MessageDialog {
         id: errorMessageDialog
-        visible: model.errorWhileLoading ? true : false;
-        text: "The Integrated Mesh Layer Service is Currently Unavailable."
-        onButtonClicked: model.errorWhileLoading = false;
+        visible: model.errorMessage === "" ? false : true;
+        text: model.errorMessage
+        onButtonClicked: model.errorMessage = "";
     }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -35,16 +35,10 @@ Item {
     Dialog {
         id: errorMessageDialog
         anchors.centerIn: parent
+        visible: model.errorMessage !== ""
         title: "Error:"
         contentItem: Label {
             text: model.errorMessage
-        }
-    }
-
-    Connections {
-        target: model
-        function onErrorMessageChanged() {
-            errorMessageDialog.visible = model.errorMessage !== ''
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 2.2
 import Esri.Samples 1.0
+import QtQuick.Dialogs 1.2
 
 Item {
 
@@ -29,5 +30,12 @@ Item {
     AddIntegratedMeshLayerSample {
         id: model
         sceneView: view
+    }
+
+    MessageDialog {
+        id: errorMessageDialog
+        visible: model.errorWhileLoading ? true : false;
+        text: "The Integrated Mesh Layer Service is Currently Unavailable."
+        onButtonClicked: model.errorWhileLoading = false;
     }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 2.2
 import Esri.Samples 1.0
-import QtQuick.Dialogs 1.2
+import QtQuick.Controls 2.5
 
 Item {
 
@@ -32,10 +32,20 @@ Item {
         sceneView: view
     }
 
-    MessageDialog {
+    Dialog {
         id: errorMessageDialog
-        visible: model.errorMessage === "" ? false : true;
-        text: model.errorMessage
-        onButtonClicked: model.errorMessage = "";
+        anchors.centerIn: parent
+        title: "Error:"
+        contentItem: Label {
+            text: model.errorMessage
+        }
+    }
+
+    Connections {
+        target: model
+        function onErrorMessageChanged() {
+            errorMessageDialog.visible = model.errorMessage !== ''
+        }
     }
 }
+

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -42,6 +42,7 @@ Rectangle {
                         errorMessage = error.message;
                     else
                         errorMessage = error.message + "\n" + error.additionalMessage;
+                    errorMessageDialog.visible = errorMessage !== "";
                 }
             }
 
@@ -73,13 +74,6 @@ Rectangle {
             contentItem: Label {
                 id: errorLabel
                 text: errorMessage
-            }
-        }
-
-        Connections {
-            target: integratedMeshLyr
-            function onLoadErrorChanged() {
-                errorMessageDialog.visible = errorMessage !== "";
             }
         }
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -16,7 +16,7 @@
 
 import QtQuick 2.6
 import Esri.ArcGISRuntime 100.12
-import QtQuick.Dialogs 1.2
+import QtQuick.Controls 2.5
 
 Rectangle {
     id: rootRectangle
@@ -35,12 +35,13 @@ Rectangle {
 
             // Add the integrated mesh layer to the scene
             IntegratedMeshLayer {
+                id: integratedMeshLyr
                 url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer"
                 onLoadErrorChanged: {
                     if (!error.additionalMessage)
-                        rootRectangle.errorMessage = error.message;
+                        errorMessage = error.message;
                     else
-                        rootRectangle.errorMessage = error.message + "\n" + error.additionalMessage;
+                        errorMessage = error.message + "\n" + error.additionalMessage;
                 }
             }
 
@@ -65,11 +66,21 @@ Rectangle {
             }
         }
 
-        MessageDialog {
-            id: errorMessageDialogue
-            visible: !rootRectangle.errorMessage ? false : true;
-            text: rootRectangle.errorMessage;
-            onButtonClicked: rootRectangle.errorMessage = "";
+        Dialog {
+            id: errorMessageDialog
+            anchors.centerIn: parent
+            title: "Error:"
+            contentItem: Label {
+                id: errorLabel
+                text: errorMessage
+            }
+        }
+
+        Connections {
+            target: integratedMeshLyr
+            function onLoadErrorChanged() {
+                errorMessageDialog.visible = errorMessage !== "";
+            }
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -16,12 +16,15 @@
 
 import QtQuick 2.6
 import Esri.ArcGISRuntime 100.12
+import QtQuick.Dialogs 1.2
 
 Rectangle {
     id: rootRectangle
     clip: true
     width: 800
     height: 600
+
+    property string errorMessage: ""
 
     SceneView {
         id: sceneView
@@ -33,9 +36,15 @@ Rectangle {
             // Add the integrated mesh layer to the scene
             IntegratedMeshLayer {
                 url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer"
+                onLoadErrorChanged: {
+                    if (!error.additionalMessage)
+                        rootRectangle.errorMessage = error.message;
+                    else
+                        rootRectangle.errorMessage = error.message + "\n" + error.additionalMessage;
+                }
             }
 
-            // Set the initial viewpoint to Yosemite Valley
+            // Set the initial viewpoint
             ViewpointCenter {
                 center: Point {
                     id: initPt
@@ -54,6 +63,13 @@ Rectangle {
                     distance: 200.0
                 }
             }
+        }
+
+        MessageDialog {
+            id: errorMessageDialogue
+            visible: !rootRectangle.errorMessage ? false : true;
+            text: rootRectangle.errorMessage;
+            onButtonClicked: rootRectangle.errorMessage = "";
         }
     }
 }


### PR DESCRIPTION
This PR addresses issues reported with the Add Integrated Mesh Layer sample. The previous implementation of the sample resulted in unexpected behaviour if the Girona Integrated Mesh service was unavailable. These updates check to see if an error occurs while accessing the service and presents the user with an error message if applicable.

@tanneryould, @lsmallwood, and @ldanzinger - would you be able to review these changes? I would appreciate your thoughts, especially on whether you think the implemented changes are sufficient safeguarding against the service being unavailable.