### PR TITLE
Replace broken USA tapestry

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/OpenExistingMap.cpp
@@ -79,7 +79,7 @@ OpenExistingMap::~OpenExistingMap() = default;
 void OpenExistingMap::createPortalMaps()
 {
     m_portalIds.insert("Population Pressure", "392451c381ad4109bf04f7bd442bc038");
-    m_portalIds.insert("USA Tapestry Segmentation", "01f052c8995e4b9e889d73c3e210ebe3");
+    m_portalIds.insert("Terrestrial Ecosystems of the World", "5be0bc3ee36c4e058f7b3cebc21c74e6");
     m_portalIds.insert("Geology of United States", "92ad152b9da94dee89b9e387dfe21acd");
 }
 


### PR DESCRIPTION
# Description

USA Tapestry data no longer works so replace it with the portal map for `Terrestrial Ecosystems of the World`

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement: fix sample

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

