### PR TITLE
Clip geometry and cut geometry reset button

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.cpp
@@ -132,3 +132,9 @@ void ClipGeometry::clipAreas()
     }
   }
 }
+
+void ClipGeometry::resetAreas()
+{
+  m_clippedAreasOverlay->graphics()->clear();
+  m_coloradoGraphic->setVisible(true);
+}

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.h
@@ -44,6 +44,7 @@ public:
   void componentComplete() override;
   static void init();
   Q_INVOKABLE void clipAreas();
+  Q_INVOKABLE void resetAreas();
 
 private:
   void createGraphics();

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -36,31 +36,24 @@ ClipGeometrySample {
     }
 
     Button {
-        id: clipButton
-        anchors {
-            horizontalCenter: parent.horizontalCenter
-            bottom: parent.bottom
-            bottomMargin: 75
-        }
-        text: "Clip"
-        onClicked: {
-            // Only allow clipAreas(); to be called once
-            clipButton.enabled = false;
-            clipAreas();
-        }
-    }
-
-    Button {
-        id: resetButton
+        id: clipOrResetButton
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
             bottomMargin: 25
         }
-        text: "Reset"
+        text: "Clip"
         onClicked: {
-            clipButton.enabled = true;
-            resetAreas();
+            if (clipOrResetButton.text == "Clip")
+            {
+                clipAreas();
+                clipOrResetButton.text = "Reset"
+            }
+            else
+            {
+                resetAreas();
+                clipOrResetButton.text = "Clip"
+            }
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -40,13 +40,27 @@ ClipGeometrySample {
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
-            bottomMargin: 25
+            bottomMargin: 75
         }
         text: "Clip"
         onClicked: {
             // Only allow clipAreas(); to be called once
             clipButton.enabled = false;
             clipAreas();
+        }
+    }
+
+    Button {
+        id: resetButton
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            bottom: parent.bottom
+            bottomMargin: 25
+        }
+        text: "Reset"
+        onClicked: {
+            clipButton.enabled = true;
+            resetAreas();
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -44,7 +44,7 @@ ClipGeometrySample {
         }
         text: "Clip"
         onClicked: {
-            if (clipOrResetButton.text == "Clip")
+            if (clipOrResetButton.text === "Clip")
             {
                 clipAreas();
                 clipOrResetButton.text = "Reset"

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.cpp
@@ -89,6 +89,14 @@ void CutGeometry::cutPolygon()
   m_overlay->graphics()->append(usSide);
 }
 
+void CutGeometry::resetPolygon()
+{
+  m_overlay->graphics()->clear();
+
+  m_overlay->graphics()->append(m_lakeSuperiorGraphic);
+  m_overlay->graphics()->append(m_borderGraphic);
+}
+
 // Create the two baseline graphics
 void CutGeometry::createGraphics()
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.h
@@ -43,6 +43,7 @@ public:
   void componentComplete() override;
   static void init();
   Q_INVOKABLE void cutPolygon();
+  Q_INVOKABLE void resetPolygon();
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -36,7 +36,7 @@ CutGeometrySample {
     }
 
     Button {
-        id: cutButton
+        id: cutOrResetButton
         anchors {
             left: parent.left
             top: parent.top
@@ -45,24 +45,16 @@ CutGeometrySample {
 
         text: "Cut"
         onClicked: {
-            cutPolygon();
-            enabled = false;
-        }
-    }
-
-    Button {
-        id: resetButton
-        anchors {
-            left: parent.left
-            top: parent.top
-            topMargin: 60
-            leftMargin: 10;
-        }
-
-        text: "Reset"
-        onClicked: {
-            resetPolygon();
-            enabled = false;
+            if (cutOrResetButton.text == "Cut")
+            {
+                cutPolygon();
+                cutOrResetButton.text = "Reset";
+            }
+            else
+            {
+                cutOrResetButton.text = "Cut";
+                resetPolygon();
+            }
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -45,7 +45,7 @@ CutGeometrySample {
 
         text: "Cut"
         onClicked: {
-            if (cutOrResetButton.text == "Cut")
+            if (cutOrResetButton.text === "Cut")
             {
                 cutPolygon();
                 cutOrResetButton.text = "Reset";

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -49,4 +49,20 @@ CutGeometrySample {
             enabled = false;
         }
     }
+
+    Button {
+        id: resetButton
+        anchors {
+            left: parent.left
+            top: parent.top
+            topMargin: 60
+            leftMargin: 10;
+        }
+
+        text: "Reset"
+        onClicked: {
+            resetPolygon();
+            enabled = false;
+        }
+    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -166,49 +166,57 @@ Rectangle {
 
     // Create a button that clips the geometry into the envelopes
     Button {
-        id: clipButton
-        anchors {
-            horizontalCenter: parent.horizontalCenter
-            bottom: parent.bottom
-            bottomMargin: 75
-        }
-        text: "Clip"
-        onClicked: {
-            // Immediately hide the Colorado graphic to prevent overlap
-            coloradoOverlay.visible = false;
-
-            // Iterate through the clipping envelopes
-            envelopesOverlay.graphics.forEach(graphic => {
-
-                // Create a variable that contains the clip result, which is an envelope of the overlap between colorado and the current graphic
-                const clippedGeometry = GeometryEngine.clip(coloradoGraphic.geometry, graphic.geometry.extent);
-                if (clippedGeometry !== null) {
-
-                    // Create a new graphic using the clip envelope, and fill it in with the colorado fill symbol
-                    const clippedGraphic = ArcGISRuntimeEnvironment.createObject("Graphic", { geometry: clippedGeometry, symbol: coloradoFillSymbol });
-
-                    // Add the new clipped graphic to the map
-                    clippedAreasOverlay.graphics.append(clippedGraphic);
-                }
-            });
-
-            // Only allow the clip action to fire once
-            clipButton.enabled = false;
-        }
-    }
-
-    Button {
-        id: resetButton
+        id: clipOrResetButton
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
             bottomMargin: 25
         }
-        text: "Reset"
+        text: "Clip"
         onClicked: {
-            coloradoOverlay.visible = true;
-            clippedAreasOverlay.graphics.clear();
-            clipButton.enabled = true;
+            if (clipOrResetButton.text == "Clip")
+            {
+                // Immediately hide the Colorado graphic to prevent overlap
+                coloradoOverlay.visible = false;
+
+                // Iterate through the clipping envelopes
+                envelopesOverlay.graphics.forEach(graphic => {
+
+                    // Create a variable that contains the clip result, which is an envelope of the overlap between colorado and the current graphic
+                    const clippedGeometry = GeometryEngine.clip(coloradoGraphic.geometry, graphic.geometry.extent);
+                    if (clippedGeometry !== null) {
+
+                        // Create a new graphic using the clip envelope, and fill it in with the colorado fill symbol
+                        const clippedGraphic = ArcGISRuntimeEnvironment.createObject("Graphic", { geometry: clippedGeometry, symbol: coloradoFillSymbol });
+
+                        // Add the new clipped graphic to the map
+                        clippedAreasOverlay.graphics.append(clippedGraphic);
+                    }
+                });
+
+                clipOrResetButton.text = "Reset";
+            }
+            else
+            {
+                clipOrResetButton.text = "Clip";
+                coloradoOverlay.visible = true;
+                clippedAreasOverlay.graphics.clear();
+
+            }
         }
     }
+
+//    Button {
+//        id: resetButton
+//        anchors {
+//            horizontalCenter: parent.horizontalCenter
+//            bottom: parent.bottom
+//            bottomMargin: 25
+//        }
+//        text: "Reset"
+//        onClicked: {
+
+//            clipButton.enabled = true;
+//        }
+//    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -170,7 +170,7 @@ Rectangle {
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
-            bottomMargin: 25
+            bottomMargin: 75
         }
         text: "Clip"
         onClicked: {
@@ -194,6 +194,21 @@ Rectangle {
 
             // Only allow the clip action to fire once
             clipButton.enabled = false;
+        }
+    }
+
+    Button {
+        id: resetButton
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            bottom: parent.bottom
+            bottomMargin: 25
+        }
+        text: "Reset"
+        onClicked: {
+            coloradoOverlay.visible = true;
+            clippedAreasOverlay.graphics.clear();
+            clipButton.enabled = true;
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -174,7 +174,7 @@ Rectangle {
         }
         text: "Clip"
         onClicked: {
-            if (clipOrResetButton.text == "Clip")
+            if (clipOrResetButton.text === "Clip")
             {
                 // Immediately hide the Colorado graphic to prevent overlap
                 coloradoOverlay.visible = false;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -205,18 +205,4 @@ Rectangle {
             }
         }
     }
-
-//    Button {
-//        id: resetButton
-//        anchors {
-//            horizontalCenter: parent.horizontalCenter
-//            bottom: parent.bottom
-//            bottomMargin: 25
-//        }
-//        text: "Reset"
-//        onClicked: {
-
-//            clipButton.enabled = true;
-//        }
-//    }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -93,6 +93,19 @@ Rectangle {
         onClicked: cutPolygon();
     }
 
+    Button {
+        id: resetButton
+        anchors {
+            left: parent.left
+            top: parent.top
+            topMargin: 60;
+            leftMargin: 10;
+        }
+
+        text: "Reset"
+        onClicked: resetPolygon();
+    }
+
     SpatialReference {
         id: spatialRef
         wkid: 3857
@@ -130,6 +143,14 @@ Rectangle {
 
         // disable button (only cut once)
         cutButton.enabled = false;
+    }
+
+    function resetPolygon() {
+        cutButton.enabled = true;
+        graphicsOverlay.graphics.clear();
+
+        graphicsOverlay.graphics.append(lakeSuperiorGraphic);
+        graphicsOverlay.graphics.append(borderGraphic);
     }
 
     // Creates a line between the border of Canada and the United States

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -91,7 +91,7 @@ Rectangle {
 
         text: "Cut"
         onClicked: {
-            if (cutOrResetButton.text == "Cut")
+            if (cutOrResetButton.text === "Cut")
             {
                 cutOrResetButton.text = "Reset";
                 cutPolygon();

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -82,7 +82,7 @@ Rectangle {
     }
 
     Button {
-        id: cutButton
+        id: cutOrResetButton
         anchors {
             left: parent.left
             top: parent.top
@@ -90,20 +90,18 @@ Rectangle {
         }
 
         text: "Cut"
-        onClicked: cutPolygon();
-    }
-
-    Button {
-        id: resetButton
-        anchors {
-            left: parent.left
-            top: parent.top
-            topMargin: 60
-            leftMargin: 10
+        onClicked: {
+            if (cutOrResetButton.text == "Cut")
+            {
+                cutOrResetButton.text = "Reset";
+                cutPolygon();
+            }
+            else
+            {
+                cutOrResetButton.text = "Cut";
+                resetPolygon();
+            }
         }
-
-        text: "Reset"
-        onClicked: resetPolygon();
     }
 
     SpatialReference {
@@ -140,13 +138,9 @@ Rectangle {
         // add graphics
         graphicsOverlay.graphics.append(canadaSide);
         graphicsOverlay.graphics.append(usSide);
-
-        // disable button (only cut once)
-        cutButton.enabled = false;
     }
 
     function resetPolygon() {
-        cutButton.enabled = true;
         graphicsOverlay.graphics.clear();
 
         graphicsOverlay.graphics.append(lakeSuperiorGraphic);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -98,8 +98,8 @@ Rectangle {
         anchors {
             left: parent.left
             top: parent.top
-            topMargin: 60;
-            leftMargin: 10;
+            topMargin: 60
+            leftMargin: 10
         }
 
         text: "Reset"


### PR DESCRIPTION
# Description

Add a reset button to the samples "Cut Geometry" and "Clip Geometry" to bring them back to their initial/opening stage. Screenshots did not need to be updated since the original ones did not include any buttons either.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS