### PR TITLE
nearest vertex sample: fix panning issue

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
@@ -120,7 +120,6 @@ Rectangle {
     }
 
     MouseArea {
-        anchors.fill: parent
         onClicked: {
             const clickedPoint = mapView.screenToLocation(mouseX, mouseY);
             // normalizing the geometry before performing geometric operations

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
@@ -117,23 +117,23 @@ Rectangle {
                 itemId: "99fd67933e754a1181cc755146be21ca"
             }
         }
-    }
 
-    MouseArea {
-        onClicked: {
-            const clickedPoint = mapView.screenToLocation(mouseX, mouseY);
-            // normalizing the geometry before performing geometric operations
-            const normalizedPoint = GeometryEngine.normalizeCentralMeridian(clickedPoint);
-            clickedPointGraphic.geometry = normalizedPoint;
+        onMouseClicked: {
+            anchors.fill = parent;
+                const clickedPoint = mapView.screenToLocation(mouse.x, mouse.y);
+                // normalizing the geometry before performing geometric operations
+                const normalizedPoint = GeometryEngine.normalizeCentralMeridian(clickedPoint);
+                clickedPointGraphic.geometry = normalizedPoint;
 
-            const nearestVertexPoint = GeometryEngine.nearestVertex(polygonBuilder.geometry, normalizedPoint);
-            nearestVertexGraphic.geometry = nearestVertexPoint.coordinate;
+                const nearestVertexPoint = GeometryEngine.nearestVertex(polygonBuilder.geometry, normalizedPoint);
+                nearestVertexGraphic.geometry = nearestVertexPoint.coordinate;
 
-            const nearestCoordinateResult = GeometryEngine.nearestCoordinate(polygonBuilder.geometry, normalizedPoint);
-            nearestCoordinateGraphic.geometry = nearestCoordinateResult.coordinate;
+                const nearestCoordinateResult = GeometryEngine.nearestCoordinate(polygonBuilder.geometry, normalizedPoint);
+                nearestCoordinateGraphic.geometry = nearestCoordinateResult.coordinate;
 
-            distancesLabel.text = `Vertex distance: ${(nearestVertexPoint.distance/5280.0).toFixed()} mi
-Coordinate distance: ${(nearestCoordinateResult.distance/5280.0).toFixed()} mi` ;
+                distancesLabel.text = `Vertex distance: ${(nearestVertexPoint.distance/5280.0).toFixed()} mi
+    Coordinate distance: ${(nearestCoordinateResult.distance/5280.0).toFixed()} mi` ;
+
         }
     }
 


### PR DESCRIPTION
# Description

Remove extra property that prevents users from panning. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS
