### PR TITLE
Reorder metadata snippets

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/README.metadata.json
@@ -25,11 +25,11 @@
         "Surface"
     ],
     "snippets": [
-        "DisplayScenesInTabletopAR.qml",
         "DisplayScenesInTabletopAR.cpp",
         "DisplayScenesInTabletopAR.h",
         "PermissionsHelper.cpp",
-        "PermissionsHelper.h"
+        "PermissionsHelper.h",
+        "DisplayScenesInTabletopAR.qml"
     ],
     "title": "Display scenes in tabletop AR"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/README.metadata.json
@@ -24,9 +24,9 @@
         "SceneView"
     ],
     "snippets": [
-        "ExploreScenesInFlyoverAR.qml",
         "ExploreScenesInFlyoverAR.cpp",
-        "ExploreScenesInFlyoverAR.h"
+        "ExploreScenesInFlyoverAR.h",
+        "ExploreScenesInFlyoverAR.qml"
     ],
     "title": "Explore scenes in flyover AR"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/README.metadata.json
@@ -26,9 +26,9 @@
         "GeoprocessingTask"
     ],
     "snippets": [
-        "AnalyzeHotspots.qml",
         "AnalyzeHotspots.cpp",
-        "AnalyzeHotspots.h"
+        "AnalyzeHotspots.h",
+        "AnalyzeHotspots.qml"
     ],
     "title": "Analyze hotspots"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/README.metadata.json
@@ -29,9 +29,9 @@
         "GeoprocessingTask"
     ],
     "snippets": [
-        "AnalyzeViewshed.qml",
         "AnalyzeViewshed.cpp",
-        "AnalyzeViewshed.h"
+        "AnalyzeViewshed.h",
+        "AnalyzeViewshed.qml"
     ],
     "title": "Viewshed (Geoprocessing)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
@@ -23,9 +23,9 @@
         "MeasurementChanged"
     ],
     "snippets": [
-        "DistanceMeasurementAnalysis.qml",
         "DistanceMeasurementAnalysis.cpp",
-        "DistanceMeasurementAnalysis.h"
+        "DistanceMeasurementAnalysis.h",
+        "DistanceMeasurementAnalysis.qml"
     ],
     "title": "Distance measurement analysis"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/README.metadata.json
@@ -48,10 +48,10 @@
         "SimulatedLocationDataSource"
     ],
     "snippets": [
-        "Geotriggers.qml",
-        "FeatureInfoPane.qml",
         "Geotriggers.cpp",
-        "Geotriggers.h"
+        "Geotriggers.h",
+        "FeatureInfoPane.qml",
+        "Geotriggers.qml"
     ],
     "title": "Set up location-driven Geotriggers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/README.metadata.json
@@ -29,9 +29,9 @@
         "LineOfSight::targetVisibility"
     ],
     "snippets": [
-        "LineOfSightGeoElement.qml",
         "LineOfSightGeoElement.cpp",
-        "LineOfSightGeoElement.h"
+        "LineOfSightGeoElement.h",
+        "LineOfSightGeoElement.qml"
     ],
     "title": "Line of sight (geoelement)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/README.metadata.json
@@ -23,9 +23,9 @@
         "SceneView"
     ],
     "snippets": [
-        "LineOfSightLocation.qml",
         "LineOfSightLocation.cpp",
-        "LineOfSightLocation.h"
+        "LineOfSightLocation.h",
+        "LineOfSightLocation.qml"
     ],
     "title": "Line of sight (location)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/README.metadata.json
@@ -41,9 +41,9 @@
         "StatisticsQueryResult"
     ],
     "snippets": [
-        "StatisticalQuery.qml",
         "StatisticalQuery.cpp",
-        "StatisticalQuery.h"
+        "StatisticalQuery.h",
+        "StatisticalQuery.qml"
     ],
     "title": "Statistical query"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/README.metadata.json
@@ -39,13 +39,13 @@
         "StatisticsQueryResult"
     ],
     "snippets": [
-        "StatisticalQueryGroupSort.qml",
+        "StatisticalQueryGroupSort.cpp",
+        "StatisticalQueryGroupSort.h",
         "OptionsPage.qml",
         "ResultsPage.qml",
         "StatisticResultListModel.cpp",
         "StatisticResultListModel.h",
-        "StatisticalQueryGroupSort.cpp",
-        "StatisticalQueryGroupSort.h"
+        "StatisticalQueryGroupSort.qml"
     ],
     "title": "Statistical query (group & sort)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/README.metadata.json
@@ -32,9 +32,9 @@
         "SceneView"
     ],
     "snippets": [
-        "ViewshedCamera.qml",
         "ViewshedCamera.cpp",
-        "ViewshedCamera.h"
+        "ViewshedCamera.h",
+        "ViewshedCamera.qml"
     ],
     "title": "Viewshed (camera)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/README.metadata.json
@@ -38,9 +38,9 @@
         "OrbitGeoElementCameraController"
     ],
     "snippets": [
-        "ViewshedGeoElement.qml",
         "ViewshedGeoElement.cpp",
-        "ViewshedGeoElement.h"
+        "ViewshedGeoElement.h",
+        "ViewshedGeoElement.qml"
     ],
     "title": "Viewshed (GeoElement)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/README.metadata.json
@@ -28,11 +28,11 @@
         "Viewshed"
     ],
     "snippets": [
-        "ViewshedLocation.qml",
-        "ColorDialog.qml",
         "ViewshedLocation.cpp",
         "ViewshedLocation.h",
-        "ViewshedSlider.qml"
+        "ColorDialog.qml",
+        "ViewshedSlider.qml",
+        "ViewshedLocation.qml"
     ],
     "title": "Viewshed (location)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/README.metadata.json
@@ -24,9 +24,9 @@
         "PortalUser::deleteItem"
     ],
     "snippets": [
-        "AddItemsToPortal.qml",
         "AddItemsToPortal.cpp",
-        "AddItemsToPortal.h"
+        "AddItemsToPortal.h",
+        "AddItemsToPortal.qml"
     ],
     "title": "Add items to portal"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/README.metadata.json
@@ -22,9 +22,9 @@
         "Portal"
     ],
     "snippets": [
-        "IntegratedWindowsAuthentication.qml",
         "IntegratedWindowsAuthentication.cpp",
-        "IntegratedWindowsAuthentication.h"
+        "IntegratedWindowsAuthentication.h",
+        "IntegratedWindowsAuthentication.qml"
     ],
     "title": "Integrated windows authentication"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.metadata.json
@@ -1,6 +1,6 @@
 {
     "category": "Cloud and portal",
-    "description": "This sample demonstrates an approach to using OAuth2 for authenticating with an ArcGIS portal",
+    "description": "This sample demonstrates an approach to using OAuth2 for authenticating with an ArcGIS portal.",
     "ignore": true,
     "images": [],
     "keywords": [

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/OAuthRedirectExample/README.metadata.json
@@ -21,13 +21,13 @@
         "Portal"
     ],
     "snippets": [
-        "OAuthRedirectExample.qml",
+        "OAuthRedirectExample.cpp",
         "OAuthRedirectExample.h",
         "MyApplication.h",
         "OAuthRedirectHandler.cpp",
         "OAuthRedirectHandler.h",
         "MyApplication.cpp",
-        "OAuthRedirectExample.cpp"
+        "OAuthRedirectExample.qml"
     ],
     "title": "OAuth redirect example"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/README.metadata.json
@@ -33,9 +33,9 @@
         "PortalUser"
     ],
     "snippets": [
-        "PortalUserInfo.qml",
         "PortalUserInfo.cpp",
-        "PortalUserInfo.h"
+        "PortalUserInfo.h",
+        "PortalUserInfo.qml"
     ],
     "title": "Access portal user info"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/README.metadata.json
@@ -25,9 +25,9 @@
         "PortalQueryResultSet"
     ],
     "snippets": [
-        "SearchForWebmap.qml",
         "SearchForWebmap.cpp",
-        "SearchForWebmap.h"
+        "SearchForWebmap.h",
+        "SearchForWebmap.qml"
     ],
     "title": "Search for web map by keyword"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/README.metadata.json
@@ -21,9 +21,9 @@
         "Portal::fetchBasemaps"
     ],
     "snippets": [
-        "ShowOrgBasemaps.qml",
         "ShowOrgBasemaps.cpp",
-        "ShowOrgBasemaps.h"
+        "ShowOrgBasemaps.h",
+        "ShowOrgBasemaps.qml"
     ],
     "title": "Show organization basemaps"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/README.metadata.json
@@ -26,9 +26,9 @@
         "PortalItem"
     ],
     "snippets": [
-        "TokenAuthentication.qml",
         "TokenAuthentication.cpp",
-        "TokenAuthentication.h"
+        "TokenAuthentication.h",
+        "TokenAuthentication.qml"
     ],
     "title": "Token authentication"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/README.metadata.json
@@ -46,9 +46,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "AddGraphicsWithRenderer.qml",
         "AddGraphicsWithRenderer.cpp",
-        "AddGraphicsWithRenderer.h"
+        "AddGraphicsWithRenderer.h",
+        "AddGraphicsWithRenderer.qml"
     ],
     "title": "Add graphics with renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/README.metadata.json
@@ -25,9 +25,9 @@
         "LegendInfoListModel"
     ],
     "snippets": [
-        "BuildLegend.qml",
         "BuildLegend.cpp",
-        "BuildLegend.h"
+        "BuildLegend.h",
+        "BuildLegend.qml"
     ],
     "title": "Build a legend"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/README.metadata.json
@@ -30,9 +30,9 @@
         "LayerContent"
     ],
     "snippets": [
-        "ControlAnnotationSublayerVisibility.qml",
         "ControlAnnotationSublayerVisibility.cpp",
-        "ControlAnnotationSublayerVisibility.h"
+        "ControlAnnotationSublayerVisibility.h",
+        "ControlAnnotationSublayerVisibility.qml"
     ],
     "title": "Control annotation sublayer visibility"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/README.metadata.json
@@ -27,9 +27,9 @@
         "UniqueValueRenderer"
     ],
     "snippets": [
-        "CreateSymbolStylesFromWebStyles.qml",
         "CreateSymbolStylesFromWebStyles.cpp",
-        "CreateSymbolStylesFromWebStyles.h"
+        "CreateSymbolStylesFromWebStyles.h",
+        "CreateSymbolStylesFromWebStyles.qml"
     ],
     "title": "Create symbol styles from web styles"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/README.metadata.json
