### PR TITLE
Avoid clazy warning with QStringLiteral

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -80,7 +80,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
 
       return;

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -77,7 +77,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
 
       return;

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
@@ -81,7 +81,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
 
       return;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -77,7 +77,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
 
       return;

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/BuildLegend/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -76,7 +76,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
       return;
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DefinitionExpression/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabase/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -72,7 +72,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
       return;
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/main.cpp
@@ -81,7 +81,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
       return;
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     const QString apiKey = QString("");
     if (apiKey.isEmpty())
     {
-        qWarning() << "Use of Esri location services, including basemaps, requires "
+        qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
     }
     else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires "
+    qWarning() << "Use of Esri location services, including basemaps, requires" <<
                   "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -72,7 +72,7 @@ void setAPIKey(const QGuiApplication& app, QString apiKey)
 
     if (apiKey.isEmpty())
     {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
       return;
     }

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   if (apiKey.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires "
+      qWarning() << "Use of Esri location services, including basemaps, requires" <<
                     "you to authenticate with an ArcGIS identity or set the API Key property.";
   }
   else


### PR DESCRIPTION
Also standardize API key message.

@tanneryould please review. Someone mentioned they were getting this on the console when running a sample:

```
Use of Esri location services, including basemaps, requiresyou to authenticate with an ArcGIS identity or set the API Key property.
```

I standardized every occurrence of this across all samples for v.next. I've also updated the QStringLiteral to just a QString since it will produce this [clazy](https://github.com/KDE/clazy/blob/master/docs/checks/README-empty-qstringliteral.md) warning in Qt Creator. QString should suffice for both empty and non-empty strings to avoid the warning.

I found a few cases using the ` <<` operator and some inconsistent indenting and fixed them all.