### PR TITLE
Move FeatureLayer declaration in Qml DisplayLayerViewDrawState

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
@@ -45,28 +45,28 @@ Rectangle {
             Basemap {
                 initStyle: Enums.BasemapStyleArcGISTopographic
             }
+        }
 
-            FeatureLayer {
-                id: featureLayer
-                serviceLayerIdAsInt: 0
-                minScale: 400000000
-                maxScale: 400000000 / 10
-                visible: loadLayerButton.text === qsTr("Hide Layer") ? true : false
+        FeatureLayer {
+            id: featureLayer
+            serviceLayerIdAsInt: 0
+            minScale: 400000000
+            maxScale: 400000000 / 10
+            visible: loadLayerButton.text === qsTr("Hide Layer") ? true : false
 
-                PortalItem {
-                    id: portalItem
-                    itemId: portalItemId
-                }
+            PortalItem {
+                id: portalItem
+                itemId: portalItemId
+            }
 
-                // once loaded set the viewpoint
-                onLoadStatusChanged: {
-                    if (loadStatus !== Enums.LoadStatusLoaded)
-                        return;
+            // once loaded set the viewpoint
+            onLoadStatusChanged: {
+                if (loadStatus !== Enums.LoadStatusLoaded)
+                    return;
 
-                    mapView.map.operationalLayers.append(featureLayer);
-                    mapView.setViewpointCenter(viewPoint);
-                    mapView.setViewpointScale(40000000.0);
-                }
+                mapView.map.operationalLayers.append(featureLayer);
+                mapView.setViewpointCenter(viewPoint);
+                mapView.setViewpointScale(40000000.0);
             }
         }
 


### PR DESCRIPTION
This PR moves the FeatureLayer declared in the Qml `DisplayLayerViewDrawState` sample out of the scope of the Map declaration.

This change is required following `qt-common` issue [7206](https://devtopia.esri.com/runtime/qt-common/issues/7206) (PR: [2660](https://devtopia.esri.com/runtime/qt/pull/2660)), which has changed the way that nested feature layers are loaded. This resulted in the behaviour of this sample changing, so the FeatureLayer declaration has been moved to ensure the sample runs as expected.