@@ -35,9 +35,9 @@
         "PortalItem"
     ],
     "snippets": [
-        "CustomDictionaryStyle.qml",
         "CustomDictionaryStyle.cpp",
-        "CustomDictionaryStyle.h"
+        "CustomDictionaryStyle.h",
+        "CustomDictionaryStyle.qml"
     ],
     "title": "Custom dictionary style"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/README.metadata.json
@@ -44,9 +44,9 @@
         "UTMGrid"
     ],
     "snippets": [
-        "DisplayGrid.qml",
         "DisplayGrid.cpp",
-        "DisplayGrid.h"
+        "DisplayGrid.h",
+        "DisplayGrid.qml"
     ],
     "title": "Display a grid"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -34,9 +34,9 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "GODictionaryRenderer.qml",
         "GODictionaryRenderer.cpp",
-        "GODictionaryRenderer.h"
+        "GODictionaryRenderer.h",
+        "GODictionaryRenderer.qml"
     ],
     "title": "Graphics overlay (dictionary renderer)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
@@ -34,9 +34,9 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "GODictionaryRenderer_3D.qml",
         "GODictionaryRenderer_3D.cpp",
-        "GODictionaryRenderer_3D.h"
+        "GODictionaryRenderer_3D.h",
+        "GODictionaryRenderer_3D.qml"
     ],
     "title": "Graphics overlay (dictionary renderer) 3D"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/README.metadata.json
@@ -33,9 +33,9 @@
         "SimpleMarkerSymbol"
     ],
     "snippets": [
-        "GOSymbols.qml",
         "GOSymbols.cpp",
-        "GOSymbols.h"
+        "GOSymbols.h",
+        "GOSymbols.qml"
     ],
     "title": "Add graphics with symbols"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/README.metadata.json
@@ -21,9 +21,9 @@
         "MapView"
     ],
     "snippets": [
-        "IdentifyGraphics.qml",
         "IdentifyGraphics.cpp",
-        "IdentifyGraphics.h"
+        "IdentifyGraphics.h",
+        "IdentifyGraphics.qml"
     ],
     "title": "Identify graphics"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/README.metadata.json
@@ -26,9 +26,9 @@
         "PictureMarkerSymbol"
     ],
     "snippets": [
-        "Picture_Marker_Symbol.qml",
         "Picture_Marker_Symbol.cpp",
-        "Picture_Marker_Symbol.h"
+        "Picture_Marker_Symbol.h",
+        "Picture_Marker_Symbol.qml"
     ],
     "title": "Picture marker symbol"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/README.metadata.json
@@ -41,12 +41,12 @@
         "SymbolStyleSearchResultListModel"
     ],
     "snippets": [
-        "ReadSymbolsFromMobileStyle.qml",
         "ReadSymbolsFromMobileStyle.cpp",
         "ReadSymbolsFromMobileStyle.h",
         "SymbolComboBox.qml",
         "SymbolImageProvider.cpp",
-        "SymbolImageProvider.h"
+        "SymbolImageProvider.h",
+        "ReadSymbolsFromMobileStyle.qml"
     ],
     "title": "Read symbols from a mobile style"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/README.metadata.json
@@ -31,9 +31,9 @@
         "MapView::showCalloutAt"
     ],
     "snippets": [
-        "ShowCallout.qml",
         "ShowCallout.cpp",
-        "ShowCallout.h"
+        "ShowCallout.h",
+        "ShowCallout.qml"
     ],
     "title": "Show callout"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/README.metadata.json
@@ -29,9 +29,9 @@
         "TextSymbol"
     ],
     "snippets": [
-        "ShowLabelsOnLayers.qml",
         "ShowLabelsOnLayers.cpp",
-        "ShowLabelsOnLayers.h"
+        "ShowLabelsOnLayers.h",
+        "ShowLabelsOnLayers.qml"
     ],
     "title": "Show labels on layers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/README.metadata.json
@@ -25,9 +25,9 @@
         "PopupStackView"
     ],
     "snippets": [
-        "ShowPopup.qml",
         "ShowPopup.cpp",
-        "ShowPopup.h"
+        "ShowPopup.h",
+        "ShowPopup.qml"
     ],
     "title": "Show popup"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/README.metadata.json
@@ -22,9 +22,9 @@
         "SimpleMarkerSymbol"
     ],
     "snippets": [
-        "Simple_Marker_Symbol.qml",
         "Simple_Marker_Symbol.cpp",
-        "Simple_Marker_Symbol.h"
+        "Simple_Marker_Symbol.h",
+        "Simple_Marker_Symbol.qml"
     ],
     "title": "Simple marker symbol"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/README.metadata.json
@@ -29,9 +29,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "Simple_Renderer.qml",
         "Simple_Renderer.cpp",
-        "Simple_Renderer.h"
+        "Simple_Renderer.h",
+        "Simple_Renderer.qml"
     ],
     "title": "Simple renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/README.metadata.json
@@ -27,10 +27,10 @@
         "SketchEditor"
     ],
     "snippets": [
-        "SketchOnMap.qml",
-        "SketchEditorButton.qml",
         "SketchOnMap.cpp",
-        "SketchOnMap.h"
+        "SketchOnMap.h",
+        "SketchEditorButton.qml",
+        "SketchOnMap.qml"
     ],
     "title": "Sketch on map"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/README.metadata.json
@@ -34,9 +34,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "SymbolizeShapefile.qml",
         "SymbolizeShapefile.cpp",
-        "SymbolizeShapefile.h"
+        "SymbolizeShapefile.h",
+        "SymbolizeShapefile.qml"
     ],
     "title": "Symbolize a shapefile"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/README.metadata.json
@@ -30,9 +30,9 @@
         "UniqueValueRenderer"
     ],
     "snippets": [
-        "Unique_Value_Renderer.qml",
         "Unique_Value_Renderer.cpp",
-        "Unique_Value_Renderer.h"
+        "Unique_Value_Renderer.h",
+        "Unique_Value_Renderer.qml"
     ],
     "title": "Unique value renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/README.metadata.json
@@ -24,9 +24,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "AddFeaturesFeatureService.qml",
         "AddFeaturesFeatureService.cpp",
-        "AddFeaturesFeatureService.h"
+        "AddFeaturesFeatureService.h",
+        "AddFeaturesFeatureService.qml"
     ],
     "title": "Add features (feature service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/README.metadata.json
@@ -24,9 +24,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "DeleteFeaturesFeatureService.qml",
         "DeleteFeaturesFeatureService.cpp",
-        "DeleteFeaturesFeatureService.h"
+        "DeleteFeaturesFeatureService.h",
+        "DeleteFeaturesFeatureService.qml"
     ],
     "title": "Delete features (feature service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/README.metadata.json
@@ -39,9 +39,9 @@
         "SyncLayerOption"
     ],
     "snippets": [
-        "EditAndSyncFeatures.qml",
         "EditAndSyncFeatures.cpp",
-        "EditAndSyncFeatures.h"
+        "EditAndSyncFeatures.h",
+        "EditAndSyncFeatures.qml"
     ],
     "title": "Edit and sync features"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/README.metadata.json
@@ -36,9 +36,9 @@
         "UpdateFeature"
     ],
     "snippets": [
-        "EditFeatureAttachments.qml",
         "EditFeatureAttachments.cpp",
-        "EditFeatureAttachments.h"
+        "EditFeatureAttachments.h",
+        "EditFeatureAttachments.qml"
     ],
     "title": "Edit feature attachments"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Edit Data",
+    "category": "Edit data",
     "dataItems": [
         {
             "itemId": "74c0c9fa80f4498c9739cc42531e9948",

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/README.metadata.json
@@ -32,9 +32,9 @@
         "Geodatabase"
     ],
     "snippets": [
-        "EditFeaturesWithFeatureLinkedAnnotation.qml",
         "EditFeaturesWithFeatureLinkedAnnotation.cpp",
-        "EditFeaturesWithFeatureLinkedAnnotation.h"
+        "EditFeaturesWithFeatureLinkedAnnotation.h",
+        "EditFeaturesWithFeatureLinkedAnnotation.qml"
     ],
     "title": "Edit features with feature-linked annotation"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/README.metadata.json
@@ -32,9 +32,9 @@
         "KmlLayer"
     ],
     "snippets": [
-        "EditKmlGroundOverlay.qml",
         "EditKmlGroundOverlay.cpp",
-        "EditKmlGroundOverlay.h"
+        "EditKmlGroundOverlay.h",
+        "EditKmlGroundOverlay.qml"
     ],
     "title": "Edit KML ground overlay"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/README.metadata.json
@@ -37,9 +37,9 @@
         "VersionAccess"
     ],
     "snippets": [
-        "EditWithBranchVersioning.qml",
         "EditWithBranchVersioning.cpp",
-        "EditWithBranchVersioning.h"
+        "EditWithBranchVersioning.h",
+        "EditWithBranchVersioning.qml"
     ],
     "title": "Edit with branch versioning"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/README.metadata.json
@@ -26,9 +26,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "UpdateAttributesFeatureService.qml",
         "UpdateAttributesFeatureService.cpp",
-        "UpdateAttributesFeatureService.h"
+        "UpdateAttributesFeatureService.h",
+        "UpdateAttributesFeatureService.qml"
     ],
     "title": "Update attributes (feature service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/README.metadata.json
@@ -25,9 +25,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "UpdateGeometryFeatureService.qml",
         "UpdateGeometryFeatureService.cpp",
-        "UpdateGeometryFeatureService.h"
+        "UpdateGeometryFeatureService.h",
+        "UpdateGeometryFeatureService.qml"
     ],
     "title": "Update geometry (feature service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/README.metadata.json
@@ -28,9 +28,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "ControlTimeExtentTimeSlider.qml",
         "ControlTimeExtentTimeSlider.cpp",
-        "ControlTimeExtentTimeSlider.h"
+        "ControlTimeExtentTimeSlider.h",
+        "ControlTimeExtentTimeSlider.qml"
     ],
     "title": "Control time extent using time slider"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/README.metadata.json
@@ -22,9 +22,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "FeatureLayerChangeRenderer.qml",
         "FeatureLayerChangeRenderer.cpp",
