### PR TITLE
Tanneryould/update generate offline map paths

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -105,7 +105,7 @@ void GenerateOfflineMap::generateMapByExtent(double xCorner1, double yCorner1, d
     if (generateJob)
     {
       // connect to the job's status changed signal
-      connect(generateJob, &GenerateOfflineMapJob::jobStatusChanged, this, [this, generateJob]()
+      connect(generateJob, &GenerateOfflineMapJob::statusChanged, this, [this, generateJob]()
       {
         // connect to the job's status changed signal to know once it is done
         switch (generateJob->jobStatus()) {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -99,7 +99,7 @@ void GenerateOfflineMap::generateMapByExtent(double xCorner1, double yCorner1, d
           this, [this](QUuid, const GenerateOfflineMapParameters& params)
   {
     // Take the map offline once the parameters are generated
-    GenerateOfflineMapJob* generateJob = m_offlineMapTask->generateOfflineMap(params, m_tempPath.path() + "/offlinemap.mmpk");
+    GenerateOfflineMapJob* generateJob = m_offlineMapTask->generateOfflineMap(params, m_tempPath.path() + "/offlinemap");
 
     // check if there is a valid job
     if (generateJob)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -105,10 +105,10 @@ void GenerateOfflineMap::generateMapByExtent(double xCorner1, double yCorner1, d
     if (generateJob)
     {
       // connect to the job's status changed signal
-      connect(generateJob, &GenerateOfflineMapJob::statusChanged, this, [this, generateJob]()
+      connect(generateJob, &GenerateOfflineMapJob::statusChanged, this, [this, generateJob](JobStatus jobStatus)
       {
         // connect to the job's status changed signal to know once it is done
-        switch (generateJob->jobStatus()) {
+        switch (jobStatus) {
         case JobStatus::Failed:
           emit updateStatus("Generate failed");
           emit hideWindow(5000, false);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -18,7 +18,6 @@ import QtQuick 2.6
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.Samples 1.0
-import Esri.ArcGISRuntime.Toolkit 100.14
 
 GenerateOfflineMapSample {
     id: offlineMapSample

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -27,7 +27,7 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property url outputMapPackage: System.temporaryFolder.url + "/OfflineMap_%1.mmpk".arg(new Date().getTime().toString())
+    readonly property url outputMapPackagePath: System.temporaryFolder.url + "/OfflineMap_%1".arg(new Date().getTime().toString())
     readonly property string webMapId: "acc027394bc84c2fb04d1ed317aac674"
 
     MapView {
@@ -110,7 +110,7 @@ Rectangle {
 
         function takeMapOffline(parameters) {
             // create the job
-            generateJob = offlineMapTask.generateOfflineMap(parameters, outputMapPackage);
+            generateJob = offlineMapTask.generateOfflineMap(parameters, outputMapPackagePath);
 
             // check if job is valid
             if (generateJob) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -19,7 +19,6 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import Esri.ArcGISRuntime 100.14
 import Esri.ArcGISExtras 1.1
-import Esri.ArcGISRuntime.Toolkit 100.14
 
 Rectangle {
     id: rootRectangle


### PR DESCRIPTION
The old path is wrong - an .mmpk is a zipped archive exported from pro, whereas the offline map task just writes a new directory. This PR removes that misleading ".mmpk" at the end of the directory path. It also cleans up the code a little by removing the unused toolkits and updating a deprecated property.