### PR TITLE
Add telemetry

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -33,6 +33,8 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
   message("Building against the dev environment")
   DEFINES += ESRI_BUILD
   DEFINES += SAMPLE_VIEWER_API_KEY=$$(SAMPLEVIEWERAPIKEY_INTERNAL)
+  DEFINES += GANALYTICS_API_KEY=$$(GANALYTICS_API_KEY)
+  DEFINES += GANALYTICS_STREAM_ID=$$(GANALYTICS_STREAM_ID)
 
   # use the Esri dev build script
   include ($$PWD/../../../../DevBuildCpp.pri)
@@ -109,6 +111,7 @@ HEADERS += \
     $$COMMONVIEWER/DataItem.h \
     $$COMMONVIEWER/DataItemListModel.h \
     $$COMMONVIEWER/DownloadSampleManager.h \
+    $$COMMONVIEWER/GAnalytics.h \
     $$COMMONVIEWER/Sample.h \
     $$COMMONVIEWER/SampleCategory.h \
     $$COMMONVIEWER/SampleListModel.h \
@@ -130,6 +133,7 @@ SOURCES += \
     $$COMMONVIEWER/DataItem.cpp \
     $$COMMONVIEWER/DataItemListModel.cpp \
     $$COMMONVIEWER/DownloadSampleManager.cpp \
