### PR TITLE
Change BasemapType to BasemapStyle

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.cpp
@@ -63,8 +63,9 @@ void GOSymbols::componentComplete()
   // Create a map using the oceans basemap
   constexpr double lat = 56.075844;
   constexpr double lon = -2.681572;
-  constexpr int levelOfDetail = 11;
-  m_map = new Map(BasemapType::Oceans, lat, lon, levelOfDetail, this);
+  constexpr double scale = 288895.277144;
+  m_map = new Map(BasemapStyle::ArcGISOceans, this);
+  m_map->setInitialViewpoint(Viewpoint(lat, lon, scale));
   // set map on the map view
   m_mapView->setMap(m_map);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
@@ -79,10 +79,15 @@ namespace
 
 EditFeaturesWithFeatureLinkedAnnotation::EditFeaturesWithFeatureLinkedAnnotation(QObject* parent /* = nullptr */):
   QObject(parent),
-  m_map(new Map(BasemapType::LightGrayCanvasVector, 39.0204, -77.4159, 18, this)),
   s_ad_address(QStringLiteral("AD_ADDRESS")),
   s_st_str_nam(QStringLiteral("ST_STR_NAM"))
 {
+  constexpr double lat = 39.0204;
+  constexpr double lon = -77.4159;
+  constexpr double scale = 2256.994353;
+  m_map = new Map(BasemapStyle::ArcGISLightGray, this);
+  m_map->setInitialViewpoint(Viewpoint(lat, lon, scale));
+
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/geodatabase/loudoun_anno.geodatabase";
 
   m_geodatabase = new Geodatabase(dataPath, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.md
@@ -21,7 +21,6 @@ When the sample opens, it will automatically display the map with the OpenStreet
 ## Relevant API
 
 * Basemap
-* Basemap::openStreetMap
 * Map
 * MapView
 * OpenStreetMapLayer

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/README.metadata.json
@@ -14,7 +14,6 @@
         "open",
         "street",
         "Basemap",
-        "Basemap::openStreetMap",
         "Map",
         "MapView",
         "OpenStreetMapLayer"
@@ -24,7 +23,6 @@
     ],
     "relevant_apis": [
         "Basemap",
-        "Basemap::openStreetMap",
         "Map",
         "MapView",
         "OpenStreetMapLayer"

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.md
@@ -14,12 +14,12 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## How it works
 
-1. Create a `Map`, specifying a basemap type, latitude and longitude in WGS84, and target scale.
+1. Create a `Map`, specifying a basemap style, latitude and longitude in WGS84, and target scale.
 2. Display the map in a map view.
 
 ## Relevant API
 
-* BasemapType
+* Basemap
 * Map
 * MapView
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/README.metadata.json
@@ -20,7 +20,7 @@
         "longitude",
         "scale",
         "zoom level",
-        "BasemapType",
+        "Basemap",
         "Map",
         "MapView"
     ],
@@ -28,7 +28,7 @@
         "/qt/latest/cpp/sample-code/sample-qt-setinitialmaplocation.htm"
     ],
     "relevant_apis": [
-        "BasemapType",
+        "Basemap",
         "Map",
         "MapView"
     ],

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp
@@ -45,8 +45,13 @@ void SetInitialMapLocation::componentComplete()
   // find QML MapView component
   m_mapView = findChild<MapQuickView*>("mapView");
 
