### PR TITLE
Remove codeblock

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml_cpp.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/arcgisruntime.pri
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/arcgisruntime.pri
@@ -25,8 +25,3 @@ priLocation = $$replace(cleanDirPath, '"', "")
 !include($$priLocation/sdk/ideintegration/arcgis_runtime_qml.pri) {
   message("Error. Cannot locate ArcGIS Runtime PRI file")
 }
-ios {
-  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
-    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
-  }
-}


### PR DESCRIPTION
All samples contain an `arcgisruntime.pri` file to help find all the required pri files on disk. For the samples that require toolkit, such as Portal User Info, they contain the below line, which is now invalid. This was needed with the "old" toolkit, but since it was refactored a few releases back, it is no longer valid.

```js
ios {
  !include($$priLocation/sdk/toolkit/Plugin/ArcGISRuntimeToolkitPlugin.pri) {
    message("Error. Cannot locate ArcGIS Runtime Toolkit PRI file")
  }
}
```