### PR TITLE
Cherry pick reroute sample review comments to v.next

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/Info.plist
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/Info.plist
@@ -25,7 +25,7 @@
 	<key>NOTE</key>
 	<string>This app is cool</string>
 	<key>UIFileSharingEnabled</key>
-        <string>FALSE</string>
+        <string>TRUE</string>
 	<key>UIRequiresPersistentWiFi</key>
 	<string>NO</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.h
@@ -68,27 +68,27 @@ private:
   void setMapView(Esri::ArcGISRuntime::MapQuickView* mapView);
 
   bool navigationEnabled() const;
-    bool recenterEnabled() const;
-    QString textString() const;
-    void connectRouteTaskSignals();
-    void connectRouteTrackerSignals();
+  bool recenterEnabled() const;
+  QString textString() const;
+  void connectRouteTaskSignals();
+  void connectRouteTrackerSignals();
 
-    Esri::ArcGISRuntime::Graphic* m_routeAheadGraphic = nullptr;
-    Esri::ArcGISRuntime::Graphic* m_routeTraveledGraphic = nullptr;
-    Esri::ArcGISRuntime::GraphicsOverlay* m_routeOverlay = nullptr;
-    Esri::ArcGISRuntime::Map* m_map = nullptr;
-    Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
-    Esri::ArcGISRuntime::RouteTask* m_routeTask = nullptr;
-    Esri::ArcGISRuntime::Route m_route;
-    Esri::ArcGISRuntime::RouteResult m_routeResult;
-    Esri::ArcGISRuntime::RouteTracker* m_routeTracker = nullptr;
-    Esri::ArcGISRuntime::SimulatedLocationDataSource* m_simulatedLocationDataSource = nullptr;
-    bool m_navigationEnabled = false;
-    bool m_recenterEnabled = false;
-    QString m_textString = "";
-    QTextToSpeech* m_speaker = nullptr;
-    Esri::ArcGISRuntime::RouteParameters m_routeParameters;
-    QList<Esri::ArcGISRuntime::DirectionManeuver> m_directionManeuvers;
+  Esri::ArcGISRuntime::Graphic* m_routeAheadGraphic = nullptr;
+  Esri::ArcGISRuntime::Graphic* m_routeTraveledGraphic = nullptr;
+  Esri::ArcGISRuntime::GraphicsOverlay* m_routeOverlay = nullptr;
+  Esri::ArcGISRuntime::Map* m_map = nullptr;
+  Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
+  Esri::ArcGISRuntime::RouteTask* m_routeTask = nullptr;
+  Esri::ArcGISRuntime::Route m_route;
+  Esri::ArcGISRuntime::RouteResult m_routeResult;
+  Esri::ArcGISRuntime::RouteTracker* m_routeTracker = nullptr;
+  Esri::ArcGISRuntime::SimulatedLocationDataSource* m_simulatedLocationDataSource = nullptr;
+  bool m_navigationEnabled = false;
+  bool m_recenterEnabled = false;
+  QString m_textString = "";
+  QTextToSpeech* m_speaker = nullptr;
+  Esri::ArcGISRuntime::RouteParameters m_routeParameters;
+  QList<Esri::ArcGISRuntime::DirectionManeuver> m_directionManeuvers;
 
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -32,56 +32,56 @@ Item {
             forceActiveFocus();
         }
         Rectangle {
-                    id: backBox
-                    anchors {
-                        top: parent.top
-                        left: parent.left
-                        margins: 20
-                    }
-                    z: 1
-                    width: buttonRow.width * 1.5
-                    height: 200
-                    color: "#FBFBFB"
-                    border.color: "black"
+            id: backBox
+            anchors {
+                top: parent.top
+                left: parent.left
+                margins: 20
+            }
+            z: 1
+            width: buttonRow.width * 1.5
+            height: 200
+            color: "#FBFBFB"
+            border.color: "black"
 
-                    RowLayout {
-                        id: buttonRow
-                        anchors {
-                            top: parent.top
-                            horizontalCenter: parent.horizontalCenter
-                            margins: 5
-                        }
-                        Button {
-                            text: "Navigate"
-                            enabled: model.navigationEnabled
-                            onClicked: {
-                                model.startNavigation();
-                            }
-                        }
-                        Button {
-                            text: "Recenter"
-                            enabled: model.recenterEnabled
-                            onClicked: {
-                                model.recenterMap();
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        anchors {
-                            top: buttonRow.bottom
-                            left: parent.left
-                            margins: 5
-                        }
-                        width: parent.width
-                        Text {
-                            padding: 5
-                            width: parent.width
-                            wrapMode: Text.Wrap
-                            text: model.textString
-                        }
+            RowLayout {
+                id: buttonRow
+                anchors {
+                    top: parent.top
+                    horizontalCenter: parent.horizontalCenter
+                    margins: 5
+                }
+                Button {
+                    text: "Navigate"
+                    enabled: model.navigationEnabled
+                    onClicked: {
+                        model.startNavigation();
                     }
                 }
+                Button {
+                    text: "Recenter"
+                    enabled: model.recenterEnabled
+                    onClicked: {
+                        model.recenterMap();
+                    }
+                }
+            }
+
+            Rectangle {
+                anchors {
+                    top: buttonRow.bottom
+                    left: parent.left
+                    margins: 5
+                }
+                width: parent.width
+                Text {
+                    padding: 5
+                    width: parent.width
+                    wrapMode: Text.Wrap
+                    text: model.textString
+                }
+            }
+        }
     }
 
     // Declare the C++ instance which creates the scene etc. and supply the view

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/README.md
@@ -14,7 +14,7 @@ Click 'Navigate' to simulate traveling and to receive directions from a preset s
 
 ## How it works
 
-1. Create a `RouteTask` using a URL to an online route service.
+1. Create a `RouteTask` using a local geodatabase.
 2. Generate default `RouteParameters` using `createDefaultParameters`.
 3. Set `returnStops` and `returnDirections` on the parameters to true.
 4. Add `Stop`s to the parameters `stops` collection for each destination.
@@ -43,11 +43,11 @@ Click 'Navigate' to simulate traveling and to receive directions from a preset s
 
 ## Offline data
 
-The data used by this sample is available on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=df193653ed39449195af0c9725701dca).
+The data used by this sample is available on [ArcGIS Online](https://www.arcgis.com/home/item.html?id=4caec8c55ea2463982f1af7d9611b8d5).
 
 Link | Local Location
 ---------|-------|
-|[San Diego Streets TPKX](https://arcgisruntime.maps.arcgis.com/home/item.html?id=df193653ed39449195af0c9725701dca)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/san_diego |
+|[Navigate a Route JSON Track](https://www.arcgis.com/home/item.html?id=4caec8c55ea2463982f1af7d9611b8d5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/san_diego |
 
 ## About the data
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/Info.plist
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/Info.plist
@@ -25,7 +25,7 @@
 	<key>NOTE</key>
 	<string>This app is cool</string>
 	<key>UIFileSharingEnabled</key>
-        <string>FALSE</string>
+        <string>TRUE</string>
 	<key>UIRequiresPersistentWiFi</key>
 	<string>NO</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -50,7 +50,6 @@ Rectangle {
             }
         }
 
-
         GraphicsOverlay {
             id: routeOverlay
             Graphic {
@@ -119,7 +118,6 @@ Rectangle {
 
     RouteTask {
         id: routeTask
-
         url: dataPath + "san_diego/sandiego.geodatabase"
         networkName: "Streets_ND"
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.cpp
@@ -1,3 +1,19 @@
+// [WriteFile Name=NavigateARouteWithRerouting, Category=Routing]
+// [Legal]
+// Copyright 2022 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
 #include "NavigateRouteSpeaker.h"
 #include <QTextToSpeech>
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.h
@@ -1,3 +1,19 @@
+// [WriteFile Name=NavigateARouteWithRerouting, Category=Routing]
+// [Legal]
+// Copyright 2022 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
 #ifndef NAVIGATEROUTESPEAKER_H
 #define NAVIGATEROUTESPEAKER_H
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/README.md
@@ -14,7 +14,7 @@ Click 'Navigate' to simulate traveling and to receive directions from a preset s
 
 ## How it works
 
-1. Create a `RouteTask` using a URL to an online route service.
+1. Create a `RouteTask` using a local geodatabase.
 2. Generate default `RouteParameters` using `createDefaultParameters`.
 3. Set `returnStops` and `returnDirections` on the parameters to true.
 4. Add `Stop`s to the parameters `stops` collection for each destination.
@@ -43,11 +43,11 @@ Click 'Navigate' to simulate traveling and to receive directions from a preset s
 
 ## Offline data
 
-The data used by this sample is available on [ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=df193653ed39449195af0c9725701dca).
+The data used by this sample is available on [ArcGIS Online](https://www.arcgis.com/home/item.html?id=4caec8c55ea2463982f1af7d9611b8d5).
 
 Link | Local Location
 ---------|-------|
-|[San Diego Streets TPKX](https://arcgisruntime.maps.arcgis.com/home/item.html?id=df193653ed39449195af0c9725701dca)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/san_diego |
+|[Navigate a Route JSON Track](https://www.arcgis.com/home/item.html?id=4caec8c55ea2463982f1af7d9611b8d5)| `<userhome>`/ArcGIS/Runtime/Data/tpkx/san_diego |
 
 ## About the data
 


### PR DESCRIPTION
# Description

Cherry pick the code review changes from this [main PR](https://github.com/Esri/arcgis-runtime-samples-qt/pull/1456) back to v.next to keep both samples in sync.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS
