### PR TITLE
Update from 100.6 to 100.13

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.pro
@@ -27,7 +27,7 @@ QT += opengl qml quick
 TEMPLATE = app
 TARGET = ControlAnnotationSublayerVisibility
 
-ARCGIS_RUNTIME_VERSION = 100.6
+ARCGIS_RUNTIME_VERSION = 100.13
 include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.pro
@@ -20,7 +20,7 @@ QT += opengl qml quick
 
 CONFIG += c++14
 
-ARCGIS_RUNTIME_VERSION = 100.6
+ARCGIS_RUNTIME_VERSION = 100.13
 include($$PWD/arcgisruntime.pri)
 
 SOURCES += \

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
@@ -17,7 +17,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import Esri.ArcGISRuntime 100.6
+import Esri.ArcGISRuntime 100.13
 import Esri.ArcGISExtras 1.1
 
 Rectangle {


### PR DESCRIPTION
Control annotation sublayer visibility was still using Runtime 100.6 - this updates v.next to use 100.13. These samples have been updated in the 100.12 main release branch as well.