+    $$COMMONVIEWER/GAnalytics.cpp \
     $$COMMONVIEWER/Sample.cpp \
     $$COMMONVIEWER/SampleCategory.cpp \
     $$COMMONVIEWER/SampleListModel.cpp \

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.rc
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.rc
@@ -1,4 +1,4 @@
-#include "..\..\..\..\buildnum\buildnum.h"
+#include "../../../../buildnum/buildnum.h"
 #include <winver.h>
 
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
@@ -25,6 +25,8 @@ exists($$PWD/../../../../DevBuildQml.pri) {
   message("Building against the dev environment")
   DEFINES += ESRI_BUILD
   DEFINES += SAMPLE_VIEWER_API_KEY=$$(SAMPLEVIEWERAPIKEY_INTERNAL)
+  DEFINES += GANALYTICS_API_KEY=$$(GANALYTICS_API_KEY)
+  DEFINES += GANALYTICS_STREAM_ID=$$(GANALYTICS_STREAM_ID)
 
   # use the Esri dev build script
   include ($$PWD/../../../../DevBuildQml.pri)
@@ -95,6 +97,7 @@ HEADERS += \
     $$COMMONVIEWER/DataItem.h \
     $$COMMONVIEWER/DataItemListModel.h \
     $$COMMONVIEWER/DownloadSampleManager.h \
+    $$COMMONVIEWER/GAnalytics.h \
     $$COMMONVIEWER/Sample.h \
     $$COMMONVIEWER/SampleCategory.h \
     $$COMMONVIEWER/SampleListModel.h \
@@ -116,6 +119,7 @@ SOURCES += \
     $$COMMONVIEWER/DataItem.cpp \
     $$COMMONVIEWER/DataItemListModel.cpp \
     $$COMMONVIEWER/DownloadSampleManager.cpp \
+    $$COMMONVIEWER/GAnalytics.cpp \
     $$COMMONVIEWER/Sample.cpp \
     $$COMMONVIEWER/SampleCategory.cpp \
     $$COMMONVIEWER/SampleListModel.cpp \

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/GAnalytics.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/GAnalytics.cpp
@@ -1,0 +1,177 @@
+#include "GAnalytics.h"
+
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QOperatingSystemVersion>
+#include <QQmlEngine>
+#include <QSettings>
+#include <QUuid>
+
+#ifdef GANALYTICS_API_KEY
+#ifdef GANALYTICS_STREAM_ID
+GAnalytics::GAnalytics(QObject* parent /* = nullptr */):
+  QObject(parent),
+  m_apiSecret(QUOTE(GANALYTICS_API_KEY)),
+  m_measurementId(QUOTE(GANALYTICS_STREAM_ID))
+{
+}
+#endif // GANALYTICS_STREAM_ID
+#endif // GANALYTICS_API_KEY
+
+GAnalytics::GAnalytics(QObject* parent /* = nullptr */):
+  QObject(parent),
+  m_apiSecret(""),
+  m_measurementId("")
+{
+}
+
+GAnalytics::~GAnalytics()
+{
+  endSession();
+}
+
+void GAnalytics::init()
+{
+  if (m_apiSecret == "" || m_measurementId == "")
+  {
+    m_telemetryEnabled = false;
+    setIsVisible(false);
+    return;
+  }
+
+  QSettings settings;
+  generateClientId();
+  if (!settings.contains("GAnalytics-telemetry-enabled"))
+  {
+    m_telemetryEnabled = true;
+    settings.setValue("GAnalytics-telemetry-enabled", m_telemetryEnabled);
+    setIsVisible(true);
+  }
+  else
+  {
+    m_telemetryEnabled = settings.value("GAnalytics-telemetry-enabled").toBool();
+  }
+}
+
+void GAnalytics::postEvent(const QString eventName, QVariantMap parameters)
+{
+  if (!m_telemetryEnabled || m_apiSecret == "" || m_measurementId == "")
+    return;
+
+#ifdef CPP_VIEWER
+  parameters.insert("sample_viewer_type", "Cpp");
+#else // QML_VIEWER
+  parameters.insert("sample_viewer_type", "QML");
+#endif // CPP_VIEWER / QML_VIEWER
+
+  auto os = QOperatingSystemVersion::current();
+
+  parameters.insert("operating_system", os.name() + " " + QString::number(os.majorVersion()) + "." + QString::number(os.minorVersion()));
+
+  int sessionTime = (QDateTime::currentSecsSinceEpoch()-m_startTime)*1000;
+
+  // Google will not accept the POST request if the engagement time is 0 or undefined
+  if (sessionTime <= 0)
+    sessionTime = 1;
+
+  parameters.insert("engagement_time_msec", sessionTime);
+
+  QJsonObject event;
+  event.insert("name", eventName);
+  event.insert("params", QJsonObject::fromVariantMap(parameters));
+
+  QJsonObject body;
+  body.insert("client_id", m_clientId);
+  body.insert("events", event);
+  QNetworkAccessManager* mgr = new QNetworkAccessManager();
+  const QUrl url(QString("https://google-analytics.com/mp/collect?"
+                         "api_secret=" + m_apiSecret +
+                         "&measurement_id=" + m_measurementId));
+
+  QNetworkRequest request(url);
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application, json");
+  QJsonDocument data(body);
+
+  mgr->post(request, data.toJson());
+}
+
+void GAnalytics::startSession()
+{
+  m_startTime = QDateTime::currentSecsSinceEpoch();
+  postEvent("open_sample_viewer", QVariantMap());
+}
+
+void GAnalytics::endSession()
+{
+  QVariantMap params;
+  params.insert("session_duration_sec", QDateTime::currentSecsSinceEpoch() - m_startTime);
+  postEvent("close_sample_viewer", params);
+}
+
+void GAnalytics::generateClientId()
+{
+  QSettings settings;
+  if (!settings.contains("GAnalytics-clientId"))
+  {
+    m_clientId= QUuid::createUuid().toString();
+    settings.setValue("GAnalytics-clientId", m_clientId);
+  }
+  else
+  {
+    m_clientId = settings.value("GAnalytics-clientId").toString();
+  }
+}
+
+QString GAnalytics::apiSecret() const
+{
+  return m_apiSecret;
+}
+
+void GAnalytics::setApiSecret(const QString apiSecret)
+{
+  m_apiSecret = apiSecret;
+}
+
+QString GAnalytics::measurementId() const
+{
+  return m_measurementId;
+}
+
+void GAnalytics::setMeasurementId(const QString measurementId)
+{
+  m_measurementId = measurementId;
+}
+
+bool GAnalytics::telemetryEnabled() const
+{
+  return m_telemetryEnabled;
+}
+
+void GAnalytics::setTelemetryEnabled(const bool telemetryEnabled)
+{
+  m_telemetryEnabled = telemetryEnabled;
+
+  QSettings settings;
+  settings.setValue("GAnalytics-telemetry-enabled", m_telemetryEnabled);
+
+  if (telemetryEnabled)
+    startSession();
+}
+
+bool GAnalytics::isVisible() const
+{
+  return m_isVisible;
+}
+
+void GAnalytics::setIsVisible(bool isVisible)
+{
+  m_isVisible = isVisible;
+}
+
+QString GAnalytics::clientId() const
+{
+  return m_clientId;
+}

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/GAnalytics.h
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/GAnalytics.h
@@ -1,0 +1,53 @@
+#ifndef GANALYTICS_H
+#define GANALYTICS_H
+
+#include <QDateTime>
+#include <QObject>
+#include <QVariantMap>
+
+class GAnalytics : public QObject
+{
+  Q_OBJECT
+
+  Q_PROPERTY(QString clientId READ clientId CONSTANT)
+  Q_PROPERTY(QString apiSecret READ apiSecret WRITE setApiSecret NOTIFY apiSecretChanged)
+  Q_PROPERTY(QString measurementId READ measurementId WRITE setMeasurementId NOTIFY measurementIdChanged)
+  Q_PROPERTY(bool telemetryEnabled READ telemetryEnabled WRITE setTelemetryEnabled NOTIFY telemetryEnabledChanged)
+  Q_PROPERTY(bool isVisible READ isVisible WRITE setIsVisible NOTIFY isVisibleChanged)
+
+public:
+  explicit GAnalytics(QObject* parent = nullptr);
+
+  ~GAnalytics() override;
+
+  Q_INVOKABLE virtual void init();
+  Q_INVOKABLE void postEvent(const QString eventName, QVariantMap parameters);
+
+signals:
+  void apiSecretChanged();
+  void measurementIdChanged();
+  void telemetryEnabledChanged();
+  void isVisibleChanged();
+
+private:
+  void setApiSecret(const QString apiSecret);
+  void setMeasurementId(const QString measurementId);
+  void setTelemetryEnabled(const bool telemetryEnabled);
+  void setIsVisible(const bool isVisible);
+  void startSession();
+  void endSession();
+  void generateClientId();
+  QString apiSecret() const;
+  QString clientId() const;
+  QString measurementId() const;
+  bool telemetryEnabled() const;
+  bool isVisible() const;
+  QString m_apiSecret;
+  QString m_measurementId;
+  QString m_clientId;
+  qint64 m_startTime;
+  bool m_telemetryEnabled;
+  bool m_isVisible;
+};
+
+#endif // GANALYTICS_H

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/Sample.h
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/Sample.h
@@ -38,6 +38,7 @@ public:
   Q_PROPERTY(QVariant description READ description CONSTANT)
   Q_PROPERTY(QVariant thumbnailUrl READ thumbnailUrl CONSTANT)
   Q_PROPERTY(DataItemListModel* dataItems READ dataItems CONSTANT)
+  Q_PROPERTY(QVariant name READ name CONSTANT)
 
   QVariant name() const { return m_name; }
   QVariant path() const { return m_path; }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
@@ -26,6 +26,8 @@
 #include <QQuickWindow>
 #include <QtGlobal>
 
+#include "GAnalytics.h"
+
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
 #  include <QtWebEngine>
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
@@ -56,7 +58,7 @@
 #include "DrawOrderLayerListModel.h"
 
 #ifdef ESRI_BUILD
-#include "../../../../buildnum/buildnum.h"
+#include "../../../../../buildnum/buildnum.h"
 #endif
 
 // All CPP Samples
@@ -293,6 +295,7 @@
 #define QUOTE(x) STRINGIZE(x)
 
 QObject* esriSampleManagerProvider(QQmlEngine* engine, QJSEngine* scriptEngine);
+QObject* gAnalyticsProvider(QQmlEngine* engine, QJSEngine* scriptEngine);
 QObject* syntaxHighlighterProvider(QQmlEngine* engine, QJSEngine* scriptEngine);
 void registerClasses();
 void registerCppSampleClasses();
@@ -595,6 +598,8 @@ void registerClasses()
 
   qmlRegisterSingletonType<DownloadSampleManager>("Esri.ArcGISRuntimeSamples", 1, 0, "SampleManager",
                                                   &esriSampleManagerProvider);
+  // Register the Google Analytics class
+  qmlRegisterSingletonType<GAnalytics>("Telemetry", 0, 1, "GAnalytics", &gAnalyticsProvider);
 
   qmlRegisterSingletonType<SyntaxHighlighter>("Esri.ArcGISRuntimeSamples", 1, 0, "SyntaxHighlighter",
                                               &syntaxHighlighterProvider);
@@ -635,6 +640,12 @@ QObject* esriSampleManagerProvider(QQmlEngine* engine, QJSEngine*)
   static QObject* sampleManager = new QmlSampleManager(engine, engine);
 #endif
   return sampleManager;
+}
+
+QObject* gAnalyticsProvider(QQmlEngine* engine, QJSEngine*)
+{
+  static QObject* gAnalytics = new GAnalytics(engine);
+  return gAnalytics;
 }
 
 QObject* syntaxHighlighterProvider(QQmlEngine* engine, QJSEngine*)

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
@@ -17,6 +17,7 @@ import QtQuick 2.5
 import QtQuick.Controls 2.2
 import QtGraphicalEffects 1.0
 import Esri.ArcGISRuntimeSamples 1.0