-        "FeatureLayerChangeRenderer.h"
+        "FeatureLayerChangeRenderer.h",
+        "FeatureLayerChangeRenderer.qml"
     ],
     "title": "Feature layer change renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDefinitionExpression/README.metadata.json
@@ -26,9 +26,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "FeatureLayerDefinitionExpression.qml",
         "FeatureLayerDefinitionExpression.cpp",
-        "FeatureLayerDefinitionExpression.h"
+        "FeatureLayerDefinitionExpression.h",
+        "FeatureLayerDefinitionExpression.qml"
     ],
     "title": "Feature layer definition expression"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/README.metadata.json
@@ -29,9 +29,9 @@
         "DictionarySymbolStyle"
     ],
     "snippets": [
-        "FeatureLayerDictionaryRenderer.qml",
         "FeatureLayerDictionaryRenderer.cpp",
-        "FeatureLayerDictionaryRenderer.h"
+        "FeatureLayerDictionaryRenderer.h",
+        "FeatureLayerDictionaryRenderer.qml"
     ],
     "title": "Feature layer (dictionary renderer)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/README.metadata.json
@@ -27,9 +27,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "FeatureLayerFeatureService.qml",
         "FeatureLayerFeatureService.cpp",
-        "FeatureLayerFeatureService.h"
+        "FeatureLayerFeatureService.h",
+        "FeatureLayerFeatureService.qml"
     ],
     "title": "Feature layer (feature service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/README.metadata.json
@@ -33,9 +33,9 @@
         "Map"
     ],
     "snippets": [
-        "FeatureLayer_GeoPackage.qml",
+        "FeatureLayer_GeoPackage.cpp",
         "FeatureLayer_GeoPackage.h",
-        "FeatureLayer_GeoPackage.cpp"
+        "FeatureLayer_GeoPackage.qml"
     ],
     "title": "Feature layer (GeoPackage)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/README.metadata.json
@@ -32,9 +32,9 @@
         "GeodatabaseFeatureTable"
     ],
     "snippets": [
-        "FeatureLayerGeodatabase.qml",
         "FeatureLayerGeodatabase.cpp",
-        "FeatureLayerGeodatabase.h"
+        "FeatureLayerGeodatabase.h",
+        "FeatureLayerGeodatabase.qml"
     ],
     "title": "Feature layer (geodatabase)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/README.metadata.json
@@ -22,9 +22,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "FeatureLayerQuery.qml",
         "FeatureLayerQuery.cpp",
-        "FeatureLayerQuery.h"
+        "FeatureLayerQuery.h",
+        "FeatureLayerQuery.qml"
     ],
     "title": "Feature layer query"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/README.metadata.json
@@ -24,9 +24,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "FeatureLayerSelection.qml",
         "FeatureLayerSelection.cpp",
-        "FeatureLayerSelection.h"
+        "FeatureLayerSelection.h",
+        "FeatureLayerSelection.qml"
     ],
     "title": "Feature layer selection"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabase/README.metadata.json
@@ -31,9 +31,9 @@
         "GeodatabaseSyncTask"
     ],
     "snippets": [
-        "GenerateGeodatabase.qml",
         "GenerateGeodatabase.cpp",
-        "GenerateGeodatabase.h"
+        "GenerateGeodatabase.h",
+        "GenerateGeodatabase.qml"
     ],
     "title": "Generate geodatabase"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/README.metadata.json
@@ -29,13 +29,13 @@
         "RelatedFeatureQueryResult"
     ],
     "snippets": [
-        "ListRelatedFeatures.qml",
         "ListRelatedFeatures.cpp",
         "ListRelatedFeatures.h",
         "RelatedFeature.cpp",
         "RelatedFeature.h",
         "RelatedFeatureListModel.cpp",
-        "RelatedFeatureListModel.h"
+        "RelatedFeatureListModel.h",
+        "ListRelatedFeatures.qml"
     ],
     "title": "List related features"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/README.metadata.json
@@ -24,9 +24,9 @@
         "ServiceFeatureTable::setFeatureRequestMode"
     ],
     "snippets": [
-        "ServiceFeatureTableCache.qml",
         "ServiceFeatureTableCache.cpp",
-        "ServiceFeatureTableCache.h"
+        "ServiceFeatureTableCache.h",
+        "ServiceFeatureTableCache.qml"
     ],
     "title": "Service feature table (cache)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/README.metadata.json
@@ -26,9 +26,9 @@
         "ServiceFeatureTable::setFeatureRequestMode"
     ],
     "snippets": [
-        "ServiceFeatureTableManualCache.qml",
         "ServiceFeatureTableManualCache.cpp",
-        "ServiceFeatureTableManualCache.h"
+        "ServiceFeatureTableManualCache.h",
+        "ServiceFeatureTableManualCache.qml"
     ],
     "title": "Service feature table (manual cache)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/README.metadata.json
@@ -24,9 +24,9 @@
         "ServiceFeatureTable::setFeatureRequestMode"
     ],
     "snippets": [
-        "ServiceFeatureTableNoCache.qml",
         "ServiceFeatureTableNoCache.cpp",
-        "ServiceFeatureTableNoCache.h"
+        "ServiceFeatureTableNoCache.h",
+        "ServiceFeatureTableNoCache.qml"
     ],
     "title": "Service feature table (no cache)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/README.metadata.json
@@ -25,9 +25,9 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "Buffer.qml",
         "Buffer.cpp",
-        "Buffer.h"
+        "Buffer.h",
+        "Buffer.qml"
     ],
     "title": "Buffer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/README.metadata.json
@@ -26,9 +26,9 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "ClipGeometry.qml",
         "ClipGeometry.cpp",
-        "ClipGeometry.h"
+        "ClipGeometry.h",
+        "ClipGeometry.qml"
     ],
     "title": "Clip geometry"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/README.metadata.json
@@ -20,9 +20,9 @@
         "GeometryEngine"
     ],
     "snippets": [
-        "ConvexHull.qml",
         "ConvexHull.cpp",
-        "ConvexHull.h"
+        "ConvexHull.h",
+        "ConvexHull.qml"
     ],
     "title": "Convex hull"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/README.metadata.json
@@ -31,9 +31,9 @@
         "Polyline"
     ],
     "snippets": [
-        "CreateGeometries.qml",
         "CreateGeometries.cpp",
-        "CreateGeometries.h"
+        "CreateGeometries.h",
+        "CreateGeometries.qml"
     ],
     "title": "Create geometries"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/README.metadata.json
@@ -22,9 +22,9 @@
         "Polyline"
     ],
     "snippets": [
-        "CutGeometry.qml",
         "CutGeometry.cpp",
-        "CutGeometry.h"
+        "CutGeometry.h",
+        "CutGeometry.qml"
     ],
     "title": "Cut geometry"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/README.metadata.json
@@ -31,9 +31,9 @@
         "SpatialReference"
     ],
     "snippets": [
-        "DensifyAndGeneralize.qml",
         "DensifyAndGeneralize.cpp",
-        "DensifyAndGeneralize.h"
+        "DensifyAndGeneralize.h",
+        "DensifyAndGeneralize.qml"
     ],
     "title": "Densify and generalize"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/README.metadata.json
@@ -28,9 +28,9 @@
         "UtmConversionMode"
     ],
     "snippets": [
-        "FormatCoordinates.qml",
         "FormatCoordinates.cpp",
-        "FormatCoordinates.h"
+        "FormatCoordinates.h",
+        "FormatCoordinates.qml"
     ],
     "title": "Format coordinates"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/README.metadata.json
@@ -21,9 +21,9 @@
         "GeometryEngine::lengthGeodetic"
     ],
     "snippets": [
-        "GeodesicOperations.qml",
         "GeodesicOperations.cpp",
-        "GeodesicOperations.h"
+        "GeodesicOperations.h",
+        "GeodesicOperations.qml"
     ],
     "title": "Geodesic operations"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/README.metadata.json
@@ -30,9 +30,9 @@
         "TransformationCatalog"
     ],
     "snippets": [
-        "ListTransformations.qml",
         "ListTransformations.cpp",
-        "ListTransformations.h"
+        "ListTransformations.h",
+        "ListTransformations.qml"
     ],
     "title": "List transformations by suitability"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/README.metadata.json
@@ -23,9 +23,9 @@
         "ProximityResult"
     ],
     "snippets": [
-        "NearestVertex.qml",
         "NearestVertex.cpp",
-        "NearestVertex.h"
+        "NearestVertex.h",
+        "NearestVertex.qml"
     ],
     "title": "Nearest vertex"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/README.metadata.json
@@ -28,9 +28,9 @@
         "SpatialReference"
     ],
     "snippets": [
-        "ProjectGeometry.qml",
         "ProjectGeometry.cpp",
-        "ProjectGeometry.h"
+        "ProjectGeometry.h",
+        "ProjectGeometry.qml"
     ],
     "title": "Project"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/README.metadata.json
@@ -37,9 +37,9 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "SpatialOperations.qml",
         "SpatialOperations.cpp",
-        "SpatialOperations.h"
+        "SpatialOperations.h",
+        "SpatialOperations.qml"
     ],
     "title": "Spatial operations"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/README.metadata.json
@@ -44,9 +44,9 @@
         "Polyline"
     ],
     "snippets": [
-        "SpatialRelationships.qml",
         "SpatialRelationships.cpp",
-        "SpatialRelationships.h"
+        "SpatialRelationships.h",
+        "SpatialRelationships.qml"
     ],
     "title": "Spatial relationships"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/README.metadata.json
@@ -37,9 +37,9 @@
         "EncLayer"
     ],
     "snippets": [
-        "AddEncExchangeSet.qml",
         "AddEncExchangeSet.cpp",
-        "AddEncExchangeSet.h"
+        "AddEncExchangeSet.h",
+        "AddEncExchangeSet.qml"
     ],
     "title": "Add ENC exchange set"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/README.metadata.json
@@ -25,9 +25,9 @@
         "MosaicRule::setMosaicOperation"
     ],
     "snippets": [
-        "ApplyMosaicRuleToRasters.qml",
         "ApplyMosaicRuleToRasters.cpp",
-        "ApplyMosaicRuleToRasters.h"
+        "ApplyMosaicRuleToRasters.h",
+        "ApplyMosaicRuleToRasters.qml"
     ],
     "title": "Apply mosaic rule to rasters"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/README.metadata.json
