### PR TITLE
Fix DisplayFilter QML property

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
@@ -136,7 +136,7 @@ void FilterByDefinitionExpressionOrDisplayFilter::queryFeatureCountInCurrentExte
 
 void FilterByDefinitionExpressionOrDisplayFilter::resetDisplayFilterParams()
 {
-  DisplayFilter* displayFilter = new DisplayFilter("Damaged Trees", "", this);
+  DisplayFilter* displayFilter = new DisplayFilter("No Filter", "1=1", this);
   const QList<DisplayFilter*> available_filters{displayFilter};
 
   ManualDisplayFilterDefinition* display_filter_defintion = new ManualDisplayFilterDefinition(displayFilter, available_filters, this);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -128,7 +128,7 @@ Rectangle {
             onClicked: {
                 featureLayer.definitionExpression = "";
 
-                const displayFilter = ArcGISRuntimeEnvironment.createObject("DisplayFilter", {filterId: "No Filter", whereClause: "1=1"});
+                const displayFilter = ArcGISRuntimeEnvironment.createObject("DisplayFilter", {name: "No Filter", whereClause: "1=1"});
                 const displayFilterDefintionVar = ArcGISRuntimeEnvironment.createObject("ManualDisplayFilterDefinition");
                 displayFilterDefintionVar.availableFilters.append(displayFilter);
                 displayFilterDefintionVar.activeFilter = displayFilter;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -128,7 +128,7 @@ Rectangle {
             onClicked: {
                 featureLayer.definitionExpression = "";
 
-                const displayFilter = ArcGISRuntimeEnvironment.createObject("DisplayFilter", {id: "No Filter", whereClause: "1=1"});
+                const displayFilter = ArcGISRuntimeEnvironment.createObject("DisplayFilter", {filterId: "No Filter", whereClause: "1=1"});
                 const displayFilterDefintionVar = ArcGISRuntimeEnvironment.createObject("ManualDisplayFilterDefinition");
                 displayFilterDefintionVar.availableFilters.append(displayFilter);
                 displayFilterDefintionVar.activeFilter = displayFilter;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -109,7 +109,7 @@ Rectangle {
             width: 200
             enabled: featureTable.loadStatus === Enums.LoadStatusLoaded
             onClicked: {
-                const displayFilter = ArcGISRuntimeEnvironment.createObject("DisplayFilter", {name: "Damaged Trees", filterId: "Damaged Trees", whereClause: "req_Type = \'Tree Maintenance or Damage\'"});
+                const displayFilter = ArcGISRuntimeEnvironment.createObject("DisplayFilter", {name: "Damaged Trees", whereClause: "req_Type = \'Tree Maintenance or Damage\'"});
                 const displayFilterDefintionVar = ArcGISRuntimeEnvironment.createObject("ManualDisplayFilterDefinition");
                 displayFilterDefintionVar.availableFilters.append(displayFilter);
                 displayFilterDefintionVar.activeFilter = displayFilter;


### PR DESCRIPTION
The DisplayFilter object should have a `name` not an `id`. `id` is reserved and `filterId` is read-only.