### PR TITLE
Tanneryould/replace deprecated un property

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.cpp
@@ -337,7 +337,7 @@ void ConfigureSubnetworkTrace::onUtilityNetworkLoaded(const Error& e)
   const UtilityTier* utilityTierSource = domainNetwork->tier(m_tierName);
 
   // Set the trace configuration.
-  m_traceConfiguration = utilityTierSource->traceConfiguration();
+  m_traceConfiguration = utilityTierSource->defaultTraceConfiguration();
 
   m_initialExpression = m_traceConfiguration->traversability()->barriers();
 
@@ -348,7 +348,7 @@ void ConfigureSubnetworkTrace::onUtilityNetworkLoaded(const Error& e)
   }
 
   // Set the traversability scope.
-  utilityTierSource->traceConfiguration()->traversability()->setScope(UtilityTraversabilityScope::Junctions);
+  utilityTierSource->defaultTraceConfiguration()->traversability()->setScope(UtilityTraversabilityScope::Junctions);
 }
 
 ConfigureSubnetworkTrace::~ConfigureSubnetworkTrace() = default;

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.cpp
@@ -89,7 +89,7 @@ CreateLoadReport::CreateLoadReport(QObject* parent /* = nullptr */):
       m_traceConfiguration = createDefaultTraceConfiguration();
 
       // Create a base condition to compare against
-      m_baseCondition = dynamic_cast<UtilityTraceConditionalExpression*>(m_utilityTier->traceConfiguration()->traversability()->barriers());
+      m_baseCondition = dynamic_cast<UtilityTraceConditionalExpression*>(m_utilityTier->defaultTraceConfiguration()->traversability()->barriers());
 
       // Create downstream trace parameters with function outputs
       m_traceParameters = new UtilityTraceParameters(UtilityTraceType::Downstream, {m_startingLocation}, this);
@@ -145,7 +145,7 @@ UtilityElement* CreateLoadReport::createStartingLocation()
 
 UtilityTraceConfiguration* CreateLoadReport::createDefaultTraceConfiguration()
 {
-  UtilityTraceConfiguration* traceConfig = m_utilityTier->traceConfiguration();
+  UtilityTraceConfiguration* traceConfig = m_utilityTier->defaultTraceConfiguration();
 
   // Service Category for counting total customers
   UtilityCategory* servicePointCategory = getUtilityCategory(m_serviceCategoryName);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/README.md
@@ -20,7 +20,7 @@ Select phases to be included in the report. Press the "Run Report" button to ini
 4. Create a `UtilityCategoryComparison` where "ServicePoint" category exists.
 5. Reset the `functions` property of the trace configuration with a new `UtilityTraceFunction` adding a "Service Load" network attribute where this category comparison applies. This will limit the function results.
 6. Set `outputCondition` with the category comparison to limit the element results.
-7. Get a base condition from the utility tier's trace configuration.
+7. Get a base condition from the utility tier's default trace configuration.
 8. Create `UtilityTraceParameters` passing in `downstream` utility trace type and the default starting location. Set its `traceConfiguration` property with the trace configuration above.
 9. Populate a list of phases using the network attribute's `codedValues` property.
 10. When the "Run Report" button is tapped, run a trace for every checked `CodedValue` in the phases list. Do this by creating a `UtilityTraceOrCondition` with the base condition and a `UtilityNetworkAttributeComparison` where the "Phases Current" network attribute does not include the coded value.

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -285,7 +285,7 @@ void PerformValveIsolationTrace::connectSignals()
     {
       UtilityTier* tier = domainNetwork->tier(tierName);
       if (tier)
-        m_traceConfiguration = tier->traceConfiguration();
+        m_traceConfiguration = tier->defaultTraceConfiguration();
     }
 
     if (!m_traceConfiguration)

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -248,7 +248,7 @@ void TraceUtilityNetwork::trace(int index)
   }
 
   if (m_mediumVoltageTier)
-    m_traceParams->setTraceConfiguration(m_mediumVoltageTier->traceConfiguration());
+    m_traceParams->setTraceConfiguration(m_mediumVoltageTier->defaultTraceConfiguration());
 
   m_traceParams->setStartingLocations(m_startingLocations);
   m_traceParams->setBarriers(m_barriers);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
