### PR TITLE
FilterByDefinitionExpressionOrDisplayFilter: wait for draw status complete before reporting back the count

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
@@ -33,15 +33,9 @@
 #include "ServiceFeatureTable.h"
 #include "Viewpoint.h"
 
-#include <chrono>
-#include <thread>
-
 #include <QUrl>
 
 using namespace Esri::ArcGISRuntime;
-//using namespace std::this_thread;     // sleep_for, sleep_until
-//using namespace std::chrono_literals; // ns, us, ms, s, h, etc.
-//using std::chrono::system_clock;
 
 FilterByDefinitionExpressionOrDisplayFilter::FilterByDefinitionExpressionOrDisplayFilter(QQuickItem* parent) :
   QQuickItem(parent)
@@ -153,17 +147,15 @@ void FilterByDefinitionExpressionOrDisplayFilter::resetDisplayFilterParams()
 
 void FilterByDefinitionExpressionOrDisplayFilter::resetDefExpressionParams()
 {
-   m_featureLayer->setDefinitionExpression("");
+  m_featureLayer->setDefinitionExpression("");
 
-   connect(m_mapView, &MapQuickView::drawStatusChanged, this, [this](DrawStatus drawStatus)
-   {
-     drawStatus == DrawStatus::InProgress ? m_mapDrawing = true : m_mapDrawing = false;
-     emit mapDrawStatusChanged();
+  connect(m_mapView, &MapQuickView::drawStatusChanged, this, [this](DrawStatus drawStatus)
+  {
+    drawStatus == DrawStatus::InProgress ? m_mapDrawing = true : m_mapDrawing = false;
+    emit mapDrawStatusChanged();
 
-     queryFeatureCountInCurrentExtent();
-   });
-
-
+    queryFeatureCountInCurrentExtent();
+  });
 }
 
 bool FilterByDefinitionExpressionOrDisplayFilter::mapDrawing() const

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
@@ -151,10 +151,17 @@ void FilterByDefinitionExpressionOrDisplayFilter::resetDefExpressionParams()
 
   connect(m_mapView, &MapQuickView::drawStatusChanged, this, [this](DrawStatus drawStatus)
   {
-    drawStatus == DrawStatus::InProgress ? m_mapDrawing = true : m_mapDrawing = false;
+    if (drawStatus == DrawStatus::Completed)
+    {
+      m_mapDrawing = false;
+      queryFeatureCountInCurrentExtent();
+    }
+    else
+    {
+      m_mapDrawing = true;
+    }
+    
     emit mapDrawStatusChanged();
-
-    queryFeatureCountInCurrentExtent();
   });
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.h
@@ -36,6 +36,7 @@ class FilterByDefinitionExpressionOrDisplayFilter : public QQuickItem
 
   Q_PROPERTY(bool layerInitialized READ layerInitialized NOTIFY layerInitializedChanged)
   Q_PROPERTY(int currentFeatureCount READ currentFeatureCount NOTIFY currentFeatureCountChanged)
+  Q_PROPERTY(bool mapDrawing READ mapDrawing NOTIFY mapDrawStatusChanged)
 
 public:
   explicit FilterByDefinitionExpressionOrDisplayFilter(QQuickItem* parent = nullptr);
@@ -45,15 +46,19 @@ public:
   static void init();
   Q_INVOKABLE void setDefExpression(const QString& whereClause);
   Q_INVOKABLE void setDisplayFilter(const QString& whereClause);
+  Q_INVOKABLE void resetDisplayFilterParams();
+  Q_INVOKABLE void resetDefExpressionParams();
 
 signals:
   void layerInitializedChanged();
   void currentFeatureCountChanged();
+  void mapDrawStatusChanged();
 
 private:
   bool layerInitialized() const;
   int currentFeatureCount() const;
   void queryFeatureCountInCurrentExtent();
+  bool mapDrawing() const;
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;
@@ -62,6 +67,7 @@ private:
   bool m_initialized = false;
   Esri::ArcGISRuntime::ServiceFeatureTable* m_featureTable = nullptr;
   int m_currentFeatureCount = 0;
+  bool m_mapDrawing = false;
 };
 
 #endif // FILTER_BY_DEFINITION_EXPRESSION_OR_DISPLAY_FILTER_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -83,7 +83,6 @@ FilterByDefinitionExpressionOrDisplayFilterSample {
             width: 200
             onClicked: {
                 // Call C++ invokable function to reset the definition expression and display filter
-//                definitionExpressionOrDisplayFilterSample.setDefExpression("");
                 definitionExpressionOrDisplayFilterSample.resetDisplayFilterParams();
                 definitionExpressionOrDisplayFilterSample.resetDefExpressionParams();
             }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -83,8 +83,9 @@ FilterByDefinitionExpressionOrDisplayFilterSample {
             width: 200
             onClicked: {
                 // Call C++ invokable function to reset the definition expression and display filter
-                definitionExpressionOrDisplayFilterSample.setDefExpression("");
-                definitionExpressionOrDisplayFilterSample.setDisplayFilter("");
+//                definitionExpressionOrDisplayFilterSample.setDefExpression("");
+                definitionExpressionOrDisplayFilterSample.resetDisplayFilterParams();
+                definitionExpressionOrDisplayFilterSample.resetDefExpressionParams();
             }
         }
     }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/README.md
@@ -14,7 +14,9 @@ In this sample you can filter a dataset of tree quality selecting for only those
 
 ## How to use the sample
 
-Press 'Apply Expression' to limit the features requested from the feature layer to those specified by the SQL query definition expression. Click 'Reset Expression' to remove the definition expression on the feature layer, which returns all the records.
+Press 'Apply Expression' to limit the features requested from the feature layer to those specified by the SQL query definition expression.
+Press 'Apply Filter' to limit the features shown on the feature layer to those specified by the SQL query without modifying the feature table.
+Click 'Reset' to remove the definition expression on the feature layer, which returns all the records.
 
 ## How it works
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -16,7 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 2.2
-import Esri.ArcGISRuntime 100.14
+import Esri.ArcGISRuntime 100.13
 
 //! [Rectangle-mapview-map-viewpoint]
 Rectangle {
@@ -67,6 +67,15 @@ Rectangle {
                 }
             }
             targetScale: 300000
+        }
+
+        onDrawStatusChanged: {
+
+            // Recalculate the feature count in current extent any time the map redraws
+            if (drawStatus === Enums.DrawStatusCompleted)
+            {
+                queryFeatureCountInCurrentExtent();
+            }
         }
     }
     //! [Rectangle-mapview-map-viewpoint]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -16,7 +16,7 @@
 
 import QtQuick 2.6
 import QtQuick.Controls 2.2
-import Esri.ArcGISRuntime 100.13
+import Esri.ArcGISRuntime 100.14
 
 //! [Rectangle-mapview-map-viewpoint]
 Rectangle {


### PR DESCRIPTION
This pull request addresses an issue with this sample where if the user sets a definition expression and then hits reset, it would update the new feature count too quickly before the map has finished drawing, therefore reporting a number that is lower than expected. To address this, we connect a lambda to listen for drawing complete before reporting back anything.