### PR TITLE
Tanner/qml ips bluetooth plist fix

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
@@ -146,9 +146,9 @@ Rectangle {
         // Update information text box and floor view if necessary
         mapView.locationDisplay.locationChanged.connect(() => {
             if (mapView.locationDisplay.location !== undefined) {
-                initializingText.visible = true;
-            } else {
                 initializingText.visible = false;
+            } else {
+                initializingText.visible = true;
             }
 
             if (mapView.locationDisplay.location.additionalSourceProperties.floor !== undefined) {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/iOS/Info.plist
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/iOS/Info.plist
@@ -78,6 +78,8 @@
     <string></string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string></string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Bluetooth access is required for Indoor Positioning</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/iOS/Info.plist
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/iOS/Info.plist
@@ -78,6 +78,8 @@
     <string></string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string></string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Bluetooth access is required for Indoor Positioning</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
# Description

Fixes a bug where the iOS and Android IPS samples wouldn't open in the Sample Viewer because there were no bluetooth permissions in the Info.plist files. (Also fixes a small UI logic bug in QML).

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)