### PR TITLE
Revisit OpenStreetMapLayer sample 

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.cpp
@@ -46,8 +46,14 @@ void OSM_Layer::componentComplete()
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
 
-  // Create a map using the OpenStreetMap basemap
-  m_map = new Map(BasemapStyle::OsmStandard, this);
+  // Create a map
+  m_map = new Map();
+
+
+  // Create a new OpenStreetMapLayer and add it to the list of operational layers
+  OpenStreetMapLayer* osm = new OpenStreetMapLayer();
+  m_map->operationalLayers()->append(osm);
+
 
   // Set map to map view
   m_mapView->setMap(m_map);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.cpp
@@ -49,7 +49,6 @@ void OSM_Layer::componentComplete()
   // Create a map
   m_map = new Map();
 
-
   // Create a new OpenStreetMapLayer and add it to the list of operational layers
   OpenStreetMapLayer* osm = new OpenStreetMapLayer();
   m_map->operationalLayers()->append(osm);


### PR DESCRIPTION
This PR updates the existing OpenStreetMapLayer sample. It previously used an OSM basemap, but the original intention of this sample was to actually demonstrate use of the OpenStreetMapLayer class. 