### PR TITLE
Revert redirect_from link in metadata

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/README.metadata.json
@@ -23,7 +23,7 @@
         "GeodatabaseSyncTask"
     ],
     "redirect_from": [
-        "/qt/latest/cpp/sample-code/sample-qt-generategeodatabasereplicafromfeatureservice.htm"
+        "/qt/latest/cpp/sample-code/sample-qt-generategeodatabase.htm"
     ],
     "relevant_apis": [
         "GenerateGeodatabaseJob",

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/README.metadata.json
@@ -23,7 +23,7 @@
         "GeodatabaseSyncTask"
     ],
     "redirect_from": [
-        "/qt/latest/qml/sample-code/sample-qt-generategeodatabasereplicafromfeatureservice.htm"
+        "/qt/latest/qml/sample-code/sample-qt-generategeodatabase.htm"
     ],
     "relevant_apis": [
         "GenerateGeodatabaseJob",


### PR DESCRIPTION
# Description

Revert this change back to the original sample name so the hyperlinks stay active after renaming the sample.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)