+import Telemetry 0.1
 
 Component {
     id: categoryDelegate
@@ -95,6 +96,7 @@ Component {
             sampleListView.currentCategory = displayName;
             SampleManager.currentCategory = SampleManager.categories.get(index);
             stackView.push(sampleListView);
+            GAnalytics.postEvent("category_selected", {"category name": displayName});
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
@@ -17,6 +17,7 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtGraphicalEffects 1.0
 import Esri.ArcGISRuntimeSamples 1.0
+import Telemetry 0.1
 
 Page {
     id: categoryView
@@ -49,6 +50,10 @@ Page {
             font.pixelSize: 14
             placeholderText: qsTr("Find a sample...")
             padding: 10
+
+            onTextChanged: {
+                searchQueryEventTimer.start();
+            }
         }
     }
 
@@ -88,4 +93,15 @@ Page {
     // Ensure virtual keyboard is not persisted after this item has been
     // hidden. This is an issue on iOS and Android devices.
     onVisibleChanged:  searchBar.focus = false;
+
+    Timer {
+        id: searchQueryEventTimer
+        interval: 3000 // milliseconds
+        running: false
+        repeat: false
+        onTriggered: {
+            if (searchBar.text !== "")
+                GAnalytics.postEvent("search_query", {"search text": searchBar.text});
+        }
+    }
 }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -1,0 +1,92 @@
+import QtQuick 2.0
+import Telemetry 0.1
+import QtGraphicalEffects 1.0
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.3
+import QtQuick.Layouts 1.0
+
+Item {
+    id: dialogComponent
+    visible: GAnalytics.isVisible
+
+    RadialGradient {
+        id: overlay
+        anchors.fill: parent
+        opacity: 0.7
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: "lightgrey" }
+            GradientStop { position: 0.7; color: "black" }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                dialogComponent.visible = false
+            }
+        }
+    }
+
+    Page {
+        id: dialogWindow
+        anchors.centerIn: parent
+        width: 275
+        height: 300
+        clip: true
+        background: Rectangle {
+            radius: 3
+        }
+
+        header: ToolBar {
+            height: 42
+
+            Label {
+                id: titleText
+                anchors.centerIn: parent
+                text: qsTr("Telemetry Settings")
+                font {
+                    family: fontFamily
+                    pixelSize: 18
+                }
+                color: "white"
+            }
+        }
+
+        ColumnLayout {
+            id: items
+            anchors {
+                fill: parent
+                margins: 10
+            }
+            spacing: 5
+
+            Text {
+                id: msg
+                Layout.fillWidth: true
+                text: qsTr("This app uses telemetry to determine which samples are being used and what searches are done in app. No location or GPS data is reported using telemetry.")
+                wrapMode: Text.WordWrap
+                font.pixelSize: 12
+            }
+
+            CheckBox {
+                id: analyticsEnabledCheckBox
+                text: "Enable analytics"
+                onCheckedChanged: {
+                    GAnalytics.telemetryEnabled = analyticsEnabledCheckBox.checked;
+                }
+                Component.onCompleted: {
+                    checked = GAnalytics.telemetryEnabled;
+                }
+            }
+
+            Button {
+                id : closeButton
+                Layout.alignment: Qt.AlignCenter
+                text: qsTr("Close")
+                width: 110
+                height: 48
+                onClicked: dialogComponent.visible = false
+            }
+        }
+    }
+}
+

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
@@ -16,6 +16,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.2
 import Esri.ArcGISRuntimeSamples 1.0