@@ -19,9 +19,9 @@
         "ArcGISMapImageLayer"
     ],
     "snippets": [
-        "ArcGISMapImageLayerUrl.qml",
         "ArcGISMapImageLayerUrl.cpp",
-        "ArcGISMapImageLayerUrl.h"
+        "ArcGISMapImageLayerUrl.h",
+        "ArcGISMapImageLayerUrl.qml"
     ],
     "title": "ArcGIS map image layer (URL)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/README.metadata.json
@@ -26,9 +26,9 @@
         "MapView"
     ],
     "snippets": [
-        "ArcGISTiledLayerUrl.qml",
         "ArcGISTiledLayerUrl.cpp",
-        "ArcGISTiledLayerUrl.h"
+        "ArcGISTiledLayerUrl.h",
+        "ArcGISTiledLayerUrl.qml"
     ],
     "title": "ArcGIS tiled layer (URL)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/README.metadata.json
@@ -38,11 +38,11 @@
         "RasterLayer"
     ],
     "snippets": [
-        "BlendRasterLayer.qml",
         "BlendRasterLayer.cpp",
         "BlendRasterLayer.h",
         "ColorRampModel.qml",
-        "SlopeTypeModel.qml"
+        "SlopeTypeModel.qml",
+        "BlendRasterLayer.qml"
     ],
     "title": "Blend raster layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/README.metadata.json
@@ -29,9 +29,9 @@
         "OgcFeatureServiceInfo"
     ],
     "snippets": [
-        "BrowseOGCAPIFeatureService.qml",
         "BrowseOGCAPIFeatureService.cpp",
-        "BrowseOGCAPIFeatureService.h"
+        "BrowseOGCAPIFeatureService.h",
+        "BrowseOGCAPIFeatureService.qml"
     ],
     "title": "Browse OGC API Feature Service"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/README.metadata.json
@@ -33,9 +33,9 @@
         "WfsServiceInfo"
     ],
     "snippets": [
-        "BrowseWfsLayers.qml",
         "BrowseWfsLayers.cpp",
-        "BrowseWfsLayers.h"
+        "BrowseWfsLayers.h",
+        "BrowseWfsLayers.qml"
     ],
     "title": "Browse WFS layers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/README.metadata.json
@@ -28,9 +28,9 @@
         "ClassBreaksRenderer::classBreak"
     ],
     "snippets": [
-        "ChangeSublayerRenderer.qml",
         "ChangeSublayerRenderer.cpp",
-        "ChangeSublayerRenderer.h"
+        "ChangeSublayerRenderer.h",
+        "ChangeSublayerRenderer.qml"
     ],
     "title": "Change sublayer renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/README.metadata.json
@@ -20,9 +20,9 @@
         "ArcGISSublayerListModel"
     ],
     "snippets": [
-        "ChangeSublayerVisibility.qml",
         "ChangeSublayerVisibility.cpp",
-        "ChangeSublayerVisibility.h"
+        "ChangeSublayerVisibility.h",
+        "ChangeSublayerVisibility.qml"
     ],
     "title": "Change sublayer visibility"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/README.metadata.json
@@ -35,9 +35,9 @@
         "KmlStyle"
     ],
     "snippets": [
-        "CreateAndSaveKmlFile.qml",
         "CreateAndSaveKmlFile.cpp",
-        "CreateAndSaveKmlFile.h"
+        "CreateAndSaveKmlFile.h",
+        "CreateAndSaveKmlFile.qml"
     ],
     "title": "Create and save KML file"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/README.metadata.json
@@ -26,9 +26,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "DisplayAnnotation.qml",
         "DisplayAnnotation.cpp",
-        "DisplayAnnotation.h"
+        "DisplayAnnotation.h",
+        "DisplayAnnotation.qml"
     ],
     "title": "Display annotation"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/README.metadata.json
@@ -27,9 +27,9 @@
         "KmlLayer"
     ],
     "snippets": [
-        "DisplayKml.qml",
         "DisplayKml.cpp",
-        "DisplayKml.h"
+        "DisplayKml.h",
+        "DisplayKml.qml"
     ],
     "title": "Display KML"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/README.metadata.json
@@ -27,10 +27,10 @@
         "kmlNetworkLinkMessageReceived"
     ],
     "snippets": [
-        "DisplayKmlNetworkLinks.qml",
         "DisplayKmlNetworkLinks.cpp",
         "DisplayKmlNetworkLinks.h",
-        "MessageButton.qml"
+        "MessageButton.qml",
+        "DisplayKmlNetworkLinks.qml"
     ],
     "title": "Display KML network links"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/README.metadata.json
@@ -25,9 +25,9 @@
         "QueryParameters"
     ],
     "snippets": [
-        "DisplayOgcApiFeatureCollection.qml",
         "DisplayOgcApiFeatureCollection.cpp",
-        "DisplayOgcApiFeatureCollection.h"
+        "DisplayOgcApiFeatureCollection.h",
+        "DisplayOgcApiFeatureCollection.qml"
     ],
     "title": "Display OGC API Feature Collection"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/README.metadata.json
@@ -33,9 +33,9 @@
         "TextSymbol"
     ],
     "snippets": [
-        "DisplaySubtypeFeatureLayer.qml",
         "DisplaySubtypeFeatureLayer.cpp",
-        "DisplaySubtypeFeatureLayer.h"
+        "DisplaySubtypeFeatureLayer.h",
+        "DisplaySubtypeFeatureLayer.qml"
     ],
     "title": "Display subtype feature layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/README.metadata.json
@@ -30,9 +30,9 @@
         "WfsFeatureTable::populateFromService"
     ],
     "snippets": [
-        "DisplayWfsLayer.qml",
         "DisplayWfsLayer.cpp",
-        "DisplayWfsLayer.h"
+        "DisplayWfsLayer.h",
+        "DisplayWfsLayer.qml"
     ],
     "title": "Display a WFS layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/README.metadata.json
@@ -26,9 +26,9 @@
         "TileCache"
     ],
     "snippets": [
-        "ExportTiles.qml",
         "ExportTiles.cpp",
-        "ExportTiles.h"
+        "ExportTiles.h",
+        "ExportTiles.qml"
     ],
     "title": "Export tiles"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/README.metadata.json
@@ -28,9 +28,9 @@
         "PortalItem"
     ],
     "snippets": [
-        "FeatureCollectionLayerFromPortal.qml",
         "FeatureCollectionLayerFromPortal.cpp",
-        "FeatureCollectionLayerFromPortal.h"
+        "FeatureCollectionLayerFromPortal.h",
+        "FeatureCollectionLayerFromPortal.qml"
     ],
     "title": "Create feature collection layer (Portal item)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/README.metadata.json
@@ -33,9 +33,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "FeatureCollectionLayerQuery.qml",
         "FeatureCollectionLayerQuery.cpp",
-        "FeatureCollectionLayerQuery.h"
+        "FeatureCollectionLayerQuery.h",
+        "FeatureCollectionLayerQuery.qml"
     ],
     "title": "Feature collection layer (query)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/README.metadata.json
@@ -28,9 +28,9 @@
         "MapView"
     ],
     "snippets": [
-        "FeatureLayerRenderingModeMap.qml",
         "FeatureLayerRenderingModeMap.cpp",
-        "FeatureLayerRenderingModeMap.h"
+        "FeatureLayerRenderingModeMap.h",
+        "FeatureLayerRenderingModeMap.qml"
     ],
     "title": "Feature layer rendering mode (map)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/README.metadata.json
@@ -29,9 +29,9 @@
         "SceneView"
     ],
     "snippets": [
-        "FeatureLayerRenderingModeScene.qml",
         "FeatureLayerRenderingModeScene.cpp",
-        "FeatureLayerRenderingModeScene.h"
+        "FeatureLayerRenderingModeScene.h",
+        "FeatureLayerRenderingModeScene.qml"
     ],
     "title": "Feature layer rendering mode (scene)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/README.metadata.json
@@ -27,9 +27,9 @@
         "ShapefileFeatureTable"
     ],
     "snippets": [
-        "FeatureLayerShapefile.qml",
         "FeatureLayerShapefile.cpp",
-        "FeatureLayerShapefile.h"
+        "FeatureLayerShapefile.h",
+        "FeatureLayerShapefile.qml"
     ],
     "title": "Feature layer (shapefile)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/README.metadata.json
@@ -29,9 +29,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "Feature_Collection_Layer.qml",
         "Feature_Collection_Layer.cpp",
-        "Feature_Collection_Layer.h"
+        "Feature_Collection_Layer.h",
+        "Feature_Collection_Layer.qml"
     ],
     "title": "Feature collection layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/README.metadata.json
@@ -16,9 +16,9 @@
         "GroupLayer"
     ],
     "snippets": [
-        "GroupLayers.qml",
         "GroupLayers.cpp",
-        "GroupLayers.h"
+        "GroupLayers.h",
+        "GroupLayers.qml"
     ],
     "title": "Group layers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/README.metadata.json
@@ -33,11 +33,11 @@
         "RasterLayer"
     ],
     "snippets": [
-        "Hillshade_Renderer.qml",
+        "Hillshade_Renderer.cpp",
+        "Hillshade_Renderer.h",
         "HillshadeSettings.qml",
         "HillshadeSlopeTypeModel.qml",
-        "Hillshade_Renderer.cpp",
-        "Hillshade_Renderer.h"
+        "Hillshade_Renderer.qml"
     ],
     "title": "Hillshade renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/README.metadata.json
@@ -30,9 +30,9 @@
         "KmlPlacemark::balloonContent()"
     ],
     "snippets": [
-        "IdentifyKmlFeatures.qml",
         "IdentifyKmlFeatures.cpp",
-        "IdentifyKmlFeatures.h"
+        "IdentifyKmlFeatures.h",
+        "IdentifyKmlFeatures.qml"
     ],
     "title": "Identify KML features"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/README.metadata.json
@@ -38,9 +38,9 @@
         "RasterLayer"
     ],
     "snippets": [
-        "IdentifyRasterCell.qml",
         "IdentifyRasterCell.cpp",
-        "IdentifyRasterCell.h"
+        "IdentifyRasterCell.h",
+        "IdentifyRasterCell.qml"
     ],
     "title": "Identify raster cell"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/README.metadata.json
@@ -44,9 +44,9 @@
         "KmlScreenOverlay"
     ],
     "snippets": [
-        "ListKmlContents.qml",
         "ListKmlContents.cpp",
-        "ListKmlContents.h"
+        "ListKmlContents.h",
+        "ListKmlContents.qml"
     ],
     "title": "List KML contents"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/README.metadata.json
@@ -28,9 +28,9 @@
         "WfsFeatureTable::populateFromService"
     ],
     "snippets": [
-        "LoadWfsXmlQuery.qml",
         "LoadWfsXmlQuery.cpp",
-        "LoadWfsXmlQuery.h"
+        "LoadWfsXmlQuery.h",
+        "LoadWfsXmlQuery.qml"
     ],
     "title": "Load WFS with XML query"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/README.metadata.json
@@ -30,11 +30,11 @@
         "Map"
     ],
     "snippets": [
-        "ManageOperationalLayers.qml",
+        "ManageOperationalLayers.cpp",
+        "ManageOperationalLayers.h",
         "DrawOrderLayerListModel.cpp",
         "DrawOrderLayerListModel.h",
-        "ManageOperationalLayers.cpp",
-        "ManageOperationalLayers.h"
+        "ManageOperationalLayers.qml"
     ],
     "title": "Manage operational layers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.metadata.json
@@ -30,9 +30,9 @@
         "OpenStreetMapLayer"
     ],
     "snippets": [
-        "OSM_Layer.qml",
         "OSM_Layer.cpp",
-        "OSM_Layer.h"
+        "OSM_Layer.h",
+        "OSM_Layer.qml"
     ],
     "title": "OpenStreetMap layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/README.metadata.json
@@ -43,9 +43,9 @@
         "KmlTourController::tour"
     ],
     "snippets": [
-        "PlayAKmlTour.qml",
         "PlayAKmlTour.cpp",
-        "PlayAKmlTour.h"
+        "PlayAKmlTour.h",
+        "PlayAKmlTour.qml"
     ],
     "title": "Play a KML tour"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/README.metadata.json
@@ -29,9 +29,9 @@
         "ServiceFeatureTable"
     ],
     "snippets": [
-        "QueryMapImageSublayer.qml",
         "QueryMapImageSublayer.cpp",
-        "QueryMapImageSublayer.h"
+        "QueryMapImageSublayer.h",
+        "QueryMapImageSublayer.qml"
     ],
     "title": "Query map image sublayer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/README.metadata.json
@@ -30,9 +30,9 @@
         "TimeExtent"
     ],
     "snippets": [
-        "QueryOGCAPICQLFilters.qml",
         "QueryOGCAPICQLFilters.cpp",
-        "QueryOGCAPICQLFilters.h"
+        "QueryOGCAPICQLFilters.h",
+        "QueryOGCAPICQLFilters.qml"
     ],
     "title": "Query OGC API with CQL Filters"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/README.metadata.json
@@ -30,9 +30,9 @@
         "RasterLayer"
     ],
     "snippets": [
-        "RasterColormapRenderer.qml",
         "RasterColormapRenderer.cpp",
-        "RasterColormapRenderer.h"
+        "RasterColormapRenderer.h",
+        "RasterColormapRenderer.qml"
     ],
     "title": "Colormap renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/README.metadata.json
@@ -37,9 +37,9 @@
         "RasterLayer"
     ],
     "snippets": [
-        "RasterFunctionFile.qml",
         "RasterFunctionFile.cpp",
-        "RasterFunctionFile.h"
+        "RasterFunctionFile.h",
+        "RasterFunctionFile.qml"
     ],
     "title": "Raster function (file)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/README.metadata.json
@@ -34,9 +34,9 @@
         "RasterLayer"
     ],
     "snippets": [
-        "RasterFunctionService.qml",
         "RasterFunctionService.cpp",
-        "RasterFunctionService.h"
+        "RasterFunctionService.h",
+        "RasterFunctionService.qml"
     ],
     "title": "Raster function (service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/README.metadata.json
@@ -29,10 +29,10 @@
         "RasterLayer"
     ],
     "snippets": [
-        "RasterLayerFile.qml",
         "RasterLayerFile.cpp",
         "RasterLayerFile.h",
-        "RasterLoader.qml"
+        "RasterLoader.qml",
+        "RasterLayerFile.qml"
     ],
     "title": "Raster layer (file)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/README.metadata.json
@@ -34,9 +34,9 @@
         "RasterLayer"
     ],
     "snippets": [
-        "RasterLayerGeoPackage.qml",
         "RasterLayerGeoPackage.cpp",
-        "RasterLayerGeoPackage.h"
+        "RasterLayerGeoPackage.h",
+        "RasterLayerGeoPackage.qml"
     ],
     "title": "Raster layer (GeoPackage)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/README.metadata.json
@@ -19,9 +19,9 @@
         "RasterLayer"
     ],
     "snippets": [
-        "RasterLayerService.qml",
         "RasterLayerService.cpp",
-        "RasterLayerService.h"
+        "RasterLayerService.h",
+        "RasterLayerService.qml"
     ],
     "title": "Raster layer (service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/README.metadata.json
@@ -22,9 +22,9 @@
         "RenderingRule"
     ],
     "snippets": [
-        "RasterRenderingRule.qml",
         "RasterRenderingRule.cpp",
-        "RasterRenderingRule.h"
+        "RasterRenderingRule.h",
+        "RasterRenderingRule.qml"
     ],
     "title": "Raster rendering rule"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/README.metadata.json
@@ -41,9 +41,9 @@
         "StretchParameters"
     ],
     "snippets": [
-        "RasterRgbRenderer.qml",
         "RasterRgbRenderer.cpp",
-        "RasterRgbRenderer.h"
+        "RasterRgbRenderer.h",
+        "RasterRgbRenderer.qml"
     ],
     "title": "RGB renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/README.metadata.json
@@ -47,10 +47,10 @@
         "StretchRenderer"
     ],
     "snippets": [
-        "RasterStretchRenderer.qml",
-        "InputWithLabel.qml",
         "RasterStretchRenderer.cpp",
-        "RasterStretchRenderer.h"
+        "RasterStretchRenderer.h",
+        "InputWithLabel.qml",
+        "RasterStretchRenderer.qml"
     ],
     "title": "Stretch renderer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/README.metadata.json
@@ -25,9 +25,9 @@
         "WmsSublayerInfo"
     ],
     "snippets": [
-        "StyleWmsLayer.qml",
         "StyleWmsLayer.cpp",
-        "StyleWmsLayer.h"
+        "StyleWmsLayer.h",
+        "StyleWmsLayer.qml"
     ],
     "title": "Style WMS layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/README.metadata.json
@@ -31,9 +31,9 @@
         "TileCache"
     ],
     "snippets": [
-        "TileCacheLayer.qml",
         "TileCacheLayer.cpp",
-        "TileCacheLayer.h"
+        "TileCacheLayer.h",
+        "TileCacheLayer.qml"
     ],
     "title": "ArcGIS tiled layer (tile cache)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/README.metadata.json
@@ -22,9 +22,9 @@
         "Basemap"
     ],
     "snippets": [
-        "VectorTiledLayerUrl.qml",
         "VectorTiledLayerUrl.cpp",
-        "VectorTiledLayerUrl.h"
+        "VectorTiledLayerUrl.h",
+        "VectorTiledLayerUrl.qml"
     ],
     "title": "Vector tiled layer (URL)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/README.metadata.json
@@ -26,9 +26,9 @@
         "WmtsServiceInfo"
     ],
     "snippets": [
-        "WMTS_Layer.qml",
         "WMTS_Layer.cpp",
-        "WMTS_Layer.h"
+        "WMTS_Layer.h",
+        "WMTS_Layer.qml"
     ],
     "title": "WMTS layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/README.metadata.json
@@ -24,9 +24,9 @@
         "WebTiledLayer"
     ],
     "snippets": [
-        "Web_Tiled_Layer.qml",
         "Web_Tiled_Layer.cpp",
-        "Web_Tiled_Layer.h"
+        "Web_Tiled_Layer.h",
+        "Web_Tiled_Layer.qml"
     ],
     "title": "Web tiled layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/README.metadata.json
@@ -21,9 +21,9 @@
         "WmsLayer"
     ],
     "snippets": [
-        "WmsLayerUrl.qml",
         "WmsLayerUrl.cpp",
-        "WmsLayerUrl.h"
+        "WmsLayerUrl.h",
+        "WmsLayerUrl.qml"
     ],
     "title": "WMS layer (URL)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/README.metadata.json
@@ -34,9 +34,9 @@
         "LocalServerStatus"
     ],
     "snippets": [
-        "LocalServerFeatureLayer.qml",
         "LocalServerFeatureLayer.cpp",
-        "LocalServerFeatureLayer.h"
+        "LocalServerFeatureLayer.h",
+        "LocalServerFeatureLayer.qml"
     ],
     "title": "Local Server feature layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/README.metadata.json
@@ -47,9 +47,9 @@
         "LocalServerStatus"
     ],
     "snippets": [
-        "LocalServerGeoprocessing.qml",
         "LocalServerGeoprocessing.cpp",
-        "LocalServerGeoprocessing.h"
+        "LocalServerGeoprocessing.h",
+        "LocalServerGeoprocessing.qml"
     ],
     "title": "Local server geoprocessing"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/README.metadata.json
@@ -32,9 +32,9 @@
         "LocalServerStatus"
     ],
     "snippets": [
-        "LocalServerMapImageLayer.qml",
         "LocalServerMapImageLayer.cpp",
-        "LocalServerMapImageLayer.h"
+        "LocalServerMapImageLayer.h",
+        "LocalServerMapImageLayer.qml"
     ],
     "title": "Local Server map image layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/README.metadata.json
@@ -41,9 +41,9 @@
         "LocalService"
     ],
     "snippets": [
-        "LocalServerServices.qml",
         "LocalServerServices.cpp",
-        "LocalServerServices.h"
+        "LocalServerServices.h",
+        "LocalServerServices.qml"
     ],
     "title": "Local server services"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/README.metadata.json
@@ -36,9 +36,9 @@
         "OfflineMapUpdatesInfo"
     ],
     "snippets": [
-        "ApplyScheduledMapUpdates.qml",
         "ApplyScheduledMapUpdates.cpp",
-        "ApplyScheduledMapUpdates.h"
+        "ApplyScheduledMapUpdates.h",
+        "ApplyScheduledMapUpdates.qml"
     ],
     "title": "Apply scheduled updates to preplanned map area"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/README.metadata.json
