### PR TITLE
Tanneryould/ordered anchor points

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp
@@ -97,7 +97,7 @@ void GODictionaryRenderer::componentComplete()
   {
     if (dictionarySymbolStyle->loadStatus() == LoadStatus::Loaded)
     {
-      const auto dictionarySymbolStyleConfigurations = dictionarySymbolStyle->configurations();
+      const QList<DictionarySymbolStyleConfiguration*> dictionarySymbolStyleConfigurations = dictionarySymbolStyle->configurations();
       for (DictionarySymbolStyleConfiguration* dictionarySymbolStyleConfiguration : dictionarySymbolStyleConfigurations)
       {
         if (dictionarySymbolStyleConfiguration->name() == "model")
@@ -138,6 +138,7 @@ void GODictionaryRenderer::parseXmlFile()
   QString currentElementName;
 
   QFile xmlFile(m_dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
+
   // Open the file for reading
   if (xmlFile.isOpen())
   {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.md
@@ -38,7 +38,7 @@ To set up the sample's offline data, see the [Use offline data in the samples](h
 Link | Local Location
 ---------|-------|
 |[Mil2525d Stylx File](https://www.arcgis.com/home/item.html?id=44b781991d194dd8bc423e642c1932c5)| `<userhome>`/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx |
-|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=623382e0113d40698538f249e3bcb1c0)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
+|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=8776cfc26eed4485a03de6316826384c)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.md
@@ -18,11 +18,11 @@ Pan and zoom to explore military symbols on the map.
 2. Create a new `DictionaryRenderer(symbolDictionary)`.
 3. Create a new `GraphicsOverlay`
 4. Set the  dictionary renderer to the graphics overlay.
-5. Parse through the XML and create a graphic for each element.
+5. Parse through the XML and create a map of key/value pairs for each block of attributes.
 6. Use the `_wkid` key to get the geometry's spatial reference.
 7. Use the `_control_points` key to get the geometry's shape.
-8. Create a geometry using the shape and spatial reference from above.
-9. Create a `Graphic` for each attribute, utilizing it's defined geometry.
+8. Create a geometry using the spatial reference and shape from above.
+9. Create a `Graphic` for each attribute, utilizing its defined geometry.
 10. Add the graphic to the graphics overlay.
 
 ## Relevant API
@@ -37,8 +37,8 @@ To set up the sample's offline data, see the [Use offline data in the samples](h
 
 Link | Local Location
 ---------|-------|
-|[Mil2525d Stylx File](https://www.arcgis.com/home/item.html?id=c78b149a1d52414682c86a5feeb13d30)| `<userhome>`/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx |
-|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=1e4ea99af4b440c092e7959cf3957bfa)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
+|[Mil2525d Stylx File](https://www.arcgis.com/home/item.html?id=44b781991d194dd8bc423e642c1932c5)| `<userhome>`/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx |
+|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=623382e0113d40698538f249e3bcb1c0)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.md
@@ -18,12 +18,12 @@ Pan and zoom to explore military symbols on the map.
 2. Create a new `DictionaryRenderer(symbolDictionary)`.
 3. Create a new `GraphicsOverlay`
 4. Set the  dictionary renderer to the graphics overlay.
-5. Parse through the XML and create a map of key/value pairs for each block of attributes.
-6. Use the `_wkid` key to get the geometry's spatial reference.
-7. Use the `_control_points` key to get the geometry's shape.
-8. Create a geometry using the spatial reference and shape from above.
-9. Create a `Graphic` for each attribute, utilizing its defined geometry.
-10. Add the graphic to the graphics overlay.
+5. Parse through the XML and create a `Graphic` for each element:
+  i. Use the `_wkid` key to get the geometry's spatial reference.
+  ii. Use the `_control_points` key to get the geometry's shape.
+  iii. Create a geometry using the spatial reference and shape from above.
+  iv. Create a `Graphic` for each attribute, utilizing its defined geometry.
+  v. Add the graphic to the graphics overlay.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -6,7 +6,7 @@
             "path": "~/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx"
         },
         {
-            "itemId": "623382e0113d40698538f249e3bcb1c0",
+            "itemId": "8776cfc26eed4485a03de6316826384c",
             "path": "~/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml"
         }
     ],

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -2,11 +2,11 @@
     "category": "Display information",
     "dataItems": [
         {
-            "itemId": "c78b149a1d52414682c86a5feeb13d30",
+            "itemId": "44b781991d194dd8bc423e642c1932c5",
             "path": "~/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx"
         },
         {
-            "itemId": "1e4ea99af4b440c092e7959cf3957bfa",
+            "itemId": "623382e0113d40698538f249e3bcb1c0",
             "path": "~/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml"
         }
     ],

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -58,6 +58,21 @@ Rectangle {
             DictionaryRenderer {
                 id: dictionaryRenderer
                 dictionarySymbolStyle: Factory.DictionarySymbolStyle.createFromFile(dataPath + "/styles/arcade_style/mil2525d.stylx")
+
+                Component.onCompleted: {
+                    console.log("load status is", dictionarySymbolStyle.loadStatus);
+                    dictionarySymbolStyle.loadStatusChanged.connect(() => {
+                                                                        console.log("load status is", dictionarySymbolStyle.loadStatus);
+                                                                        if (dictionarySymbolStyle.loadStatus === Enums.LoadStatusLoaded) {
+                                                                            const dictionarySymbolStyleConfigurations = dictionarySymbolStyle.configurations;
+                                                                            for (let i = 0; i < dictionarySymbolStyleConfigurations.length; i++) {
+                                                                                if (dictionarySymbolStyleConfigurations[i].name === "model") {
+                                                                                    dictionarySymbolStyleConfigurations[i].value = "ORDERED ANCHOR POINTS";
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    });
+                }
             }
         }
         //! [Apply Dictionary Renderer Graphics Overlay QML]

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -60,9 +60,7 @@ Rectangle {
                 dictionarySymbolStyle: Factory.DictionarySymbolStyle.createFromFile(dataPath + "/styles/arcade_style/mil2525d.stylx")
 
                 Component.onCompleted: {
-                    console.log("load status is", dictionarySymbolStyle.loadStatus);
                     dictionarySymbolStyle.loadStatusChanged.connect(() => {
-                                                                        console.log("load status is", dictionarySymbolStyle.loadStatus);
                                                                         if (dictionarySymbolStyle.loadStatus === Enums.LoadStatusLoaded) {
                                                                             const dictionarySymbolStyleConfigurations = dictionarySymbolStyle.configurations;
                                                                             for (let i = 0; i < dictionarySymbolStyleConfigurations.length; i++) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.md
@@ -37,7 +37,7 @@ To set up the sample's offline data, see the [Use offline data in the samples](h
 Link | Local Location
 ---------|-------|
 |[Mil2525d Stylx File](https://www.arcgis.com/home/item.html?id=44b781991d194dd8bc423e642c1932c5)| `<userhome>`/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx |
-|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=623382e0113d40698538f249e3bcb1c0)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
+|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=8776cfc26eed4485a03de6316826384c)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.md
@@ -1,6 +1,6 @@
 # Graphics overlay (dictionary renderer)
 
-Create graphics using a local mil2525d style file and an XML file with key/value pairs for each graphic.
+This sample demonstrates applying a dictionary renderer to graphics, in order to display military symbology without the need for a feature table.
 
 ![](screenshot.png)
 
@@ -17,11 +17,12 @@ Run the sample and view the military symbols on the map.
 1. Create a new `GraphicsOverlay`.
 2. Create a new `DictionaryRenderer` and set it to the graphics overlay.
 3. Create a new `DictionarySymbolStyle`.
-4. Parse through the XML and create a `Graphic` for each element.
-5. Use the `_wkid` key to get the geometry's spatial reference.
-6. Use the `_control_points` key to get the geometry's shape.
-7. Create a geometry using the shape and spatial reference from above.
-8. Create a `Graphic` for each attribute, utilizing its defined geometry.
+4. Parse through the XML and create a `Graphic` for each element:
+  i. Use the `_wkid` key to get the geometry's spatial reference.
+  ii. Use the `_control_points` key to get the geometry's shape.
+  iii. Create a geometry using the shape and spatial reference from above.
+  iv. Create a `Graphic` for each attribute, utilizing its defined geometry.
+  v. Add the graphic to the graphics overlay.
 
 ## Relevant API
 
@@ -35,8 +36,8 @@ To set up the sample's offline data, see the [Use offline data in the samples](h
 
 Link | Local Location
 ---------|-------|
-|[Mil2525d Stylx File](https://www.arcgis.com/home/item.html?id=c78b149a1d52414682c86a5feeb13d30)| `<userhome>`/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx |
-|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=1e4ea99af4b440c092e7959cf3957bfa)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
+|[Mil2525d Stylx File](https://www.arcgis.com/home/item.html?id=44b781991d194dd8bc423e642c1932c5)| `<userhome>`/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx |
+|[MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=623382e0113d40698538f249e3bcb1c0)| `<userhome>`/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -6,7 +6,7 @@
             "path": "~/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx"
         },
         {
-            "itemId": "623382e0113d40698538f249e3bcb1c0",
+            "itemId": "8776cfc26eed4485a03de6316826384c",
             "path": "~/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml"
         }
     ],

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -2,15 +2,15 @@
     "category": "Display information",
     "dataItems": [
         {
-            "itemId": "c78b149a1d52414682c86a5feeb13d30",
+            "itemId": "44b781991d194dd8bc423e642c1932c5",
             "path": "~/ArcGIS/Runtime/Data/styles/arcade_style/mil2525d.stylx"
         },
         {
-            "itemId": "1e4ea99af4b440c092e7959cf3957bfa",
+            "itemId": "623382e0113d40698538f249e3bcb1c0",
             "path": "~/ArcGIS/Runtime/Data/xml/arcade_style/Mil2525DMessages.xml"
         }
     ],
-    "description": "Create graphics using a local mil2525d style file and an XML file with key/value pairs for each graphic.",
+    "description": "This sample demonstrates applying a dictionary renderer to graphics, in order to display military symbology without the need for a feature table.",
     "ignore": false,
     "images": [
         "screenshot.png"


### PR DESCRIPTION
A few years ago we updated the XML data used with the Dictionary Renderer samples because the military dictionary styles no longer supported control points. Ordered Anchor Points are now supported with dictionary styles and the samples have been updated to show this.

Blocked until the portal items referenced are fully updated and this can be tested