### PR TITLE
Recognize Arcade as a proper noun

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
@@ -49,7 +49,7 @@ This sample uses the [Crimes in Police Beats Sample](https://www.arcgis.com/home
 
 ## Additional information
 
-Visit [Getting Started](https://developers.arcgis.com/Arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
+Visit [Getting Started](https://developers.arcgis.com/arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
@@ -1,12 +1,12 @@
-# Query features with arcade expression
+# Query features with Arcade expression
 
-Query features on a map using an arcade expression.
+Query features on a map using an Arcade expression.
 
 ![](screenshot.png)
 
 ## Use case
 
-Arcade is a portable, lightweight, and secure expression language used to create custom content in ArcGIS applications. Like other expression languages, it can perform mathematical calculations, manipulate text, and evaluate logical statements. It also supports multi-statement expressions, variables, and flow control statements. What makes Arcade particularly unique when compared to other expression and scripting languages is its inclusion of feature and geometry data types. This sample uses an arcade expression to query the number of crimes in a neighborhood in the last 60 days.
+Arcade is a portable, lightweight, and secure expression language used to create custom content in ArcGIS applications. Like other expression languages, it can perform mathematical calculations, manipulate text, and evaluate logical statements. It also supports multi-statement expressions, variables, and flow control statements. What makes Arcade particularly unique when compared to other expression and scripting languages is its inclusion of feature and geometry data types. This sample uses an Arcade expression to query the number of crimes in a neighborhood in the last 60 days.
 
 ## How to use the sample
 
@@ -24,13 +24,13 @@ Click on any neighborhood to see the number of crimes in the last 60 days in a c
     "var crimes = FeatureSetByName($map, 'Crime in the last 60 days');\n"
     "return Count(Intersects($feature, crimes));"
 
-7. Create an `ArcadeEvaluator` using the arcade expression and `ArcadeProfile.FORM_CALCULATION`.
+7. Create an `ArcadeEvaluator` using the Arcade expression and `ArcadeProfile.FORM_CALCULATION`.
 8. Create a map of profile variables with the following key-value pairs. This will be passed to `ArcadeEvaluator::evaluate()` in the next step.
 
          `{"$feature", identifiedFeature}`
          `{"$map", map}`
 
-9. Call `ArcadeEvaluator::evaluate()` on the arcade evaluator object and pass the profile variables map.
+9. Call `ArcadeEvaluator::evaluate()` on the Arcade evaluator object and pass the profile variables map.
 10. Call `ArcadeEvaluationResult::result()` to get the result from `ArcadeEvaluator::ArcadeEvaluationResult`.
 11. Convert the result to a numerical value (integer) and populate the callout with the crime count.
 
@@ -49,8 +49,8 @@ This sample uses the [Crimes in Police Beats Sample](https://www.arcgis.com/home
 
 ## Additional information
 
-Visit [Getting Started](https://developers.arcgis.com/arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
+Visit [Getting Started](https://developers.arcgis.com/Arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
 
 ## Tags
 
-arcade evaluator, arcade expression, identify layers, portal, portal item, query
+Arcade evaluator, Arcade expression, identify layers, portal, portal item, query

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.metadata.json
@@ -1,13 +1,13 @@
 {
     "category": "Display information",
-    "description": "Query features on a map using an arcade expression.",
+    "description": "Query features on a map using an Arcade expression.",
     "ignore": false,
     "images": [
         "screenshot.png"
     ],
     "keywords": [
-        "arcade evaluator",
-        "arcade expression",
+        "Arcade evaluator",
+        "Arcade expression",
         "identify layers",
         "portal",
         "portal item",

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
@@ -1,12 +1,12 @@
-# Query features with arcade expression
+# Query features with Arcade expression
 
-Query features on a map using an arcade expression.
+Query features on a map using an Arcade expression.
 
 ![](screenshot.png)
 
 ## Use case
 
-Arcade is a portable, lightweight, and secure expression language used to create custom content in ArcGIS applications. Like other expression languages, it can perform mathematical calculations, manipulate text, and evaluate logical statements. It also supports multi-statement expressions, variables, and flow control statements. What makes Arcade particularly unique when compared to other expression and scripting languages is its inclusion of feature and geometry data types. This sample uses an arcade expression to query the number of crimes in a neighborhood in the last 60 days.
+Arcade is a portable, lightweight, and secure expression language used to create custom content in ArcGIS applications. Like other expression languages, it can perform mathematical calculations, manipulate text, and evaluate logical statements. It also supports multi-statement expressions, variables, and flow control statements. What makes Arcade particularly unique when compared to other expression and scripting languages is its inclusion of feature and geometry data types. This sample uses an Arcade expression to query the number of crimes in a neighborhood in the last 60 days.
 
 ## How to use the sample
 
@@ -24,12 +24,12 @@ Click on any neighborhood to see the number of crimes in the last 60 days in a c
     "var crimes = FeatureSetByName($map, 'Crime in the last 60 days');\n"
     "return Count(Intersects($feature, crimes));"
 
-7. Create an `ArcadeEvaluator` using the arcade expression and `Enums.ArcadeProfileFormCalculation`.
+7. Create an `ArcadeEvaluator` using the Arcade expression and `Enums.ArcadeProfileFormCalculation`.
 8. Create a dictionary of profile variables with the following key-value pairs. This will be passed to `ArcadeEvaluator.evaluate()` in the next step.
          `{"$feature", identifiedFeature}`
          `{"$map", map}`
 
-9. Call `ArcadeEvaluator.evaluate()` on the arcade evaluator object and pass the profile variables map.
+9. Call `ArcadeEvaluator.evaluate()` on the Arcade evaluator object and pass the profile variables map.
 10. Call `ArcadeEvaluationResult.result()` to get the result from `ArcadeEvaluator.ArcadeEvaluationResult`.
 
 ## Relevant API
@@ -47,8 +47,8 @@ This sample uses the [Crimes in Police Beats Sample](https://www.arcgis.com/home
 
 ## Additional information
 
-Visit [Getting Started](https://developers.arcgis.com/arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
+Visit [Getting Started](https://developers.arcgis.com/Arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
 
 ## Tags
 
-arcade evaluator, arcade expression, identify layers, portal, portal item, query
+Arcade evaluator, Arcade expression, identify layers, portal, portal item, query

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.md
@@ -47,7 +47,7 @@ This sample uses the [Crimes in Police Beats Sample](https://www.arcgis.com/home
 
 ## Additional information
 
-Visit [Getting Started](https://developers.arcgis.com/Arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
+Visit [Getting Started](https://developers.arcgis.com/arcade/) on the *ArcGIS Developer* website to learn more about Arcade expressions.
 
 ## Tags
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/README.metadata.json
@@ -1,13 +1,13 @@
 {
     "category": "Display information",
-    "description": "Query features on a map using an arcade expression.",
+    "description": "Query features on a map using an Arcade expression.",
     "ignore": false,
     "images": [
         "screenshot.png"
     ],
     "keywords": [
-        "arcade evaluator",
-        "arcade expression",
+        "Arcade evaluator",
+        "Arcade expression",
         "identify layers",
         "portal",
         "portal item",
@@ -31,5 +31,5 @@
     "snippets": [
         "QueryFeaturesWithArcadeExpression.qml"
     ],
-    "title": "Query features with arcade expression"
+    "title": "Query features with Arcade expression"
 }


### PR DESCRIPTION
# Description

This PR accounts for making all references to 'Arcade' capitalized in our sample read me and metadata, since Esri's creation of this expression language as a proper noun. For instance, you can see all written usages of it capitalized here: https://developers.arcgis.com/arcade/

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement