### PR TITLE
Revisit OpenStreetMapLayer sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.cpp
@@ -46,8 +46,12 @@ void OSM_Layer::componentComplete()
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
 
-  // Create a map using the OpenStreetMap basemap
-  m_map = new Map(BasemapStyle::OsmStandard, this);
+  // Create a map
+  m_map = new Map(this);
+
+  // Create a new OpenStreetMapLayer and add it to the list of basemap layers
+  OpenStreetMapLayer* osm = new OpenStreetMapLayer(this);
+  m_map->basemap()->baseLayers()->append(osm);
 
   // Set map to map view
   m_mapView->setMap(m_map);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.qml
@@ -28,7 +28,7 @@ Rectangle {
         anchors.fill: parent
 
         Map {
-            // Declare the OpenStreetMap layer Basemap
+            // Declare a Basemap with an OpenStreetMapLayer baselayer
             Basemap {
                 OpenStreetMapLayer {}
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.qml
@@ -30,7 +30,7 @@ Rectangle {
         Map {
             // Declare the OpenStreetMap layer Basemap
             Basemap {
-                initStyle: Enums.BasemapStyleOsmStandard
+                OpenStreetMapLayer {}
             }
         }
     }


### PR DESCRIPTION
This PR updates the existing OpenStreetMapLayer sample. It previously used an OSM basemap, but the original intention of this sample was to actually demonstrate use of the OpenStreetMapLayer class.

@tanneryould @AndrewBladon Sorry to duplicate your work. I recreated the PR against the correct branch and correct instance of the repo. Please let me know if more changes are needed.