### PR TITLE
Removing reference to internal value.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -49,7 +49,7 @@ Item {
 
                 Binding {
                     target: callout
-                    value: contentHeight + callout.calloutFramePadding
+                    value: contentHeight + 15
                     property: "calloutHeight"
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
@@ -48,7 +48,7 @@ Item {
 
                 Binding {
                     target: callout
-                    value: contentHeight + callout.calloutFramePadding
+                    value: contentHeight + 15
                     property: "calloutHeight"
                 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -105,7 +105,7 @@ Rectangle {
                 text: calloutText
                 Binding {
                     target: callout
-                    value: contentHeight + callout.calloutFramePadding
+                    value: contentHeight + 15
                     property: "calloutHeight"
                 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
@@ -57,7 +57,7 @@ Rectangle {
                   text: calloutText
                   Binding {
                       target: callout
-                      value: contentHeight + callout.calloutFramePadding
+                      value: contentHeight + 15
                       property: "calloutHeight"
                   }
 


### PR DESCRIPTION
Identify KML sample reference internal API within Callout which is not publicly exposed. This caused issues with the callout rewrite, and in general is not what we should be demonstrating to users.

AFAIK this value was only there to deal with rounded corner offsets, and is not actually applicable to this use-case. Setting a hard-coded value equivalent to the same value.