### PR TITLE
Tan11389/trace utility network busy fix

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -262,6 +262,7 @@ Rectangle {
         }
 
         onErrorChanged: {
+            busy.visible = false;
             dialogText.text = qsTr("%1 - %2".arg(error.message).arg(error.additionalMessage));
             traceCompletedDialog.open();
         }


### PR DESCRIPTION
Quick fix to two bugs I found when testing the utility network container sample in the sample viewer.
 * Removed `map.utilityNetworks.append(utilityNetwork);` because the id `map` was never actually defined, so it quietly logs an error and nothing else. Defining `map` to `Map` creates an error that the utility network is already included in the map.
 * Added `busy.visible = false;` to the error changed block, because if someone pressed the `Trace` button without any features selected, the busy indicator would never be removed and the buttons wouldn't re-enable.