+import Telemetry 0.1
 
 Page {
     id: sampleListView
@@ -101,6 +102,7 @@ Page {
                             drawer.close();
                             // launch sample...
                             SampleManager.currentSample = sample;
+                            GAnalytics.postEvent("sample_opened", {"sample name": sample.name, "referrer": "category list"});
                         }
                     }
                 }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchView.qml
@@ -17,6 +17,7 @@ import QtQuick 2.9
 
 import QtQuick.Controls 2.2
 import Esri.ArcGISRuntimeSamples 1.0
+import Telemetry 0.1
 
 ListView {
     spacing: 10
@@ -52,6 +53,7 @@ ListView {
                     drawer.close();
                     // launch sample...
                     SampleManager.currentSample = sample;
+                    GAnalytics.postEvent("sample_opened", {"sample name": sample.name, "referrer": "search"});
                 }
             }
         }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -18,6 +18,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.1
 import Esri.ArcGISRuntimeSamples 1.0
 import Esri.ArcGISExtras 1.1
+import Telemetry 0.1
 
 ApplicationWindow {
     id: window
@@ -88,8 +89,12 @@ ApplicationWindow {
                         text: qsTr("Live Sample")
                         onTriggered: {
                             aboutView.visible = false;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
                             SampleManager.currentMode = SampleManager.LiveSampleView
+                            // postEvent handled in
+                            // - SampleListView.qml for categories
+                            // - SearchView.qml for searches
                         }
                     }
                     MenuItem {
@@ -98,8 +103,10 @@ ApplicationWindow {
                         text: qsTr("Source Code")
                         onTriggered: {
                             aboutView.visible = false;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
                             SampleManager.currentMode = SampleManager.SourceCodeView
+                            GAnalytics.postEvent("samplecode_view", {"sample name": SampleManager.currentSample.name})
                         }
                     }
                     MenuItem {
@@ -108,8 +115,10 @@ ApplicationWindow {
                         text: qsTr("Description")
                         onTriggered: {
                             aboutView.visible = false;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
                             SampleManager.currentMode = SampleManager.DescriptionView
+                            GAnalytics.postEvent("description_view", {"sample name": SampleManager.currentSample.name})
                         }
                     }
                     MenuItem {
@@ -118,6 +127,7 @@ ApplicationWindow {
                         text: qsTr("Manage offline data")
                         onTriggered: {
                             aboutView.visible = false;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
                             if (SampleManager.currentMode != SampleManager.DownloadDataView || !SampleManager.downloadInProgress)
                                 SampleManager.currentMode = SampleManager.ManageOfflineDataView
@@ -129,6 +139,7 @@ ApplicationWindow {
                         text: qsTr("API Reference")
                         onTriggered: {
                             aboutView.visible = false;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
                             Qt.openUrlExternally(SampleManager.apiReferenceUrl)
                         }
@@ -136,9 +147,21 @@ ApplicationWindow {
                     MenuItem {
                         width: parent.width
                         height: 48
-                        text: qsTr("Settings")
+                        text: qsTr("Telemetry Settings")
                         onTriggered: {
                             aboutView.visible = false;
+                            gAnalyticsView.visible = true;
+                            proxySetupView.visible = false;
+                        }
+                    }
+
+                    MenuItem {
+                        width: parent.width
+                        height: 48
+                        text: qsTr("Proxy Settings")
+                        onTriggered: {
+                            aboutView.visible = false;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = true;
                         }
                     }
@@ -149,6 +172,7 @@ ApplicationWindow {
                         text: qsTr("About")
                         onTriggered: {
                             aboutView.visible = true;
+                            gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
                         }
                     }
@@ -190,6 +214,11 @@ ApplicationWindow {
 
     DataDownloadView {
         id: dataDownloadView
+        anchors.fill: parent
+    }
+
+    GAnalyticsView {
+        id: gAnalyticsView
         anchors.fill: parent
     }
 
@@ -356,5 +385,8 @@ ApplicationWindow {
     Component.onCompleted: {
         // initialize the SampleManager singleton
         SampleManager.init();
+
+        // initialize the Google Analytics singleton
+        GAnalytics.init();
     }
 }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/qml.qrc
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/qml.qrc
@@ -19,5 +19,6 @@
         <file>SearchView.qml</file>
         <file>SearchBar.qml</file>
         <file>ManageOfflineDataView.qml</file>
+        <file>GAnalyticsView.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
# Description

Adds Google Analytics telemetry to the sample viewer. Requires coordination with DevOps to implement into deployed Sample Viewer. This is done with a `GAnalytics` singleton that can be invoked from any .qml file that has `import Telemetry 0.1`. The class sends events via HTTP Post to Google Analytics.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case