-  // Create a new map with the basemap type enum and pass in initial lat, lon, and scale
-  m_map = new Map(BasemapType::ImageryWithLabels, -33.867886, -63.985, 16, this);
+  // Create a new map with the imagery basemap style enum and set its initial lat, long, and scale
+  constexpr double lat = -33.867886;
+  constexpr double lon = -63.985;
+  constexpr double scale = 9027.977411;
+
+  m_map = new Map(BasemapStyle::ArcGISImagery, this);
+  m_map->setInitialViewpoint(Viewpoint(lat, lon, scale));
   // set map on the map view
   m_mapView->setMap(m_map);
 }

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/GOSymbols.cpp
@@ -40,7 +40,11 @@ GOSymbols::GOSymbols(QWidget* parent) :
   QWidget(parent)
 {
   // Create a map using the imagery with labels basemap
-  m_map = new Map(BasemapType::Oceans, 56.075844, -2.681572, 11, this);
+  constexpr double lat = 56.075844;
+  constexpr double lon = -2.681572;
+  constexpr double scale = 288895.277144;
+  m_map = new Map(BasemapStyle::ArcGISOceans, this);
+  m_map->setInitialViewpoint(Viewpoint(lat, lon, scale));
 
   // Create a map view, and pass in the map
   m_mapView = new MapGraphicsView(m_map, this);
@@ -82,10 +86,10 @@ void GOSymbols::createUi()
 void GOSymbols::addBuoyPoints(GraphicsOverlay* graphicsOverlay)
 {
   // create a list of points
-  const QList<Point> pointsList { Point(-2.712642647560347, 56.062812566811544, SpatialReference::wgs84())
-                                , Point(-2.6908416959572303, 56.06444173689877, SpatialReference::wgs84())
-                                , Point(-2.6697273884990937, 56.064250073402874, SpatialReference::wgs84())
-                                , Point(-2.6395150461199726, 56.06127916736989, SpatialReference::wgs84())
+  const QList<Point> pointsList { Point(-2.712642647560347, 56.062812566811544, SpatialReference::wgs84()),
+        Point(-2.6908416959572303, 56.06444173689877, SpatialReference::wgs84()),
+        Point(-2.6697273884990937, 56.064250073402874, SpatialReference::wgs84()),
+        Point(-2.6395150461199726, 56.06127916736989, SpatialReference::wgs84())
                                 };
 
   // create the symbology for the points

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/ChangeBasemap.cpp
@@ -32,7 +32,7 @@ ChangeBasemap::ChangeBasemap(QWidget* parent) :
     // Create a map view, and pass in the map
     m_mapView = new MapGraphicsView(m_map, this);
 
-    // Create and populate a combo box with several basemap types
+    // Create and populate a combo box with several basemap styles
     m_basemapCombo = new QComboBox(this);
     m_basemapCombo->adjustSize();
     m_basemapCombo->setStyleSheet("QComboBox#combo {color: black; background-color:#000000;}");

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp
@@ -22,18 +22,23 @@
 using namespace Esri::ArcGISRuntime;
 
 SetInitialMapLocation::SetInitialMapLocation(QWidget* parent) :
-    QWidget(parent)
+  QWidget(parent)
 {
-    // Create a new map with the basemap type enum and pass in initial lat, lon, and scale
-    m_map = new Map(BasemapType::ImageryWithLabels, -33.867886, -63.985, 16, this);
+  // Create a new map with the imagery basemap style enum and set its initial lat, long, and scale
+  constexpr double lat = -33.867886;
+  constexpr double lon = -63.985;
+  constexpr double scale = 9027.977411;
 
-    // Create a map view, and pass in the map
-    m_mapView = new MapGraphicsView(m_map, this);
+  m_map = new Map(BasemapStyle::ArcGISImagery, this);
+  m_map->setInitialViewpoint(Viewpoint(lat, lon, scale));
 
-    // Set up the UI
-    QVBoxLayout *vBoxLayout = new QVBoxLayout();
-    vBoxLayout->addWidget(m_mapView);
-    setLayout(vBoxLayout);
+  // Create a map view, and pass in the map
+  m_mapView = new MapGraphicsView(m_map, this);
+
+  // Set up the UI
+  QVBoxLayout *vBoxLayout = new QVBoxLayout();
+  vBoxLayout->addWidget(m_mapView);
+  setLayout(vBoxLayout);
 }
 
 SetInitialMapLocation::~SetInitialMapLocation() = default;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/README.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* Basemap
 * Map
 * MapView
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/README.metadata.json
@@ -20,7 +20,7 @@
         "longitude",
         "scale",
         "zoom level",
-        "BasemapType",
+        "Basemap",
         "Map",
         "MapView"
     ],
@@ -28,7 +28,7 @@
         "/qt/latest/qml/sample-code/sample-qt-setinitialmaplocation.htm"
     ],
     "relevant_apis": [
-        "BasemapType",
+        "Basemap",
         "Map",
         "MapView"
     ],


### PR DESCRIPTION
`BasemapType` enum and associated constructor, as well as the factory `Basemap` methods have been deprecated at 100.14.  `BasemapStyles` should be used instead.