### PR TITLE
Tanner/fix sv ips build

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/IndoorsLocationDataSourceCreator.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/IndoorsLocationDataSourceCreator.h
@@ -14,9 +14,6 @@
 #ifndef INDOORSLOCATIONDATASOURCECREATOR_H
 #define INDOORSLOCATIONDATASOURCECREATOR_H
 
-#include <QUuid>
-#include <QObject>
-
 namespace Esri
 {
 namespace ArcGISRuntime
@@ -27,6 +24,9 @@ class IndoorsLocationDataSource;
 class Map;
 }
 }
+
+#include <QObject>
+#include <QUuid>
 
 
 class IndoorsLocationDataSourceCreator : public QObject

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qrc
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qrc
@@ -7,5 +7,7 @@
         <file>main.qml</file>
         <file>screenshot.png</file>
         <file>README.md</file>
+        <file>IndoorsLocationDataSourceCreator.cpp</file>
+        <file>IndoorsLocationDataSourceCreator.h</file>
     </qresource>
 </RCC>

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/samples.pri
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/samples.pri
@@ -381,6 +381,7 @@ HEADERS += \
     "$$SAMPLEPATHCPP/Maps/SetInitialMapLocation/SetInitialMapLocation.h" \
     "$$SAMPLEPATHCPP/Maps/SetMapSpatialReference/SetMapSpatialReference.h" \
     "$$SAMPLEPATHCPP/Maps/SetMaxExtent/SetMaxExtent.h" \
+    "$$SAMPLEPATHCPP/Maps/ShowDeviceLocationUsingIndoorPositioning/IndoorsLocationDataSourceCreator.h" \
     "$$SAMPLEPATHCPP/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.h" \
     "$$SAMPLEPATHCPP/Maps/ShowLocationHistory/ShowLocationHistory.h" \
     "$$SAMPLEPATHCPP/Maps/ShowMagnifier/ShowMagnifier.h" \
@@ -591,6 +592,7 @@ SOURCES += \
     "$$SAMPLEPATHCPP/Maps/SetInitialMapLocation/SetInitialMapLocation.cpp" \
     "$$SAMPLEPATHCPP/Maps/SetMapSpatialReference/SetMapSpatialReference.cpp" \
     "$$SAMPLEPATHCPP/Maps/SetMaxExtent/SetMaxExtent.cpp" \
+    "$$SAMPLEPATHCPP/Maps/ShowDeviceLocationUsingIndoorPositioning/IndoorsLocationDataSourceCreator.cpp" \
     "$$SAMPLEPATHCPP/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp" \
     "$$SAMPLEPATHCPP/Maps/ShowLocationHistory/ShowLocationHistory.cpp" \
     "$$SAMPLEPATHCPP/Maps/ShowMagnifier/ShowMagnifier.cpp" \


### PR DESCRIPTION
# Description

Registers the `IndoorsLocationDataSourceCreator` class in the C++ sample viewer to fix compiler error

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

- [x] macOS
