### PR TITLE
Fix these broken properties.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.cpp
@@ -81,7 +81,7 @@ void DisplayDimensions::addMapToMapView(const Error& error)
   if (error.isEmpty() && m_mmpk->loadStatus() == LoadStatus::Loaded && m_mmpk->maps().count() > 0)
   {
     // Enable the checkboxes.
-    setdimensionsAvailable(true);
+    setDimensionsAvailable(true);
 
     // Assign the map in the mmpk to m_map.
     m_map = m_mmpk->maps().at(0);
@@ -102,7 +102,7 @@ void DisplayDimensions::addMapToMapView(const Error& error)
   else
   {
     // If the map hasn't loaded or an error has occurred, disable the checkboxes in the UI.
-    setdimensionsAvailable(false);
+    setDimensionsAvailable(false);
   }
 }
 
@@ -173,12 +173,22 @@ void DisplayDimensions::setDimensionLayerName(const QString& name)
   emit dimensionLayerNameChanged();
 }
 
-void DisplayDimensions::setDimensionLayerVisibility(const bool visibility)
+bool DisplayDimensions::dimensionLayerVisible() const
 {
-  m_dimensionLayer->setVisible(visibility);
+  return m_dimensionLayer && m_dimensionLayer->isVisible();
 }
 
-void DisplayDimensions::applyDefinitionExpression(const bool applied)
+void DisplayDimensions::setDimensionLayerVisible(bool visible)
+{
+  m_dimensionLayer->setVisible(visible);
+}
+
+bool DisplayDimensions::useDefinitionExpression() const
+{
+  return m_dimensionLayer && !m_dimensionLayer->definitionExpression().isEmpty();
+}
+
+void DisplayDimensions::setUseDefinitionExpression(bool applied)
 {
   if (applied)
     m_dimensionLayer->setDefinitionExpression("DIMLENGTH >= 450");
@@ -191,7 +201,7 @@ bool DisplayDimensions::dimensionsAvailable()
   return m_dimensionsAvailable;
 }
 
-void DisplayDimensions::setdimensionsAvailable(const bool status)
+void DisplayDimensions::setDimensionsAvailable(bool status)
 {
   m_dimensionsAvailable = status;
   emit dimensionsAvailableChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.h
@@ -38,8 +38,8 @@ class DisplayDimensions : public QObject
   Q_PROPERTY(Esri::ArcGISRuntime::MapQuickView* mapView READ mapView WRITE setMapView NOTIFY mapViewChanged)
   Q_PROPERTY(QString errorMessage READ errorMessage WRITE setErrorMessage NOTIFY errorMessageChanged)
   Q_PROPERTY(QString dimensionLayerName READ dimensionLayerName WRITE setDimensionLayerName NOTIFY dimensionLayerNameChanged)
-  Q_PROPERTY(bool dimensionLayerVisibility WRITE setDimensionLayerVisibility)
-  Q_PROPERTY(bool definitionExpressionApplied WRITE applyDefinitionExpression)
+  Q_PROPERTY(bool dimensionLayerVisible READ dimensionLayerVisible WRITE setDimensionLayerVisible)
+  Q_PROPERTY(bool useDefinitionExpression READ useDefinitionExpression WRITE setUseDefinitionExpression)
   Q_PROPERTY(bool dimensionsAvailable READ dimensionsAvailable NOTIFY dimensionsAvailableChanged)
 
 public:
@@ -61,10 +61,12 @@ private:
   void setErrorMessage(const QString& message);
   QString dimensionLayerName() const;
   void setDimensionLayerName(const QString& name);
-  void setDimensionLayerVisibility(const bool visibility);
-  void applyDefinitionExpression(const bool applied);
+  void setDimensionLayerVisible(bool visible);
+  bool dimensionLayerVisible() const;
+  bool useDefinitionExpression() const;
+  void setUseDefinitionExpression(bool applied);
   bool dimensionsAvailable();
-  void setdimensionsAvailable(const bool status);
+  void setDimensionsAvailable(bool status);
 
   void addMapToMapView(const Esri::ArcGISRuntime::Error& error);
   void handleError(const Esri::ArcGISRuntime::Error& error);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.qml
@@ -56,14 +56,14 @@ Item {
                     id: visibilityToggle
                     text: "Dimension Layer visibility"
                     checked: true
-                    onCheckStateChanged: model.dimensionLayerVisibility = visibilityToggle.checkState;
+                    onCheckStateChanged: model.dimensionLayerVisible = visibilityToggle.checkState;
                     enabled: model.dimensionsAvailable;
                 }
                 CheckBox {
                     id: definitionExpressionToggle
                     text: "Definition Expression: \nDimensions >= 450m"
                     checked: false
-                    onCheckStateChanged: model.definitionExpressionApplied = definitionExpressionToggle.checkState;
+                    onCheckStateChanged: model.useDefinitionExpression = definitionExpressionToggle.checkState;
                     enabled: model.dimensionsAvailable && visibilityToggle.checked ? true : false;
                 }
             }


### PR DESCRIPTION
Hi all. I don't know who is around to do reviews at the moment, but we need to fix this sample asap. This is causing problems with the iOS samples build.

You cannot have write-only `Q_PROPERTY`, those are illegal and result in these, which breaks the iOS build
```
Warning: Property declaration dimensionLayerVisibility has no READ accessor function or associated MEMBER variable. The property will be invalid
```

Summary of changes:
 * Added property getters and missing `READ`.
 * Some of the naming is suboptimal, but this is subjective. I changed these property names
   * `dimensionLayerVisibility` to `dimensionLayerVisible`
   * `definitionExpressionApplied`  to `useDefinitionExpression`
 * Change `const bool` args to `bool`
 * Rename `setdimensionsAvailable` to `setDimensionsAvailable`

This fixes the iOS build. I also tested the changes locally and the sample works.