### PR TITLE
Minor README updates

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/README.md
@@ -30,7 +30,7 @@ The sample will start with a viewshed created from the initial camera location, 
 
 ## About the data
 
-The scene shows an [integrated mesh layer of Girona, Spain](https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer) with the [World Elevation source image service](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) both hosted on ArcGIS Online.
+The scene shows an [integrated mesh layer of Girona, Spain](https://www.arcgis.com/home/item.html?id=5c55d0d1f21e489193cdeff11460a28c) with the [World Elevation source image service](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) both hosted on ArcGIS Online.
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/README.md
@@ -27,7 +27,7 @@ Use the sliders to change the properties (heading, pitch, etc.), of the viewshed
 
 ## About the data
 
-The scene shows a [buildings layer in Brest, France](https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0) hosted on ArcGIS Online.
+The scene shows a [buildings layer in Brest, France](https://www.arcgis.com/home/item.html?id=b343e14455fe45b98a2c20ebbceec0b0) hosted on ArcGIS Online.
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/README.md
@@ -33,7 +33,7 @@ The sample displays a map with a set of symbols that represent the categories of
 
 The sample uses the ['Esri2DPointSymbolsStyle'](https://developers.arcgis.com/javascript/latest/guide/esri-web-style-symbols-2d) Web Style.
 
-The map shows features from the [LA County Points of Interest service](https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/LA_County_Points_of_Interest/FeatureServer/0) hosted on ArcGIS Online.
+The map shows features from the [LA County Points of Interest](https://www.arcgis.com/home/item.html?id=b9f7c339f9d747558329f44059064ccc) service hosted on ArcGIS Online.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/README.md
@@ -30,7 +30,7 @@ Use the radio buttons to toggle between the dictionary symbols from the web styl
 
 ## About the data
 
-The data used in this sample is from a feature layer showing a subset of [restaurants in Redlands, CA](https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/Redlands_Restaurants/FeatureServer) hosted as a feature service with attributes for rating, style, health score, and open hours.
+The data used in this sample is from a feature layer showing a subset of [restaurants in Redlands, CA](https://www.arcgis.com/home/item.html?id=3daf83e1ec0941428526a07f2d2ae414) hosted as a feature service with attributes for rating, style, health score, and open hours.
 
 The feature layer is symbolized using a dictionary renderer that displays a single symbol for all of these variables. The renderer uses symbols from a custom restaurant dictionary style created from a [stylx file](https://arcgis.com/home/item.html?id=751138a2e0844e06853522d54103222a) and a [web style](https://arcgis.com/home/item.html?id=adee951477014ec68d7cf0ea0579c800), available as an items from ArcGIS Online, to show unique symbols based on several feature attributes. The symbols it contains were created using ArcGIS Pro. The logic used to apply the symbols comes from an Arcade script embedded in the stylx file (which is a SQLite database), along with a JSON string that defines expected attribute names and configuration properties.
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/README.md
@@ -32,7 +32,7 @@ Use the play button to step through the data one day at a time. Use the previous
 
 ## Additional information
 
-This sample uses [Atlantic hurricane data](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer) from the National Hurricane Center (NOAA / National Weather Service) and the `TimeSlider` toolkit component which requires the [toolkit](https://github.com/Esri/arcgis-runtime-toolkit-qt) to be cloned and set up locally. For information about setting up the toolkit, see the repository's root README.md [here](https://github.com/Esri/arcgis-runtime-toolkit-qt/blob/main/uitools/README.md).
+This sample uses [Atlantic hurricane data](https://www.arcgis.com/home/item.html?id=49925d814d7e40fb8fa64864ef62d55e) from the National Hurricane Center (NOAA / National Weather Service) and the `TimeSlider` toolkit component which requires the [toolkit](https://github.com/Esri/arcgis-runtime-toolkit-qt) to be cloned and set up locally. For information about setting up the toolkit, see the repository's root README.md [here](https://github.com/Esri/arcgis-runtime-toolkit-qt/blob/main/uitools/README.md).
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.md
@@ -32,7 +32,7 @@ The sample loads with the sublayer visible on the map. Toggle its visibility wit
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/100) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network with asset classification for different devices.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network with asset classification for different devices.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.md
@@ -38,8 +38,6 @@ The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/s
 
 Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
-## Additional information
-
 Credentials:
 * Username: viewer01
 * Password: I68VGU^nMurF

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.md
@@ -32,7 +32,11 @@ The sample loads with the sublayer visible on the map. Toggle its visibility wit
 
 ## About the data
 
-The [feature service layer](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/0) in this sample represents an electric network in Naperville, Illinois, which contains a utility network with asset classification for different devices.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/100) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network with asset classification for different devices.
+
+## Additional information
+
+Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.md
@@ -58,7 +58,7 @@ Example barrier conditions for the default dataset:
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer)  network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.md
@@ -49,7 +49,7 @@ Select phases to be included in the report. Press the "Run Report" button to ini
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/README.md
@@ -37,7 +37,11 @@ Select a container feature to show all features inside the container. The contai
 
 ## About the data
 
-The [Naperville electric network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer), hosted on ArcGIS Online, contains a utility network used to find associations shown in this sample and a web map portal item, [Naperville electric containers](https://sampleserver7.arcgisonline.com/portal/home/item.html?id=813eda749a9444e4a9d833a4db19e1c8), that use the same feature service endpoint and displays only container features.
+The [Naperville electric](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to find associations shown in this sample and a web map portal item, [Naperville electric containers](https://sampleserver7.arcgisonline.com/portal/home/item.html?id=813eda749a9444e4a9d833a4db19e1c8), that use the same feature service endpoint and displays only container features.
+
+## Additional information
+
+Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -35,7 +35,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -35,7 +35,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## About the data
 
-The [feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) in this sample represents an electric network in Naperville, Illinois, which contains a utility network used to run the subnetwork-based trace.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -57,7 +57,7 @@ Select one or more features to use as filter barriers or create and set the conf
 
 ## About the data
 
-The [Naperville gas network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer), hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the isolation trace shown in this sample.
+The [Naperville gas](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the isolation trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -57,7 +57,7 @@ Select one or more features to use as filter barriers or create and set the conf
 
 ## About the data
 
-The [Naperville gas network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer), hosted on ArcGIS Online, contains a utility network used to run the isolation trace shown in this sample.
+The [Naperville gas network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer), hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the isolation trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/README.md
@@ -51,7 +51,7 @@ Tap on one or more features while 'Add starting locations' or 'Add barriers' is 
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/README.md
@@ -30,7 +30,7 @@ The sample will start with a viewshed created from the initial camera location, 
 
 ## About the data
 
-The scene shows an [integrated mesh layer of Girona, Spain](https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/Girona_Spain/SceneServer) with the [World Elevation source image service](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) both hosted on ArcGIS Online.
+The scene shows an [integrated mesh layer of Girona, Spain](https://www.arcgis.com/home/item.html?id=5c55d0d1f21e489193cdeff11460a28c) with the [World Elevation source image service](https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer) both hosted on ArcGIS Online.
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/README.md
@@ -27,7 +27,7 @@ Use the sliders to change the properties (heading, pitch, etc.), of the viewshed
 
 ## About the data
 
-The scene shows a [buildings layer in Brest, France](https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer/layers/0) hosted on ArcGIS Online.
+The scene shows a [buildings layer in Brest, France](https://www.arcgis.com/home/item.html?id=b343e14455fe45b98a2c20ebbceec0b0) hosted on ArcGIS Online.
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/README.md
@@ -33,7 +33,7 @@ The sample displays a map with a set of symbols that represent the categories of
 
 The sample uses the ['Esri2DPointSymbolsStyle'](https://developers.arcgis.com/javascript/latest/guide/esri-web-style-symbols-2d) Web Style.
 
-The map shows features from the [LA County Points of Interest service](https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/LA_County_Points_of_Interest/FeatureServer/0) hosted on ArcGIS Online.
+The map shows features from the [LA County Points of Interest](https://www.arcgis.com/home/item.html?id=b9f7c339f9d747558329f44059064ccc) service hosted on ArcGIS Online.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/README.md
@@ -30,7 +30,7 @@ Use the radio buttons to toggle between the dictionary symbols from the web styl
 
 ## About the data
 
-The data used in this sample is from a feature layer showing a subset of [restaurants in Redlands, CA](https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/Redlands_Restaurants/FeatureServer) hosted as a feature service with attributes for rating, style, health score, and open hours.
+The data used in this sample is from a feature layer showing a subset of [restaurants in Redlands, CA](https://www.arcgis.com/home/item.html?id=3daf83e1ec0941428526a07f2d2ae414) hosted as a feature service with attributes for rating, style, health score, and open hours.
 
 The feature layer is symbolized using a dictionary renderer that displays a single symbol for all of these variables. The renderer uses symbols from a custom restaurant dictionary style created from a [stylx file](https://arcgis.com/home/item.html?id=751138a2e0844e06853522d54103222a) and a [web style](https://arcgis.com/home/item.html?id=adee951477014ec68d7cf0ea0579c800), available as an items from ArcGIS Online, to show unique symbols based on several feature attributes. The symbols it contains were created using ArcGIS Pro. The logic used to apply the symbols comes from an Arcade script embedded in the stylx file (which is a SQLite database), along with a JSON string that defines expected attribute names and configuration properties.
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/README.md
@@ -32,7 +32,7 @@ Use the play button to step through the data one day at a time. Use the previous
 
 ## Additional information
 
-This sample uses [Atlantic hurricane data](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer) from the National Hurricane Center (NOAA / National Weather Service) and the `TimeSlider` toolkit component which requires the [toolkit](https://github.com/Esri/arcgis-runtime-toolkit-qt) to be cloned and set up locally. For information about setting up the toolkit, see the repository's root README.md [here](https://github.com/Esri/arcgis-runtime-toolkit-qt/blob/main/uitools/README.md).
+This sample uses [Atlantic hurricane data](https://www.arcgis.com/home/item.html?id=49925d814d7e40fb8fa64864ef62d55e) from the National Hurricane Center (NOAA / National Weather Service) and the `TimeSlider` toolkit component which requires the [toolkit](https://github.com/Esri/arcgis-runtime-toolkit-qt) to be cloned and set up locally. For information about setting up the toolkit, see the repository's root README.md [here](https://github.com/Esri/arcgis-runtime-toolkit-qt/blob/main/uitools/README.md).
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/README.md
@@ -32,7 +32,7 @@ The sample loads with the sublayer visible on the map. Toggle its visibility wit
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/100) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network with asset classification for different devices.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network with asset classification for different devices.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/README.md
@@ -38,8 +38,6 @@ The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/s
 
 Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
-## Additional information
-
 Credentials:
 * Username: viewer01
 * Password: I68VGU^nMurF

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/README.md
@@ -32,7 +32,11 @@ The sample loads with the sublayer visible on the map. Toggle its visibility wit
 
 ## About the data
 
-The [feature service layer](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/0) in this sample represents an electric network in Naperville, Illinois, which contains a utility network with asset classification for different devices.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer/100) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network with asset classification for different devices.
+
+## Additional information
+
+Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.md
@@ -58,7 +58,7 @@ Example barrier conditions for the default dataset:
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer)  network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/README.md
@@ -49,7 +49,7 @@ Select phases to be included in the report. Press the "Run Report" button to ini
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/README.md
@@ -36,7 +36,11 @@ Select a container feature to show all features inside the container. The contai
 
 ## About the data
 
-The [Naperville electric network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer), hosted on ArcGIS Online, contains a utility network used to find associations shown in this sample and a web map portal item, [Naperville electric containers](https://sampleserver7.arcgisonline.com/portal/home/item.html?id=813eda749a9444e4a9d833a4db19e1c8), that use the same feature service endpoint and displays only container features.
+The [Naperville electric](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to find associations shown in this sample and a web map portal item, [Naperville electric containers](https://sampleserver7.arcgisonline.com/portal/home/item.html?id=813eda749a9444e4a9d833a4db19e1c8), that use the same feature service endpoint and displays only container features.
+
+## Additional information
+
+Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -35,7 +35,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/README.md
@@ -35,7 +35,7 @@ Pan and zoom around the map. Observe graphics that show utility associations bet
 
 ## About the data
 
-The [feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) in this sample represents an electric network in Naperville, Illinois, which contains a utility network used to run the subnetwork-based trace.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/arcgis/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -53,9 +53,11 @@ Select one or more features to use as filter barriers or create and set the conf
 
 ## About the data
 
-The [Naperville gas network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer), hosted on ArcGIS Online, contains a utility network used to run the isolation trace shown in this sample.
+The [Naperville gas network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer), hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the isolation trace shown in this sample.
 
 ## Additional information
+
+Using utility network on ArcGIS Enterprise 10.8 requires an ArcGIS Enterprise member account licensed with the [Utility Network user type extension](https://enterprise.arcgis.com/en/portal/latest/administer/windows/license-user-type-extensions.htm#ESRI_SECTION1_41D78AD9691B42E0A8C227C113C0C0BF). Please refer to the [utility network services documentation](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/utility-network-services.htm).
 
 Credentials:
 * Username: viewer01

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/README.md
@@ -53,7 +53,7 @@ Select one or more features to use as filter barriers or create and set the conf
 
 ## About the data
 
-The [Naperville gas network feature service](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer), hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the isolation trace shown in this sample.
+The [Naperville gas](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleGas/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the isolation trace shown in this sample.
 
 ## Additional information
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.md
@@ -51,7 +51,7 @@ Tap on one or more features while 'Add starting locations' or 'Add barriers' is 
 
 ## About the data
 
-The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online, contains a utility network used to run the subnetwork-based trace shown in this sample.
+The [Naperville electrical](https://sampleserver7.arcgisonline.com/server/rest/services/UtilityNetwork/NapervilleElectric/FeatureServer) network feature service, hosted on ArcGIS Online (authentication required: this is handled within the sample code), contains a utility network used to run the subnetwork-based trace shown in this sample.
 
 ## Additional information
 


### PR DESCRIPTION
This PR comprises minor changes to README files across several samples. The key changes include:

1. Changing links from references to metadata pages to references to AGOL pages where possible.
2. Ensuring all Utility Network samples include both a note to make users aware that authentication is required to access the Naperville service and an `Additional information` section that provides information about licencing etc.

Please could you review these changes @tanneryould and @Gela?