@@ -114,7 +114,7 @@ Rectangle {
             const utilityTierSource = domainNetwork.tier(tierName);
 
             // Set the trace configuration.
-            traceConfiguration = utilityTierSource.defaultTraceConfiguration;
+            traceConfiguration = utilityTierSource.defaultTraceConfiguration();
 
             initialExpression = traceConfiguration.traversability.barriers;
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
@@ -114,7 +114,7 @@ Rectangle {
             const utilityTierSource = domainNetwork.tier(tierName);
 
             // Set the trace configuration.
-            traceConfiguration = utilityTierSource.traceConfiguration;
+            traceConfiguration = utilityTierSource.defaultTraceConfiguration;
 
             initialExpression = traceConfiguration.traversability.barriers;
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/README.md
@@ -23,7 +23,7 @@ Example barrier conditions for the default dataset:
 1. Create and load a `UtilityNetwork` with a feature service URL, then get an asset type and a tier by their names.
 2. Populate the choice list for the comparison source with the non-system defined `Definition.networkAttributes`. Populate the choice list for the comparison operator with the enum values from `UtilityAttributeComparisonOperator`.
 3. Create a `UtilityElement` from this asset type to use as the starting location for the trace.
-4. Update the selected barrier expression and the checked options in the UI using this tier's `TraceConfiguration`.
+4. Update the selected barrier expression and the checked options in the UI using this tier's `TraceConfiguration` returned from `defaultTraceConfiguration()`.
 5. When 'Network Attribute' is selected, if its `Domain` is a `CodedValueDomain`, populate the choice list for the comparison value with its `CodedValues`. Otherwise, display a free-form textbox for entering an attribute value.
 6. When 'Add' is clicked, create a new `UtilityNetworkAttributeComparison` using the selected comparison source, operator, and selected or typed value. Use the selected source's `NetworkAttribute.dataType` to convert the comparison value to the correct data type.
 7. If the Traversability's list of `Barriers` is not empty, create a `UtilityTraceOrCondition` with the existing `Barriers` and the new comparison from Step 6.

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -193,7 +193,7 @@ Rectangle {
     }
 
     function createTraceConfiguration() {
-        const traceConfig = utilityTier.traceConfiguration;
+        const traceConfig = utilityTier.defaultTraceConfiguration;
         traceConfig.domainNetwork = utilityNetwork.definition.domainNetwork(domainNetworkName);
 
         serviceCategoryComparison.setServiceCategoryComparison();

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -193,7 +193,7 @@ Rectangle {
     }
 
     function createTraceConfiguration() {
-        const traceConfig = utilityTier.defaultTraceConfiguration;
+        const traceConfig = utilityTier.defaultTraceConfiguration();
         traceConfig.domainNetwork = utilityNetwork.definition.domainNetwork(domainNetworkName);
 
         serviceCategoryComparison.setServiceCategoryComparison();

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -267,7 +267,7 @@ Rectangle {
                         let domainNetwork = definition.domainNetwork(domainNetworkName);
                         if (domainNetwork.tier(tierName) !== null) {
                             let tier = domainNetwork.tier(tierName);
-                            traceConfiguration = tier.defaultTraceConfiguration;
+                            traceConfiguration = tier.defaultTraceConfiguration();
                         }
                     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -267,7 +267,7 @@ Rectangle {
                         let domainNetwork = definition.domainNetwork(domainNetworkName);
                         if (domainNetwork.tier(tierName) !== null) {
                             let tier = domainNetwork.tier(tierName);
-                            traceConfiguration = tier.traceConfiguration;
+                            traceConfiguration = tier.defaultTraceConfiguration;
                         }
                     }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.md
@@ -26,7 +26,7 @@ Tap on one or more features while 'Add starting locations' or 'Add barriers' is 
 10.  If an edge, set its `fractionAlongEdge` property using `GeometryEngine.fractionAlong`.
 11. Add this `UtilityElement` to a collection of starting locations or barriers.
 12. Create `UtilityTraceParameters` with the selected trace type along with the collected starting locations and barriers (if applicable).
-13. Set the `UtilityTraceParameters.traceConfiguration` with the utility tier's `defaultTraceConfiguration` property.
+13. Set the `UtilityTraceParameters.traceConfiguration` with the utility tier's `defaultTraceConfiguration()` function.
 14. Run a `UtilityNetwork.trace` with the specified parameters.
 15. For every `FeatureLayer` in the map, select the features using the `UtilityElement.objectId` from the filtered list of `UtilityElementTraceResult.elements`.
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/README.md
@@ -26,7 +26,7 @@ Tap on one or more features while 'Add starting locations' or 'Add barriers' is 
 10.  If an edge, set its `fractionAlongEdge` property using `GeometryEngine.fractionAlong`.
 11. Add this `UtilityElement` to a collection of starting locations or barriers.
 12. Create `UtilityTraceParameters` with the selected trace type along with the collected starting locations and barriers (if applicable).
-13. Set the `UtilityTraceParameters.traceConfiguration` with the utility tier's `traceConfiguration` property.
+13. Set the `UtilityTraceParameters.traceConfiguration` with the utility tier's `defaultTraceConfiguration` property.
 14. Run a `UtilityNetwork.trace` with the specified parameters.
 15. For every `FeatureLayer` in the map, select the features using the `UtilityElement.objectId` from the filtered list of `UtilityElementTraceResult.elements`.
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -419,7 +419,7 @@ Rectangle {
 
                         // check to see if it exists before assigning it to the parameters.
                         if (mediumVoltageTier)
-                            params.traceConfiguration = mediumVoltageTier.defaultTraceConfiguration;
+                            params.traceConfiguration = mediumVoltageTier.defaultTraceConfiguration();
 
                         // Perform a connected trace on the utility network
                         utilityNetwork.trace(params);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -419,7 +419,7 @@ Rectangle {
 
                         // check to see if it exists before assigning it to the parameters.
                         if (mediumVoltageTier)
-                            params.traceConfiguration = mediumVoltageTier.traceConfiguration;
+                            params.traceConfiguration = mediumVoltageTier.defaultTraceConfiguration;
 
                         // Perform a connected trace on the utility network
                         utilityNetwork.trace(params);


### PR DESCRIPTION
This PR replaces the deprecated `TraceConfiguration` property with a `DefaultTraceConfiguration` function for C++ and QML Utility Network samples.