### PR TITLE
Andrewbladon/add service geodatabase to un samples

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
@@ -32,8 +32,8 @@
 #include "UtilityAssociation.h"
 #include "UtilityElement.h"
 #include "UtilityNetwork.h"
-#include "UtilityNetworkListModel.h"
 #include "UtilityNetworkDefinition.h"
+#include "UtilityNetworkListModel.h"
 #include "UtilityNetworkSource.h"
 #include "UtilityNetworkTypes.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
@@ -67,9 +67,7 @@ void DisplayUtilityAssociations::addAssociations()
 {
   // check if current viewpoint is outside the max scale
   if(m_mapView->currentViewpoint(ViewpointType::CenterAndScale).targetScale() >= maxScale)
-  {
     return;
-  }
 
   // check if current viewpoint has a valid extent
   const Envelope extent = m_mapView->currentViewpoint(ViewpointType::BoundingGeometry).targetGeometry().extent();
@@ -124,9 +122,7 @@ void DisplayUtilityAssociations::setMapView(MapQuickView* mapView)
   connect(m_mapView, &MapQuickView::navigatingChanged, this, [this]()
   {
     if (!m_mapView->isNavigating())
-    {
       addAssociations();
-    }
   });
 
   m_utilityNetwork->load();
@@ -154,31 +150,23 @@ void DisplayUtilityAssociations::connectSignals()
     for (UtilityNetworkSource* networkSource : allSources)
     {
       if (networkSource->sourceType() == UtilityNetworkSourceType::Edge)
-      {
         edges.append(networkSource);
-      }
       else if (networkSource->sourceType() == UtilityNetworkSourceType::Junction)
-      {
         junctions.append(networkSource);
-      }
     }
 
     // add all edges that are not subnet lines to the map
     for (UtilityNetworkSource* source : edges)
     {
       if (source->sourceUsageType() != UtilityNetworkSourceUsageType::SubnetLine && source->featureTable() != nullptr)
-      {
         m_map->operationalLayers()->append(new FeatureLayer(source->featureTable(), this));
-      }
     }
 
     // add all junctions to the map
     for (UtilityNetworkSource* source : junctions)
     {
       if (source->featureTable())
-      {
         m_map->operationalLayers()->append(new FeatureLayer(source->featureTable(), this));
-      }
     }
 
     // create a renderer for the associations

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
@@ -53,15 +53,12 @@ DisplayUtilityAssociations::DisplayUtilityAssociations(QObject* parent /* = null
   QObject(parent),
   m_map(new Map(BasemapStyle::ArcGISTopographic, this)),
   m_cred(new Credential("viewer01", "I68VGU^nMurF", this)),
-  m_associationsOverlay(new GraphicsOverlay(this))
+  m_associationsOverlay(new GraphicsOverlay(this)),
+  m_utilityNetwork(new UtilityNetwork(featureServerUrl, m_cred, this)),
+  m_attachmentSymbol(new SimpleLineSymbol(SimpleLineSymbolStyle::Dot, Qt::green, 5, this)),
+  m_connectivitySymbol(new SimpleLineSymbol(SimpleLineSymbolStyle::Dot, Qt::red, 5, this))
 {
-  m_utilityNetwork = new UtilityNetwork(featureServerUrl, m_cred, this);
-
   m_map->utilityNetworks()->append(m_utilityNetwork);
-
-  // create symbols for the associations
-  m_attachmentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle::Dot, Qt::green, 5, this);
-  m_connectivitySymbol = new SimpleLineSymbol(SimpleLineSymbolStyle::Dot, Qt::red, 5, this);
 
   connectSignals();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
@@ -32,6 +32,7 @@
 #include "UtilityAssociation.h"
 #include "UtilityElement.h"
 #include "UtilityNetwork.h"
+#include "UtilityNetworkListModel.h"
 #include "UtilityNetworkDefinition.h"
 #include "UtilityNetworkSource.h"
 #include "UtilityNetworkTypes.h"
@@ -55,6 +56,8 @@ DisplayUtilityAssociations::DisplayUtilityAssociations(QObject* parent /* = null
   m_associationsOverlay(new GraphicsOverlay(this))
 {
   m_utilityNetwork = new UtilityNetwork(featureServerUrl, m_cred, this);
+
+  m_map->utilityNetworks()->append(m_utilityNetwork);
 
   // create symbols for the associations
   m_attachmentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle::Dot, Qt::green, 5, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -14,7 +14,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## How it works
 
-1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` array, then load it.
+1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` list, then load it.
 2. Add a `FeatureLayer` to the map for every `UtilityNetworkSource` of type `Edge` or `Junction`.
 3. Create a `GraphicsOverlay` for the utility associations.
 4. Add connection for the `ViewpointChanged` signal of the `MapView`.

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -14,7 +14,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## How it works
 
-1. Create and load a `UtilityNetwork` with a feature service URL.
+1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` array, then load it.
 2. Add a `FeatureLayer` to the map for every `UtilityNetworkSource` of type `Edge` or `Junction`.
 3. Create a `GraphicsOverlay` for the utility associations.
 4. Add connection for the `ViewpointChanged` signal of the `MapView`.
@@ -28,6 +28,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 ## Relevant API
 
 * GraphicsOverlay
+* ServiceGeodatabase
 * UtilityAssociation
 * UtilityAssociationType
 * UtilityNetwork

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -14,7 +14,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## How it works
 
-1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` list, then load it.
+1. Create a `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` list, then load it.
 2. Add a `FeatureLayer` to the map for every `UtilityNetworkSource` of type `Edge` or `Junction`.
 3. Create a `GraphicsOverlay` for the utility associations.
 4. Add connection for the `ViewpointChanged` signal of the `MapView`.

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
@@ -13,6 +13,7 @@
         "containment",
         "relationships",
         "GraphicsOverlay",
+        "ServiceGeodatabase",
         "UtilityAssociation",
         "UtilityAssociationType",
         "UtilityNetwork"
@@ -22,6 +23,7 @@
     ],
     "relevant_apis": [
         "GraphicsOverlay",
+        "ServiceGeodatabase",
         "UtilityAssociation",
         "UtilityAssociationType",
         "UtilityNetwork"

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -232,9 +232,7 @@ void PerformValveIsolationTrace::performTrace()
     // set the user selected filter barriers otherwise
     // set the category comparison to the barriers of the configuration's trace filter
     if (!m_filterBarriers.empty())
-    {
       traceParameters->setFilterBarriers(m_filterBarriers);
-    }
     else
     {
       UtilityCategory* selectedCategory = categories[m_selectedIndex];
@@ -288,9 +286,7 @@ void PerformValveIsolationTrace::connectSignals()
     {
       UtilityTier* tier = domainNetwork->tier(tierName);
       if (tier)
-      {
         m_traceConfiguration = tier->traceConfiguration();
-      }
     }
 
     if (!m_traceConfiguration)
@@ -308,9 +304,7 @@ void PerformValveIsolationTrace::connectSignals()
       {
         UtilityAssetType* assetType = assetGroup->assetType(assetTypeName);
         if (assetType)
-        {
           m_startingLocation = m_utilityNetwork->createElementWithAssetType(assetType, QUuid(globalId), nullptr, this);
-        }
       }
     }
 
@@ -375,9 +369,7 @@ void PerformValveIsolationTrace::connectSignals()
             const QString networkSourceName = utilityElement->networkSource()->name();
             const QString featureTableName = featureLayer->featureTable()->tableName();
             if (networkSourceName == featureTableName)
-            {
               objectIds.append(utilityElement->objectId());
-            }
           }
           queryParameters.setObjectIds(objectIds);
           featureLayer->selectFeatures(queryParameters, SelectionMode::New);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -43,6 +43,7 @@
 #include "UtilityElementTraceResult.h"
 #include "UtilityNetwork.h"
 #include "UtilityNetworkDefinition.h"
+#include "UtilityNetworkListModel.h"
 #include "UtilityNetworkSource.h"
 #include "UtilityNetworkTypes.h"
 #include "UtilityTerminal.h"
@@ -88,11 +89,9 @@ PerformValveIsolationTrace::PerformValveIsolationTrace(QObject* parent /* = null
   m_startingLocationOverlay(new GraphicsOverlay(this)),
   m_filterBarriersOverlay(new GraphicsOverlay(this)),
   m_cred(new Credential{sampleServer7Username, sampleServer7Password, this}),
-  m_graphicParent(new QObject())
+  m_graphicParent(new QObject()),
+  m_serviceGeodatabase(new ServiceGeodatabase(featureServiceUrl, m_cred, this))
 {
-  // create service geodatabase with the feature service url
-  m_serviceGeodatabase = new ServiceGeodatabase(featureServiceUrl, m_cred, this);
-
   // disable UI while loading service geodatabase and utility network
   m_tasksRunning = true;
   emit tasksRunningChanged();
@@ -123,8 +122,12 @@ PerformValveIsolationTrace::PerformValveIsolationTrace(QObject* parent /* = null
   });
   m_serviceGeodatabase->load();
 
+  // Create and add the utility network to the map before loading
   m_utilityNetwork = new UtilityNetwork(featureServiceUrl, m_map, m_cred, this);
+  m_map->utilityNetworks()->append(m_utilityNetwork);
+
   connectSignals();
+
   m_utilityNetwork->load();
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -15,7 +15,7 @@ Select one or more features to use as filter barriers or create and set the conf
 ## How it works
 
 1. Create a `MapView` and connect to its `mouseClicked` signal.
-2. Create and load an `ServiceGeodatabase` with a feature service URL and get tables with their layer IDs.
+2. Create and load a `ServiceGeodatabase` with a feature service URL and get tables with their layer IDs.
 3. Create a `Map` that contains `FeatureLayer`(s) created from the `ServiceGeodatabase`'s tables.
 4. Create and load a `UtilityNetwork` with the feature service URL and the `Map`.
 5. Add a `GraphicsOverlay` with a `Graphic` that represents the starting location, and another graphics overlay for the filter barriers.

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -15,25 +15,26 @@ Select one or more features to use as filter barriers or create and set the conf
 ## How it works
 
 1. Create a `MapView` and connect to its `mouseClicked` signal.
-2. Create and load a `ServiceGeodatabase` with a feature service URL and get tables by their layer IDs.
+2. Create and load an `ServiceGeodatabase` with a feature service URL and get tables with their layer IDs.
 3. Create a `Map` that contains `FeatureLayer`(s) created from the `ServiceGeodatabase`'s tables.
-4. Create and load a `UtilityNetwork` with the same feature service URL as the `Map`.
-5. Create `UtilityTraceParameters` with `UtilityTraceType::Isolation` and a starting location from a given asset type and global ID.
-6. Get a default `UtilityTraceConfiguration` from a given tier in a domain network to set `UtilityTraceParameters::traceConfiguration` property.
-7. Add a `GraphicsOverlay` with a `Graphic` that represents this starting location, and another graphics overlay for the filter barriers.
-8. Populate the choice list for the 'Filter barrier: category exists' from `UtilityNetworkDefinition::categories`.
-9. When the map view is clicked, identify which features are at that location and add a graphic that represents a filter barrier.
-10. Create a `UtilityElement` for the identified feature and add this utility element to a list of filter barriers.
+4. Create and load a `UtilityNetwork` with the feature service URL and the `Map`.
+5. Add a `GraphicsOverlay` with a `Graphic` that represents the starting location, and another graphics overlay for the filter barriers.
+6. Populate the list of filter barrier categories from `UtilityNetworkDefinition::categories`.
+7. When the map view is clicked, identify which features are at that location and add a graphic that represents a filter barrier.
+8. Create a `UtilityElement` for the identified feature and add this utility element to a list of filter barriers.
    - If the element is a junction with more than one terminal, display a terminal picker. Then set the junction's `terminal` property with the selected terminal.
    - If an edge, set its `fractionAlongEdge` property using `GeometryEngine::fractionAlong`.
-11. If 'Trace' is clicked without filter barriers:
+9. When "Trace" is pressed:
+   - Create `UtilityTraceParameters` with `UtilityTraceType::Isolation` and a starting location from a given asset type and global ID.
+   - Set the `UtilityTraceParameters::traceConfiguration` property from a default `UtilityTraceConfiguration`. Set the `filter` property with an `UtilityTraceFilter` object.
+10. If 'Trace' is clicked without filter barriers:
    - Create a new `UtilityCategoryComparison` with the selected category and `UtilityCategoryComparisonOperator::Exists`.
    - Create a new `UtilityTraceFilter` with this condition as `Barriers` to set `Filter` and update `IncludeIsolatedFeatures` properties of the default configuration from step 5.
    - Run `UtilityNetwork::trace`.
     If `Trace` is clicked with filter barriers:
    - Update `IncludeIsolatedFeatures` property of the default configuration from step 5.
    - Run `UtilityNetwork::trace`.
-12.  For every `FeatureLayer` in the map, select the features returned by `featuresForElements` from the elements matching their `NetworkSource::name` with the layer's `FeatureTable::name`.
+11.  For every `FeatureLayer` in the map, select the features returned by `featuresForElements` from the elements matching their `NetworkSource::name` with the layer's `FeatureTable::name`.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -31,10 +31,10 @@ Select one or more features to use as filter barriers or create and set the conf
    - Create a new `UtilityCategoryComparison` with the selected category and `UtilityCategoryComparisonOperator::Exists`.
    - Create a new `UtilityTraceFilter` with this condition as `Barriers` to set `Filter` and update `IncludeIsolatedFeatures` properties of the default configuration from step 5.
    - Run `UtilityNetwork::trace`.
-    If `Trace` is clicked with filter barriers:
+11. If `Trace` is clicked with filter barriers:
    - Update `IncludeIsolatedFeatures` property of the default configuration from step 5.
    - Run `UtilityNetwork::trace`.
-11.  For every `FeatureLayer` in the map, select the features returned by `featuresForElements` from the elements matching their `NetworkSource::name` with the layer's `FeatureTable::name`.
+12.  For every `FeatureLayer` in the map, select the features returned by `featuresForElements` from the elements matching their `NetworkSource::name` with the layer's `FeatureTable::name`.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -432,11 +432,7 @@ UniqueValue* TraceUtilityNetwork::createUniqueValue(const QString& label, Esri::
 
 void TraceUtilityNetwork::setBusyIndicator(bool status)
 {
-  if (status)
-    m_busy = true;
-  else
-    m_busy = false;
-
+  m_busy = status;
   emit busyChanged();
 
   return;

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -341,13 +341,9 @@ void TraceUtilityNetwork::onIdentifyLayersCompleted(QUuid, const QList<IdentifyL
       return;
     }
     else if (m_terminals.size() == 1)
-    {
       element = m_utilityNetwork->createElementWithArcGISFeature(m_feature, m_terminals[0]);
-    }
     else
-    {
       return;
-    }
 
   }
   else if (networkSource->sourceType() == UtilityNetworkSourceType::Edge)
@@ -368,9 +364,7 @@ void TraceUtilityNetwork::onIdentifyLayersCompleted(QUuid, const QList<IdentifyL
     }
   }
   else
-  {
     return;
-  }
 
   updateTraceParams(element);
 }
@@ -401,13 +395,9 @@ void TraceUtilityNetwork::onTraceCompleted()
   for (UtilityElement* item : elements)
   {
     if (item->networkSource()->name() == "Electric Distribution Device")
-    {
       deviceObjIds.append(item->objectId());
-    }
     else if (item->networkSource()->name() == "Electric Distribution Line")
-    {
       lineObjIds.append(item->objectId());
-    }
   }
 
   deviceParams.setObjectIds(deviceObjIds);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
@@ -29,6 +29,7 @@ class IdentifyLayerResult;
 class Map;
 class MapQuickView;
 class ServiceFeatureTable;
+class ServiceGeodatabase;
 class SimpleFillSymbol;
 class SimpleLineSymbol;
 class SimpleMarkerSymbol;
@@ -91,6 +92,10 @@ private:
   void connectSignals();
   void updateTraceParams(Esri::ArcGISRuntime::UtilityElement* element);
   Esri::ArcGISRuntime::UniqueValue* createUniqueValue(const QString& label, Esri::ArcGISRuntime::Symbol* fillSymbol, int value);
+  void createFeatureLayers();
+  void createRenderers();
+
+  const QUrl m_serviceUrl = QUrl("https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer");
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::Credential* m_cred = nullptr;
@@ -104,13 +109,13 @@ private:
   Esri::ArcGISRuntime::SimpleLineSymbol* m_mediumVoltageSymbol = nullptr;
   Esri::ArcGISRuntime::SimpleLineSymbol* m_lowVoltageSymbol = nullptr;
   Esri::ArcGISRuntime::GraphicsOverlay* m_graphicsOverlay = nullptr;
+  Esri::ArcGISRuntime::ServiceGeodatabase* m_serviceGeodatabase = nullptr;
   Esri::ArcGISRuntime::UtilityNetwork* m_utilityNetwork = nullptr;
   Esri::ArcGISRuntime::UtilityTraceParameters* m_traceParams = nullptr;
   Esri::ArcGISRuntime::ArcGISFeature* m_feature = nullptr;
   Esri::ArcGISRuntime::UtilityTier * m_mediumVoltageTier = nullptr;
   Esri::ArcGISRuntime::UniqueValueRenderer* m_uniqueValueRenderer = nullptr;
 
-  const QUrl m_serviceUrl = QUrl("https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer");
   bool m_terminalDialogVisisble = false;
   bool m_dialogVisible = false;
   bool m_startingLocationsEnabled = true;

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
@@ -93,11 +93,12 @@ private:
   void connectSignals();
   void updateTraceParams(Esri::ArcGISRuntime::UtilityElement* element);
   Esri::ArcGISRuntime::UniqueValue* createUniqueValue(const QString& label, Esri::ArcGISRuntime::Symbol* fillSymbol, int value);
-  void createFeatureLayers();
+  void createFeatureLayers(const Esri::ArcGISRuntime::Error& error);
   void createRenderers();
   void loadUtilityNetwork(const Esri::ArcGISRuntime::Error& error);
   bool hasErrorOccurred(const Esri::ArcGISRuntime::Error& error);
   void addUtilityNetworkToMap(const Esri::ArcGISRuntime::Error& error);
+  void setBusyIndicator(bool status);
 
   const QUrl m_serviceUrl = QUrl("https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
@@ -23,6 +23,7 @@ namespace ArcGISRuntime
 {
 class ArcGISFeature;
 class Credential;
+class Error;
 class FeatureLayer;
 class GraphicsOverlay;
 class IdentifyLayerResult;
@@ -94,6 +95,9 @@ private:
   Esri::ArcGISRuntime::UniqueValue* createUniqueValue(const QString& label, Esri::ArcGISRuntime::Symbol* fillSymbol, int value);
   void createFeatureLayers();
   void createRenderers();
+  void loadUtilityNetwork(const Esri::ArcGISRuntime::Error& error);
+  bool hasErrorOccurred(const Esri::ArcGISRuntime::Error& error);
+  void addUtilityNetworkToMap(const Esri::ArcGISRuntime::Error& error);
 
   const QUrl m_serviceUrl = QUrl("https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -92,6 +92,7 @@ Rectangle {
 
             Component.onCompleted: {
                 utilityNetwork.load();
+                map.utilityNetworks.append(utilityNetwork);
             }
 
             UtilityNetwork {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -14,7 +14,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## How it works
 
-1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` array, then load it.
+1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` list, then load it.
 2. Add a `FeatureLayer` to the map for every `UtilityNetworkSource` of type `Edge` or `Junction`.
 3. Create a `GraphicsOverlay` for the utility associations.
 4. Add connection for the `ViewpointChanged` signal of the `MapView`.

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -14,7 +14,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## How it works
 
-1. Create and load a `UtilityNetwork` with a feature service URL.
+1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` array, then load it.
 2. Add a `FeatureLayer` to the map for every `UtilityNetworkSource` of type `Edge` or `Junction`.
 3. Create a `GraphicsOverlay` for the utility associations.
 4. Add connection for the `ViewpointChanged` signal of the `MapView`.
@@ -28,6 +28,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 ## Relevant API
 
 * GraphicsOverlay
+* ServiceGeodatabase
 * UtilityAssociation
 * UtilityAssociationType
 * UtilityNetwork

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -14,7 +14,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## How it works
 
-1. Create an `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` list, then load it.
+1. Create a `UtilityNetwork` with a feature service URL, add it to the map's `utilityNetworks` list, then load it.
 2. Add a `FeatureLayer` to the map for every `UtilityNetworkSource` of type `Edge` or `Junction`.
 3. Create a `GraphicsOverlay` for the utility associations.
 4. Add connection for the `ViewpointChanged` signal of the `MapView`.

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
@@ -13,6 +13,7 @@
         "containment",
         "relationships",
         "GraphicsOverlay",
+        "ServiceGeodatabase",
         "UtilityAssociation",
         "UtilityAssociationType",
         "UtilityNetwork"
@@ -22,6 +23,7 @@
     ],
     "relevant_apis": [
         "GraphicsOverlay",
+        "ServiceGeodatabase",
         "UtilityAssociation",
         "UtilityAssociationType",
         "UtilityNetwork"

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -147,6 +147,7 @@ Rectangle {
             Component.onCompleted: {
                 serviceGeodatabase.load();
                 utilityNetwork.load();
+                map.utilityNetworks.append(utilityNetwork);
             }
 
             ServiceGeodatabase {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -15,26 +15,24 @@ Select one or more features to use as filter barriers or create and set the conf
 ## How it works
 
 1. Create a `MapView`.
-2. Create and load a `ServiceGeodatabase` with a feature service URL and get tables by their layer IDs.
+2. Create and load an `ServiceGeodatabase` with a feature service URL and get tables by their layer IDs.
 3. Create a `Map` that contains `FeatureLayer`(s) created from the service geodatabases tables.
-4. Create and load a `UtilityNetwork` with the same feature service URL and the above map.
-5. Create a default starting location from a given asset type and global id.
-6. Get a default `UtilityTraceConfiguration` from a given tier in a domain network to set `UtilityTraceParameters.traceConfiguration` property.
-7. Add a `GraphicsOverlay` with a `Graphic` that represents this starting location, and another graphics overlay for the filter barriers.
-8. Populate the choice list for the 'Filter barrier: category exists' from `UtilityNetworkDefinition.categories`.
-9. When the map view is clicked, identify which features are at that location and add a graphic that represents a filter barrier.
-10. Create a `UtilityElement` for the identified feature and add this utility element to a list of filter barriers.
+4. Create and load a `UtilityNetwork` with the feature service URL and the `Map`.
+5. Add a `GraphicsOverlay` with a `Graphic` that represents the starting location, and another graphics overlay for the filter barriers.
+6. Populate the list of filter barrier categories from `UtilityNetworkDefinition.categories`.
+7. When the map view is clicked, identify which features are at that location and add a graphic that represents a filter barrier.
+8. Create a `UtilityElement` for the identified feature and add this utility element to a list of filter barriers.
    - If the element is a junction with more than one terminal, display a terminal picker. Then set the junction's Terminal property with the selected terminal.
    - If an edge, use the result from `GeometryEngine.fractionAlong` to set the elements `fractionAlongEdge` property.
-11. If 'Trace' is clicked without filter barriers:
-   - Create a new `UtilityCategoryComparison` with the selected category and `Enums.UtilityCategoryComparisonOperatorExists`.
-   - Assign this condition to `UtilityTraceFilter.barriers` from the default configuration from step 6. Update this configuration's `includeIsolatedFeatures` property.
-   - Run `UtilityNetwork.trace`.
-12. If `Trace` is clicked with filter barriers:
+9. If `Trace` is clicked with filter barriers:
    - Update the default configurations include isolated features property.
    - Update the `UtilityTraceParameters` filter barriers property.
    - Run `UtilityNetwork.trace`.
-13.  For every `FeatureLayer` in the map, select the features returned by `featuresForElements` from the elements matching their `NetworkSource.name` with the layer's `FeatureTable.name`.
+10. If 'Trace' is clicked without filter barriers:
+   - Create a new `UtilityCategoryComparison` with the selected category and `Enums.UtilityCategoryComparisonOperatorExists`.
+   - Assign this condition to `UtilityTraceFilter.barriers` from the default configuration from step 6. Update this configuration's `includeIsolatedFeatures` property.
+   - Run `UtilityNetwork.trace`.
+11.  For every `FeatureLayer` in the map, select the features returned by `featuresForElements` from the elements matching their `NetworkSource.name` with the layer's `FeatureTable.name`.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -15,7 +15,7 @@ Select one or more features to use as filter barriers or create and set the conf
 ## How it works
 
 1. Create a `MapView`.
-2. Create and load an `ServiceGeodatabase` with a feature service URL and get tables by their layer IDs.
+2. Create and load a `ServiceGeodatabase` with a feature service URL and get tables by their layer IDs.
 3. Create a `Map` that contains `FeatureLayer`(s) created from the service geodatabases tables.
 4. Create and load a `UtilityNetwork` with the feature service URL and the `Map`.
 5. Add a `GraphicsOverlay` with a `Graphic` that represents the starting location, and another graphics overlay for the filter barriers.

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -51,7 +51,6 @@ Rectangle {
         }
 
         Map {
-
             Basemap {
                 initStyle: Enums.BasemapStyleArcGISStreetsNight
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -44,11 +44,37 @@ Rectangle {
         id: mapView
         anchors.fill: parent
         
+        Credential {
+            id: credentials
+            username: "viewer01"
+            password: "I68VGU^nMurF"
+        }
+
         Map {
+
             Basemap {
                 initStyle: Enums.BasemapStyleArcGISStreetsNight
             }
-            
+               
+            onComponentCompleted: {
+                serviceGeodatabase.load();
+                utilityNetwork.load();
+                map.utilityNetworks.append(utilityNetwork);
+            }
+
+            ServiceGeodatabase {
+                id: serviceGeodatabase
+                url: featureLayerUrl
+                credential: credentials
+                onLoadStatusChanged: {
+                    if (loadStatus === Enums.LoadStatusLoaded) {
+                        // Set feature layer feature table properties using the appropriate serviceGeodatabase table
+                        lineLayer.featureTable = serviceGeodatabase.tableWithLayerIdAsInt(3);
+                        deviceLayer.featureTable = serviceGeodatabase.tableWithLayerIdAsInt(0);
+                    }
+                }
+            }
+
             ViewpointExtent {
                 Envelope {
                     xMin: -9813547.35557238
@@ -62,15 +88,6 @@ Rectangle {
             // Add the layer with electric distribution lines.
             FeatureLayer {
                 id: lineLayer
-
-                ServiceFeatureTable {
-                    url: featureLayerUrl + "/3"
-
-                    Credential {
-                        username: "viewer01"
-                        password: "I68VGU^nMurF"
-                    }
-                }
 
                 UniqueValueRenderer {
                     fieldNames: ["ASSETGROUP"]
@@ -103,15 +120,6 @@ Rectangle {
             // Add the layer with electric devices.
             FeatureLayer {
                 id: deviceLayer
-
-                ServiceFeatureTable {
-                    url: featureLayerUrl + "/0"
-
-                    Credential {
-                        username: "viewer01"
-                        password: "I68VGU^nMurF"
-                    }
-                }
 
                 onSelectFeaturesStatusChanged: checkSelectionStatus();
             }
@@ -217,11 +225,7 @@ Rectangle {
     UtilityNetwork {
         id: utilityNetwork
         url: featureLayerUrl
-
-        Credential {
-            username: "viewer01"
-            password: "I68VGU^nMurF"
-        }
+        credential: credentials
 
         onTraceStatusChanged: {
             if (traceStatus !== Enums.TaskStatusCompleted)


### PR DESCRIPTION
This PR updates the **Display Utility Associations**, **Perform Valve Isolation Trace**, and **Trace Utility Network** samples to make use of the `ServiceGeodatabase`. Instead of creating each `FeatureLayer` using a long URL and the id of the desired table, the `ServiceGeodatabase` provides access to the `FeatureService`, the tables of which can be used to create the `FeatureLayer`s. This removes repetition and is more efficient.

Additionally, the `UtilityNetwork` in each sample has been appended to the `UtilityNetwork` list property of the `map` object. README and Metadata.json files have also been updated where applicable.

**NOTE:** The changes made in the three samples listed above are inconsistent. This is because some of the changes had been applied to some of the samples previously.

@tanneryould, @lsmallwood and Gela, please could you review the changes?