### PR TITLE
Remove duplicate Component.onCompleted properties

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
@@ -34,9 +34,7 @@ DisplayDeviceLocationSample {
         Component.onCompleted: {
             // Set the focus on MapView to initially enable keyboard navigation
             forceActiveFocus();
-        }
 
-        Component.onCompleted: {
             // populate list model with modes
             autoPanListModel.append({name: deviceLocationSample.compassMode, image: "qrc:/Samples/Maps/DisplayDeviceLocation/Compass.png"});
             autoPanListModel.append({name: deviceLocationSample.navigationMode, image: "qrc:/Samples/Maps/DisplayDeviceLocation/Navigation.png"});

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
@@ -28,11 +28,6 @@ Rectangle {
         id: mapView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on MapView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         GraphicsOverlay {
             id: graphicsOverlay
         }
@@ -96,6 +91,9 @@ Rectangle {
             graphicsOverlay.graphics.append(clickedPointGraphic);
             graphicsOverlay.graphics.append(nearestVertexGraphic);
             graphicsOverlay.graphics.append(nearestCoordinateGraphic);
+
+            // Set the focus on MapView to initially enable keyboard navigation
+            forceActiveFocus();
         }
 
         Map {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/GroupLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/GroupLayers.qml
@@ -28,11 +28,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Scene {
             id: scene
             Basemap {
@@ -80,6 +75,9 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
             // create initial viewpoint extent
             const env = ArcGISRuntimeEnvironment.createObject("Envelope", {
                                                                   json: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/ShowLocationHistory.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/ShowLocationHistory.qml
@@ -32,11 +32,6 @@ Rectangle {
     MapView {
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on MapView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Map {
             Basemap {
                 initStyle: Enums.BasemapStyleArcGISDarkGray
@@ -97,6 +92,9 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on MapView to initially enable keyboard navigation
+            forceActiveFocus();
+
             locationDisplay.autoPanMode = Enums.LocationDisplayAutoPanModeRecenter;
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
@@ -30,6 +30,9 @@ Rectangle {
         Component.onCompleted: {
             // Set the focus on SceneView to initially enable keyboard navigation
             forceActiveFocus();
+
+            // set viewpoint to the specified camera
+            setViewpointCameraAndWait(camera);
         }
 
         // create a scene...scene is a default property of sceneview
@@ -45,11 +48,6 @@ Rectangle {
                     url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
-        }
-
-        Component.onCompleted: {
-            // set viewpoint to the specified camera
-            setViewpointCameraAndWait(camera);
         }
     }
     //! [create the scene with a basemap and surface]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
@@ -58,11 +58,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Scene {
             id: scene
             Basemap {
@@ -104,6 +99,9 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
             // set viewpoint to the specified camera
             sceneView.setViewpointCamera(camera);
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.qml
@@ -30,11 +30,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Scene {
             id: scene
             Basemap {
@@ -51,8 +46,11 @@ Rectangle {
             }
         }
 
-        // Once the scene view has loaded, apply the camera.
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
+            // Once the scene view has loaded, apply the camera.
             setViewpointCameraAndWait(camera);
         }
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
@@ -30,11 +30,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Scene {
             id: scene
             Basemap {
@@ -50,8 +45,11 @@ Rectangle {
             }
         }
 
-        // Once the scene view has loaded, apply the camera.
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
+            // Once the scene view has loaded, apply the camera.
             setViewpointCameraAndWait(camera);
         }
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
@@ -31,11 +31,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         // create a scene...scene is a default property of sceneview
         // and thus will get added to the sceneview
         Scene {
@@ -69,6 +64,9 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
             // set viewpoint to the specified camera
             setViewpointCameraAndWait(camera);
             createGraphics();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.qml
@@ -31,11 +31,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Scene {
             id: scene
             Basemap {
@@ -81,8 +76,11 @@ Rectangle {
             elevationSurface.locationToElevation(lastQueriedSurfacePos)
         }
 
-        // Once the scene view has loaded, apply the camera.
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
+            // Once the scene view has loaded, apply the camera.
             setViewpointCameraAndWait(camera);
         }
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
@@ -37,11 +37,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         Scene {
             id: scene
             Basemap {
@@ -98,6 +93,9 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+            
             // set viewpoint to the specified camera
             setViewpointCameraAndWait(camera);
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
@@ -30,11 +30,6 @@ Rectangle {
     SceneView {
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         // create a scene...scene is a default property of sceneview
         // and thus will get added to the sceneview
         Scene {
@@ -61,9 +56,13 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+            
             // set viewpoint to the specified camera
             setViewpointCameraAndWait(camera);
-            addSymbols();
+
+            addSymbols(); 
         }
     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
@@ -28,11 +28,6 @@ Rectangle {
         id: sceneView
         anchors.fill: parent
 
-        Component.onCompleted: {
-            // Set the focus on SceneView to initially enable keyboard navigation
-            forceActiveFocus();
-        }
-
         // add a Scene to the SceneView
         Scene {
             // add the BasemapNationalGeographic basemap to the scene
@@ -50,6 +45,9 @@ Rectangle {
         }
 
         Component.onCompleted: {
+            // Set the focus on SceneView to initially enable keyboard navigation
+            forceActiveFocus();
+
             sceneView.setViewpointCamera(camera);
         }
 


### PR DESCRIPTION
Some views had duplicate `Component.onCompleted` properties after the template update. This fixes that issue.