### PR TITLE
Fix order of Display Map API

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/README.md
@@ -20,8 +20,8 @@ Run the sample to view the map. Pan and zoom to navigate the map.
 
 ## Relevant API
 
-* Map
 * BasemapStyle
+* Map
 * MapView
 
 ## Tags

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.md
@@ -20,8 +20,8 @@ Run the sample to view the map. Pan and zoom to navigate the map.
 
 ## Relevant API
 
-* Map
 * Enums.BasemapStyle
+* Map
 * MapView
 
 ## Tags


### PR DESCRIPTION
Somehow the API list of the "Display Map" samples is not in alphabetical order. This is a quick PR to fix that.