@@ -21,9 +21,9 @@
         "MapView"
     ],
     "snippets": [
-        "ChangeBasemap.qml",
         "ChangeBasemap.cpp",
-        "ChangeBasemap.h"
+        "ChangeBasemap.h",
+        "ChangeBasemap.qml"
     ],
     "title": "Change basemap"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/README.metadata.json
@@ -32,9 +32,9 @@
         "Viewpoint"
     ],
     "snippets": [
-        "ChangeViewpoint.qml",
         "ChangeViewpoint.cpp",
-        "ChangeViewpoint.h"
+        "ChangeViewpoint.h",
+        "ChangeViewpoint.qml"
     ],
     "title": "Change viewpoint"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/README.metadata.json
@@ -25,11 +25,11 @@
         "Portal"
     ],
     "snippets": [
-        "CreateAndSaveMap.qml",
         "CreateAndSaveMap.cpp",
         "CreateAndSaveMap.h",
         "LayerWindow.qml",
-        "SaveOptionsWindow.qml"
+        "SaveOptionsWindow.qml",
+        "CreateAndSaveMap.qml"
     ],
     "title": "Create and save map"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/README.metadata.json
@@ -28,9 +28,9 @@
         "MapView"
     ],
     "snippets": [
-        "DisplayDeviceLocation.qml",
         "DisplayDeviceLocation.cpp",
-        "DisplayDeviceLocation.h"
+        "DisplayDeviceLocation.h",
+        "DisplayDeviceLocation.qml"
     ],
     "title": "Display device location with autopan modes"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/README.metadata.json
@@ -23,9 +23,9 @@
         "NMEALocationDataSource"
     ],
     "snippets": [
-        "DisplayDeviceLocationWithNmeaDataSources.qml",
         "DisplayDeviceLocationWithNmeaDataSources.cpp",
-        "DisplayDeviceLocationWithNmeaDataSources.h"
+        "DisplayDeviceLocationWithNmeaDataSources.h",
+        "DisplayDeviceLocationWithNmeaDataSources.qml"
     ],
     "title": "Display device location with NMEA data sources"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/README.metadata.json
@@ -25,9 +25,9 @@
         "drawStatus"
     ],
     "snippets": [
-        "DisplayDrawingStatus.qml",
         "DisplayDrawingStatus.cpp",
-        "DisplayDrawingStatus.h"
+        "DisplayDrawingStatus.h",
+        "DisplayDrawingStatus.qml"
     ],
     "title": "Display draw status"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/README.metadata.json
@@ -29,9 +29,9 @@
         "MapView"
     ],
     "snippets": [
-        "DisplayLayerViewDrawState.qml",
         "DisplayLayerViewDrawState.cpp",
-        "DisplayLayerViewDrawState.h"
+        "DisplayLayerViewDrawState.h",
+        "DisplayLayerViewDrawState.qml"
     ],
     "title": "Display layer view draw state"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/README.metadata.json
@@ -21,9 +21,9 @@
         "MapView"
     ],
     "snippets": [
-        "DisplayMap.qml",
         "DisplayMap.cpp",
-        "DisplayMap.h"
+        "DisplayMap.h",
+        "DisplayMap.qml"
     ],
     "title": "Display map"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/README.metadata.json
@@ -27,9 +27,9 @@
         "PreplannedMapArea"
     ],
     "snippets": [
-        "DownloadPreplannedMap.qml",
         "DownloadPreplannedMap.cpp",
-        "DownloadPreplannedMap.h"
+        "DownloadPreplannedMap.h",
+        "DownloadPreplannedMap.qml"
     ],
     "title": "Download a preplanned map area"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/README.metadata.json
@@ -27,11 +27,11 @@
         "Portal"
     ],
     "snippets": [
-        "GenerateOfflineMap.qml",
-        "DownloadButton.qml",
         "GenerateOfflineMap.cpp",
         "GenerateOfflineMap.h",
-        "GenerateWindow.qml"
+        "DownloadButton.qml",
+        "GenerateWindow.qml",
+        "GenerateOfflineMap.qml"
     ],
     "title": "Generate offline map"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/README.metadata.json
@@ -33,11 +33,11 @@
         "OfflineMapTask"
     ],
     "snippets": [
-        "GenerateOfflineMapLocalBasemap.qml",
-        "DownloadButton.qml",
         "GenerateOfflineMapLocalBasemap.cpp",
         "GenerateOfflineMapLocalBasemap.h",
-        "GenerateWindow.qml"
+        "DownloadButton.qml",
+        "GenerateWindow.qml",
+        "GenerateOfflineMapLocalBasemap.qml"
     ],
     "title": "Generate offline map with local basemap"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.metadata.json
@@ -42,12 +42,12 @@
         "OfflineMapTask"
     ],
     "snippets": [
-        "GenerateOfflineMap_Overrides.qml",
-        "DownloadButton.qml",
         "GenerateOfflineMap_Overrides.cpp",
         "GenerateOfflineMap_Overrides.h",
+        "DownloadButton.qml",
         "GenerateWindow.qml",
-        "OverridesWindow.qml"
+        "OverridesWindow.qml",
+        "GenerateOfflineMap_Overrides.qml"
     ],
     "title": "Generate Offline Map (Overrides)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/README.metadata.json
@@ -25,9 +25,9 @@
         "MobileMapPackage"
     ],
     "snippets": [
-        "HonorMobileMapPackageExpiration.qml",
         "HonorMobileMapPackageExpiration.cpp",
-        "HonorMobileMapPackageExpiration.h"
+        "HonorMobileMapPackageExpiration.h",
+        "HonorMobileMapPackageExpiration.qml"
     ],
     "title": "Honor mobile map package expiration date"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/README.metadata.json
@@ -25,9 +25,9 @@
         "MapView::identifyLayers"
     ],
     "snippets": [
-        "IdentifyLayers.qml",
         "IdentifyLayers.cpp",
-        "IdentifyLayers.h"
+        "IdentifyLayers.h",
+        "IdentifyLayers.qml"
     ],
     "title": "Identify layers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/README.metadata.json
@@ -23,9 +23,9 @@
         "Viewpoint"
     ],
     "snippets": [
-        "ManageBookmarks.qml",
         "ManageBookmarks.cpp",
-        "ManageBookmarks.h"
+        "ManageBookmarks.h",
+        "ManageBookmarks.qml"
     ],
     "title": "Manage bookmarks"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/README.metadata.json
@@ -21,9 +21,9 @@
         "MapView"
     ],
     "snippets": [
-        "MapLoaded.qml",
         "MapLoaded.cpp",
-        "MapLoaded.h"
+        "MapLoaded.h",
+        "MapLoaded.qml"
     ],
     "title": "Map loaded"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/README.metadata.json
@@ -20,9 +20,9 @@
         "Map"
     ],
     "snippets": [
-        "MapReferenceScale.qml",
         "MapReferenceScale.cpp",
-        "MapReferenceScale.h"
+        "MapReferenceScale.h",
+        "MapReferenceScale.qml"
     ],
     "title": "Map reference scale"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/README.metadata.json
@@ -20,9 +20,9 @@
         "MapView"
     ],
     "snippets": [
-        "MapRotation.qml",
         "MapRotation.cpp",
-        "MapRotation.h"
+        "MapRotation.h",
+        "MapRotation.qml"
     ],
     "title": "Map rotation"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/README.metadata.json
@@ -27,9 +27,9 @@
         "ViewPoint"
     ],
     "snippets": [
-        "MinMaxScale.qml",
         "MinMaxScale.cpp",
-        "MinMaxScale.h"
+        "MinMaxScale.h",
+        "MinMaxScale.qml"
     ],
     "title": "Min-Max scale"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/README.metadata.json
@@ -48,9 +48,9 @@
         "TransportationNetworkDataset"
     ],
     "snippets": [
-        "MobileMap_SearchAndRoute.qml",
         "MobileMap_SearchAndRoute.cpp",
-        "MobileMap_SearchAndRoute.h"
+        "MobileMap_SearchAndRoute.h",
+        "MobileMap_SearchAndRoute.qml"
     ],
     "title": "Mobile map (search and route)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/README.metadata.json
@@ -23,9 +23,9 @@
         "PortalItem"
     ],
     "snippets": [
-        "OpenMapUrl.qml",
         "OpenMapUrl.cpp",
-        "OpenMapUrl.h"
+        "OpenMapUrl.h",
+        "OpenMapUrl.qml"
     ],
     "title": "Open map (URL)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/README.metadata.json
@@ -26,9 +26,9 @@
         "MobileMapPackage"
     ],
     "snippets": [
-        "OpenMobileMap_MapPackage.qml",
         "OpenMobileMap_MapPackage.cpp",
-        "OpenMobileMap_MapPackage.h"
+        "OpenMobileMap_MapPackage.h",
+        "OpenMobileMap_MapPackage.qml"
     ],
     "title": "Open mobile map (map package)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/README.metadata.json
@@ -38,9 +38,9 @@
         "GeoPackageRaster"
     ],
     "snippets": [
-        "ReadGeoPackage.qml",
         "ReadGeoPackage.cpp",
-        "ReadGeoPackage.h"
+        "ReadGeoPackage.h",
+        "ReadGeoPackage.qml"
     ],
     "title": "Read a GeoPackage"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/README.metadata.json
@@ -33,9 +33,9 @@
         "MapView"
     ],
     "snippets": [
-        "SetInitialMapArea.qml",
         "SetInitialMapArea.cpp",
-        "SetInitialMapArea.h"
+        "SetInitialMapArea.h",
+        "SetInitialMapArea.qml"
     ],
     "title": "Set initial map area"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.metadata.json
@@ -33,9 +33,9 @@
         "MapView"
     ],
     "snippets": [
-        "SetInitialMapLocation.qml",
         "SetInitialMapLocation.cpp",
-        "SetInitialMapLocation.h"
+        "SetInitialMapLocation.h",
+        "SetInitialMapLocation.qml"
     ],
     "title": "Set initial map location"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/README.metadata.json
@@ -25,9 +25,9 @@
         "SpatialReference"
     ],
     "snippets": [
-        "SetMapSpatialReference.qml",
         "SetMapSpatialReference.cpp",
-        "SetMapSpatialReference.h"
+        "SetMapSpatialReference.h",
+        "SetMapSpatialReference.qml"
     ],
     "title": "Set map spatial reference"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/README.metadata.json
@@ -35,9 +35,9 @@
         "SimulatedLocationDataSource"
     ],
     "snippets": [
-        "ShowLocationHistory.qml",
         "ShowLocationHistory.cpp",
-        "ShowLocationHistory.h"
+        "ShowLocationHistory.h",
+        "ShowLocationHistory.qml"
     ],
     "title": "Show location history"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/README.metadata.json
@@ -24,9 +24,9 @@
         "MapView::setMagnifierMapPanningEnabled()"
     ],
     "snippets": [
-        "ShowMagnifier.qml",
         "ShowMagnifier.cpp",
-        "ShowMagnifier.h"
+        "ShowMagnifier.h",
+        "ShowMagnifier.qml"
     ],
     "title": "Show magnifier"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/README.metadata.json
@@ -23,11 +23,11 @@
         "GeoView::exportImage"
     ],
     "snippets": [
-        "TakeScreenshot.qml",
+        "TakeScreenshot.cpp",
+        "TakeScreenshot.h",
         "MapImageProvider.cpp",
         "MapImageProvider.h",
-        "TakeScreenshot.cpp",
-        "TakeScreenshot.h"
+        "TakeScreenshot.qml"
     ],
     "title": "Take screenshot"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/README.metadata.json
@@ -35,9 +35,9 @@
         "MapView"
     ],
     "snippets": [
-        "ClosestFacility.qml",
         "ClosestFacility.cpp",
-        "ClosestFacility.h"
+        "ClosestFacility.h",
+        "ClosestFacility.qml"
     ],
     "title": "Find closest facility to an incident (interactive)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/README.metadata.json
@@ -33,9 +33,9 @@
         "Incident"
     ],
     "snippets": [
-        "FindClosestFacilityToMultipleIncidentsService.qml",
         "FindClosestFacilityToMultipleIncidentsService.cpp",
-        "FindClosestFacilityToMultipleIncidentsService.h"
+        "FindClosestFacilityToMultipleIncidentsService.h",
+        "FindClosestFacilityToMultipleIncidentsService.qml"
     ],
     "title": "Find closest facility to multiple incidents (service)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/README.metadata.json
@@ -34,9 +34,9 @@
         "Stop"
     ],
     "snippets": [
-        "FindRoute.qml",
         "FindRoute.cpp",
-        "FindRoute.h"
+        "FindRoute.h",
+        "FindRoute.qml"
     ],
     "title": "Find route"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/README.metadata.json
@@ -27,9 +27,9 @@
         "ServiceAreaTask"
     ],
     "snippets": [
-        "FindServiceAreasForMultipleFacilities.qml",
         "FindServiceAreasForMultipleFacilities.cpp",
-        "FindServiceAreasForMultipleFacilities.h"
+        "FindServiceAreasForMultipleFacilities.h",
+        "FindServiceAreasForMultipleFacilities.qml"
     ],
     "title": "Find service areas for multiple facilities"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/README.metadata.json
@@ -39,9 +39,9 @@
         "VoiceGuidance"
     ],
     "snippets": [
-        "NavigateRoute.qml",
         "NavigateRoute.cpp",
-        "NavigateRoute.h"
+        "NavigateRoute.h",
+        "NavigateRoute.qml"
     ],
     "title": "Navigate route"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/README.metadata.json
@@ -39,9 +39,9 @@
         "TravelMode"
     ],
     "snippets": [
-        "OfflineRouting.qml",
         "OfflineRouting.cpp",
-        "OfflineRouting.h"
+        "OfflineRouting.h",
+        "OfflineRouting.qml"
     ],
     "title": "Offline routing"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/README.metadata.json
@@ -36,9 +36,9 @@
         "Stop"
     ],
     "snippets": [
-        "RouteAroundBarriers.qml",
         "RouteAroundBarriers.cpp",
-        "RouteAroundBarriers.h"
+        "RouteAroundBarriers.h",
+        "RouteAroundBarriers.qml"
     ],
     "title": "Route around barriers"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/README.metadata.json
@@ -30,9 +30,9 @@
         "ServiceAreaTask"
     ],
     "snippets": [
-        "ServiceArea.qml",
         "ServiceArea.cpp",
-        "ServiceArea.h"
+        "ServiceArea.h",
+        "ServiceArea.qml"
     ],
     "title": "Service area"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/README.metadata.json
@@ -18,9 +18,9 @@
         "ArcGISSceneLayer"
     ],
     "snippets": [
-        "AddAPointSceneLayer.qml",
         "AddAPointSceneLayer.cpp",
-        "AddAPointSceneLayer.h"
+        "AddAPointSceneLayer.h",
+        "AddAPointSceneLayer.qml"
     ],
     "title": "Add a point scene layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/README.metadata.json
@@ -18,9 +18,9 @@
         "IntegratedMeshLayer"
     ],
     "snippets": [
-        "AddIntegratedMeshLayer.qml",
         "AddIntegratedMeshLayer.cpp",
-        "AddIntegratedMeshLayer.h"
+        "AddIntegratedMeshLayer.h",
+        "AddIntegratedMeshLayer.qml"
     ],
     "title": "Add an integrated mesh layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/README.metadata.json
@@ -64,12 +64,12 @@
         "SurfacePlacement"
     ],
     "snippets": [
-        "Animate3DSymbols.qml",
         "Animate3DSymbols.cpp",
         "Animate3DSymbols.h",
         "LabeledSlider.qml",
         "MissionData.cpp",
-        "MissionData.h"
+        "MissionData.h",
+        "Animate3DSymbols.qml"
     ],
     "title": "Animate 3D symbols"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/README.metadata.json
@@ -33,9 +33,9 @@
         "SceneView"
     ],
     "snippets": [
-        "AnimateImagesWithImageOverlay.qml",
         "AnimateImagesWithImageOverlay.cpp",
-        "AnimateImagesWithImageOverlay.h"
+        "AnimateImagesWithImageOverlay.h",
+        "AnimateImagesWithImageOverlay.qml"
     ],
     "title": "Animate images with image overlay"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/README.metadata.json
@@ -24,9 +24,9 @@
         "SceneView"
     ],
     "snippets": [
-        "BasicSceneView.qml",
         "BasicSceneView.cpp",
-        "BasicSceneView.h"
+        "BasicSceneView.h",
+        "BasicSceneView.qml"
     ],
     "title": "Display a scene"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/README.metadata.json
@@ -22,9 +22,9 @@
         "SceneView"
     ],
     "snippets": [
-        "ChangeAtmosphereEffect.qml",
         "ChangeAtmosphereEffect.cpp",
-        "ChangeAtmosphereEffect.h"
+        "ChangeAtmosphereEffect.h",
+        "ChangeAtmosphereEffect.qml"
     ],
     "title": "Change atmosphere effect"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/README.metadata.json
@@ -33,9 +33,9 @@
         "SceneView"
     ],
     "snippets": [
-        "ChooseCameraController.qml",
         "ChooseCameraController.cpp",
-        "ChooseCameraController.h"
+        "ChooseCameraController.h",
+        "ChooseCameraController.qml"
     ],
     "title": "Choose camera controller"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/README.metadata.json
@@ -26,9 +26,9 @@
         "Surface"
     ],
     "snippets": [
-        "CreateTerrainSurfaceFromLocalRaster.qml",
         "CreateTerrainSurfaceFromLocalRaster.cpp",
-        "CreateTerrainSurfaceFromLocalRaster.h"
+        "CreateTerrainSurfaceFromLocalRaster.h",
+        "CreateTerrainSurfaceFromLocalRaster.qml"
     ],
     "title": "Create terrain surface from a local raster"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/README.metadata.json
@@ -29,9 +29,9 @@
         "Surface"
     ],
     "snippets": [
-        "CreateTerrainSurfaceFromLocalTilePackage.qml",
         "CreateTerrainSurfaceFromLocalTilePackage.cpp",
-        "CreateTerrainSurfaceFromLocalTilePackage.h"
+        "CreateTerrainSurfaceFromLocalTilePackage.h",
+        "CreateTerrainSurfaceFromLocalTilePackage.qml"
     ],
     "title": "Create terrain surface from a local tile package"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/README.metadata.json
@@ -35,9 +35,9 @@
         "TextSymbol"
     ],
     "snippets": [
-        "Display3DLabelsInScene.qml",
         "Display3DLabelsInScene.cpp",
-        "Display3DLabelsInScene.h"
+        "Display3DLabelsInScene.h",
+        "Display3DLabelsInScene.qml"
     ],
     "title": "Display 3D labels in scene"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/README.metadata.json
@@ -26,9 +26,9 @@
         "Surface"
     ],
     "snippets": [
-        "DisplaySceneLayer.qml",
         "DisplaySceneLayer.cpp",
-        "DisplaySceneLayer.h"
+        "DisplaySceneLayer.h",
+        "DisplaySceneLayer.qml"
     ],
     "title": "Display a scene layer"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/README.metadata.json
@@ -28,9 +28,9 @@
         "RangeCollection"
     ],
     "snippets": [
-        "DistanceCompositeSymbol.qml",
         "DistanceCompositeSymbol.cpp",
-        "DistanceCompositeSymbol.h"
+        "DistanceCompositeSymbol.h",
+        "DistanceCompositeSymbol.qml"
     ],
     "title": "Distance composite symbol"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/README.metadata.json
@@ -27,9 +27,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "ExtrudeGraphics.qml",
         "ExtrudeGraphics.cpp",
-        "ExtrudeGraphics.h"
+        "ExtrudeGraphics.h",
+        "ExtrudeGraphics.qml"
     ],
     "title": "Extrude graphics"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/README.metadata.json
@@ -34,9 +34,9 @@
         "SimpleRenderer"
     ],
     "snippets": [
-        "FeatureLayerExtrusion.qml",
         "FeatureLayerExtrusion.cpp",
-        "FeatureLayerExtrusion.h"
+        "FeatureLayerExtrusion.h",
+        "FeatureLayerExtrusion.qml"
     ],
     "title": "Feature layer extrusion"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/README.metadata.json
@@ -24,9 +24,9 @@
         "SceneView"
     ],
     "snippets": [
-        "GetElevationAtPoint.qml",
         "GetElevationAtPoint.cpp",
-        "GetElevationAtPoint.h"
+        "GetElevationAtPoint.h",
+        "GetElevationAtPoint.qml"
     ],
     "title": "Get elevation at point"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/README.metadata.json
