### PR TITLE
Hide accessory button in qml sample

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qml
@@ -83,6 +83,7 @@ Rectangle {
         Callout {
             id: callout
             calloutData: parent.calloutData
+            accessoryButtonHidden: true
             leaderPosition: leaderPositionEnum.Automatic
         }
     }


### PR DESCRIPTION
# Description

This hides the little (i) button in the callout that does not lead to anywhere. This is already hidden in the C++ sample so needs to be marked as hidden in QML as well.

![image](https://user-images.githubusercontent.com/3746552/175082833-82a19452-53d8-4d41-8d22-2ffa4c04e9b1.png)


## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS