### PR TITLE
Remove Unnecessary Member Variables from Token Auth. Sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.cpp
@@ -36,11 +36,14 @@ namespace
 using namespace Esri::ArcGISRuntime;
 
 TokenAuthentication::TokenAuthentication(QQuickItem* parent /* = nullptr */):
-  QQuickItem(parent),
-  m_portal(new Portal(portalURL, this)),
-  m_portalItem(new PortalItem(m_portal, itemID, this)),
-  m_map(new Map(m_portalItem, this))
+  QQuickItem(parent)
 {
+  // Create local portal and portalItem objects using global portalURL and itemID variables
+  Portal* portal = new Portal(portalURL, this);
+  PortalItem* portalItem = new PortalItem(portal, itemID, this);
+
+  // Create a map object using the local portalItem variable
+  m_map = new Map(portalItem, this);
 }
 
 TokenAuthentication::~TokenAuthentication() = default;

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.cpp
@@ -38,7 +38,7 @@ using namespace Esri::ArcGISRuntime;
 TokenAuthentication::TokenAuthentication(QQuickItem* parent /* = nullptr */):
   QQuickItem(parent)
 {
-  // Create local portal and portalItem objects using global portalURL and itemID variables
+  // Create local portal and portalItem objects using constants defined for portalURL and itemID.
   Portal* portal = new Portal(portalURL, this);
   PortalItem* portalItem = new PortalItem(portal, itemID, this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.h
@@ -23,8 +23,6 @@ namespace Esri
   {
     class Map;
     class MapQuickView;
-    class Portal;
-    class PortalItem;
   }
 }
 
@@ -42,8 +40,6 @@ public:
   static void init();
 
 private:
-  Esri::ArcGISRuntime::Portal* m_portal = nullptr;
-  Esri::ArcGISRuntime::PortalItem* m_portalItem = nullptr;
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
 };


### PR DESCRIPTION
This PR removes two unnecessary member variables from the c++ TokenAuthentication sample. This change is a continuation of the changes made in https://github.com/Esri/arcgis-runtime-samples-qt/pull/1300.