@@ -25,9 +25,9 @@
         "SceneView"
     ],
     "snippets": [
-        "OpenMobileScenePackage.qml",
         "OpenMobileScenePackage.cpp",
-        "OpenMobileScenePackage.h"
+        "OpenMobileScenePackage.h",
+        "OpenMobileScenePackage.qml"
     ],
     "title": "Open mobile scene package"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/README.metadata.json
@@ -22,9 +22,9 @@
         "SceneView"
     ],
     "snippets": [
-        "OpenScene.qml",
         "OpenScene.cpp",
-        "OpenScene.h"
+        "OpenScene.h",
+        "OpenScene.qml"
     ],
     "title": "Open a scene (portal item)"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/README.metadata.json
@@ -27,9 +27,9 @@
         "OrbitGeoElementCameraController"
     ],
     "snippets": [
-        "OrbitCameraAroundObject.qml",
         "OrbitCameraAroundObject.cpp",
-        "OrbitCameraAroundObject.h"
+        "OrbitCameraAroundObject.h",
+        "OrbitCameraAroundObject.qml"
     ],
     "title": "Orbit the camera around an object"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/README.metadata.json
@@ -29,9 +29,9 @@
         "SceneView"
     ],
     "snippets": [
-        "RealisticLightingAndShadows.qml",
         "RealisticLightingAndShadows.cpp",
-        "RealisticLightingAndShadows.h"
+        "RealisticLightingAndShadows.h",
+        "RealisticLightingAndShadows.qml"
     ],
     "title": "Realistic lighting and shadows"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/README.metadata.json
@@ -27,9 +27,9 @@
         "SceneView"
     ],
     "snippets": [
-        "SceneLayerSelection.qml",
         "SceneLayerSelection.cpp",
-        "SceneLayerSelection.h"
+        "SceneLayerSelection.h",
+        "SceneLayerSelection.qml"
     ],
     "title": "Scene layer selection"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/README.metadata.json
@@ -35,9 +35,9 @@
         "SimpleRenderer::sceneProperties"
     ],
     "snippets": [
-        "ScenePropertiesExpressions.qml",
         "ScenePropertiesExpressions.cpp",
-        "ScenePropertiesExpressions.h"
+        "ScenePropertiesExpressions.h",
+        "ScenePropertiesExpressions.qml"
     ],
     "title": "Scene properties expressions"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/README.metadata.json
@@ -33,9 +33,9 @@
         "Surface"
     ],
     "snippets": [
-        "Surface_Placement.qml",
         "Surface_Placement.cpp",
-        "Surface_Placement.h"
+        "Surface_Placement.h",
+        "Surface_Placement.qml"
     ],
     "title": "Surface placement"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/README.metadata.json
@@ -35,9 +35,9 @@
         "SimpleMarkerSceneSymbol::style"
     ],
     "snippets": [
-        "Symbols.qml",
         "Symbols.cpp",
-        "Symbols.h"
+        "Symbols.h",
+        "Symbols.qml"
     ],
     "title": "Scene symbols"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/README.metadata.json
@@ -37,9 +37,9 @@
         "viewpointChanged"
     ],
     "snippets": [
-        "SyncMapViewSceneView.qml",
         "SyncMapViewSceneView.cpp",
-        "SyncMapViewSceneView.h"
+        "SyncMapViewSceneView.h",
+        "SyncMapViewSceneView.qml"
     ],
     "title": "Sync map and scene views"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/README.metadata.json
@@ -28,9 +28,9 @@
         "Surface::elevationExaggeration"
     ],
     "snippets": [
-        "TerrainExaggeration.qml",
         "TerrainExaggeration.cpp",
-        "TerrainExaggeration.h"
+        "TerrainExaggeration.h",
+        "TerrainExaggeration.qml"
     ],
     "title": "Terrain exaggeration"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/README.metadata.json
@@ -21,9 +21,9 @@
         "Surface"
     ],
     "snippets": [
-        "ViewContentBeneathTerrainSurface.qml",
         "ViewContentBeneathTerrainSurface.cpp",
-        "ViewContentBeneathTerrainSurface.h"
+        "ViewContentBeneathTerrainSurface.h",
+        "ViewContentBeneathTerrainSurface.qml"
     ],
     "title": "View content beneath terrain surface"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/README.metadata.json
@@ -24,9 +24,9 @@
         "PointCloudLayer"
     ],
     "snippets": [
-        "ViewPointCloudDataOffline.qml",
         "ViewPointCloudDataOffline.cpp",
-        "ViewPointCloudDataOffline.h"
+        "ViewPointCloudDataOffline.h",
+        "ViewPointCloudDataOffline.qml"
     ],
     "title": "View point cloud data offline"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/README.metadata.json
@@ -23,9 +23,9 @@
         "LocatorTask"
     ],
     "snippets": [
-        "FindAddress.qml",
         "FindAddress.cpp",
-        "FindAddress.h"
+        "FindAddress.h",
+        "FindAddress.qml"
     ],
     "title": "Find address"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/README.metadata.json
@@ -32,12 +32,12 @@
         "SuggestResult"
     ],
     "snippets": [
-        "FindPlace.qml",
         "FindPlace.cpp",
         "FindPlace.h",
         "SearchBox.qml",
         "SearchButton.qml",
-        "SuggestionView.qml"
+        "SuggestionView.qml",
+        "FindPlace.qml"
     ],
     "title": "Find a place"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/README.metadata.json
@@ -38,9 +38,9 @@
         "ReverseGeocodeParameters"
     ],
     "snippets": [
-        "OfflineGeocode.qml",
         "OfflineGeocode.cpp",
-        "OfflineGeocode.h"
+        "OfflineGeocode.h",
+        "OfflineGeocode.qml"
     ],
     "title": "Offline geocode"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/README.metadata.json
@@ -24,9 +24,9 @@
         "ReverseGeocodeParameters"
     ],
     "snippets": [
-        "ReverseGeocodeOnline.qml",
         "ReverseGeocodeOnline.cpp",
-        "ReverseGeocodeOnline.h"
+        "ReverseGeocodeOnline.h",
+        "ReverseGeocodeOnline.qml"
     ],
     "title": "Reverse geocode"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/README.metadata.json
@@ -40,9 +40,9 @@
         "SymbolStyleSearchResultListModel"
     ],
     "snippets": [
-        "SearchDictionarySymbolStyle.qml",
         "SearchDictionarySymbolStyle.cpp",
-        "SearchDictionarySymbolStyle.h"
+        "SearchDictionarySymbolStyle.h",
+        "SearchDictionarySymbolStyle.qml"
     ],
     "title": "Search dictionary symbol style"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.metadata.json
@@ -66,9 +66,9 @@
         "UtilityTraversability"
     ],
     "snippets": [
-        "ConfigureSubnetworkTrace.qml",
         "ConfigureSubnetworkTrace.cpp",
-        "ConfigureSubnetworkTrace.h"
+        "ConfigureSubnetworkTrace.h",
+        "ConfigureSubnetworkTrace.qml"
     ],
     "title": "Configure subnetwork trace"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.metadata.json
@@ -58,9 +58,9 @@
         "UtilityTraversability"
     ],
     "snippets": [
-        "CreateLoadReport.qml",
         "CreateLoadReport.cpp",
-        "CreateLoadReport.h"
+        "CreateLoadReport.h",
+        "CreateLoadReport.qml"
     ],
     "title": "Create load report"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/README.metadata.json
@@ -28,11 +28,11 @@
         "UtilityNetwork"
     ],
     "snippets": [
-        "DisplayContentOfUtilityNetworkContainer.qml",
         "DisplayContentOfUtilityNetworkContainer.cpp",
         "DisplayContentOfUtilityNetworkContainer.h",
         "SymbolImageProvider.cpp",
-        "SymbolImageProvider.h"
+        "SymbolImageProvider.h",
+        "DisplayContentOfUtilityNetworkContainer.qml"
     ],
     "title": "Display content of utility network container"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/README.metadata.json
@@ -29,11 +29,11 @@
         "UtilityNetwork"
     ],
     "snippets": [
-        "DisplayUtilityAssociations.qml",
         "DisplayUtilityAssociations.cpp",
         "DisplayUtilityAssociations.h",
         "SymbolImageProvider.cpp",
-        "SymbolImageProvider.h"
+        "SymbolImageProvider.h",
+        "DisplayUtilityAssociations.qml"
     ],
     "title": "Display utility associations"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/README.metadata.json
@@ -54,10 +54,10 @@
         "UtilityTraceType"
     ],
     "snippets": [
-        "PerformValveIsolationTrace.qml",
         "PerformValveIsolationTrace.cpp",
         "PerformValveIsolationTrace.h",
-        "TerminalPickerView.qml"
+        "TerminalPickerView.qml",
+        "PerformValveIsolationTrace.qml"
     ],
     "title": "Perform valve isolation trace"
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/README.metadata.json
@@ -54,9 +54,9 @@
         "UtilityTraversability"
     ],
     "snippets": [
-        "TraceUtilityNetwork.qml",
         "TraceUtilityNetwork.cpp",
-        "TraceUtilityNetwork.h"
+        "TraceUtilityNetwork.h",
+        "TraceUtilityNetwork.qml"
     ],
     "title": "Trace utility network"
 }

--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -284,8 +284,12 @@ class MetadataFile:
         if self.sample_type == "ArcGISRuntimeSDKQt_CppSamples":
             expected_snippets += [self.sample_name + ".cpp", self.sample_name + ".h"]
 
-        if not snippets[0] == expected_snippets[0]:
-            errors.append(f"The .qml snippet must be listed first in the list.")
+        if self.sample_type == "ArcGISRuntimeSDKQt_CppSamples":
+            if not snippets[-1] == expected_snippets[0]:
+                errors.append(f"The primary .qml snippet must be listed last in the list for C++ samples.")
+        else:
+            if not snippets[0] == expected_snippets[0]:
+                errors.append(f"The primary .qml snippet must be listed first in the list for QML samples.")
             
         for expected_snippet in expected_snippets:
             if expected_snippet not in snippets:


### PR DESCRIPTION
This PR updates the order of the snippets in C++ metadata files, so that the primary C++ file is first, and the primary QML file is last. This way, the website will display C++ files upon load rather than QML files, for our C++ samples.