### PR TITLE
Replace QStringRef with QStringView

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp
@@ -190,7 +190,7 @@ void GODictionaryRenderer::parseXmlFile()
         if (!currentElementName.isEmpty())
         {
           // Get the text and store it as the current element's value
-          QStringRef trimmedText = m_xmlParser.text().trimmed();
+          QStringView trimmedText = m_xmlParser.text().trimmed();
           if (!trimmedText.isEmpty())
           {
             elementValues[currentElementName] = trimmedText.toString();

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp
@@ -190,7 +190,7 @@ void GODictionaryRenderer::parseXmlFile()
         if (!currentElementName.isEmpty())
         {
           // Get the text and store it as the current element's value
-          QStringView trimmedText = m_xmlParser.text().trimmed();
+          const QStringView trimmedText = m_xmlParser.text().trimmed();
           if (!trimmedText.isEmpty())
           {
             elementValues[currentElementName] = trimmedText.toString();

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp
@@ -188,7 +188,7 @@ void GODictionaryRenderer_3D::parseXmlFile()
         if (!currentElementName.isEmpty())
         {
           // Get the text and store it as the current element's value
-          QStringView trimmedText = m_xmlParser.text().trimmed();
+          const QStringView trimmedText = m_xmlParser.text().trimmed();
           if (!trimmedText.isEmpty())
           {
             elementValues[currentElementName] = trimmedText.toString();

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp
@@ -188,7 +188,7 @@ void GODictionaryRenderer_3D::parseXmlFile()
         if (!currentElementName.isEmpty())
         {
           // Get the text and store it as the current element's value
-          QStringRef trimmedText = m_xmlParser.text().trimmed();
+          QStringView trimmedText = m_xmlParser.text().trimmed();
           if (!trimmedText.isEmpty())
           {
             elementValues[currentElementName] = trimmedText.toString();

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterKeywordCriteria.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterKeywordCriteria.cpp
@@ -35,20 +35,20 @@ QString highlightedMidpoint(const QString& string,
 
     // Find the portion of string that goes before the catchment.
     int startPos = std::max(0, pos-catchment);
-    QStringView startPart(&string, startPos, catchment);
+    const QStringView startPart(&string, startPos, catchment);
 
     // Start section
     builder = builder + startPart.toString().toHtmlEscaped();
 
     // The found portion of string to be highlighted
-    QStringView caughtString(&string, pos, subStringLength);
+    const QStringView caughtString(&string, pos, subStringLength);
     builder = builder + QStringLiteral("<b>")
                       + caughtString.toString().toHtmlEscaped()
                       + QStringLiteral("</b>");
 
     // Find the portion of string that goes after the catchment.
     int endPos = std::min(string.length(), pos+ subStringLength + catchment);
-    QStringView endPart(&string, pos + subStringLength, endPos);
+    const QStringView endPart(&string, pos + subStringLength, endPos);
     builder = builder + endPart.toString().toHtmlEscaped();
 
     return builder;

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterKeywordCriteria.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterKeywordCriteria.cpp
@@ -35,20 +35,20 @@ QString highlightedMidpoint(const QString& string,
 
     // Find the portion of string that goes before the catchment.
     int startPos = std::max(0, pos-catchment);
-    QStringRef startPart(&string, startPos, catchment);
+    QStringView startPart(&string, startPos, catchment);
 
     // Start section
     builder = builder + startPart.toString().toHtmlEscaped();
 
     // The found portion of string to be highlighted
-    QStringRef caughtString(&string, pos, subStringLength);
+    QStringView caughtString(&string, pos, subStringLength);
     builder = builder + QStringLiteral("<b>")
                       + caughtString.toString().toHtmlEscaped()
                       + QStringLiteral("</b>");
 
     // Find the portion of string that goes after the catchment.
     int endPos = std::min(string.length(), pos+ subStringLength + catchment);
-    QStringRef endPart(&string, pos + subStringLength, endPos);
+    QStringView endPart(&string, pos + subStringLength, endPos);
     builder = builder + endPart.toString().toHtmlEscaped();
 
     return builder;

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterSimpleKeywordCriteria.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterSimpleKeywordCriteria.cpp
@@ -42,7 +42,7 @@ constexpr qint64 DEFAULT_START_MODIFIER = 2;
  * \param subString Substring to see if partially or fully matches begining.
  * \return score value based on score system values.
  */
-qint64 stringCompare(QStringView string, const QString& subString)
+qint64 stringCompare(const QStringView string, const QString& subString)
 {
   qint64 score = 0;
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterSimpleKeywordCriteria.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SearchFilterSimpleKeywordCriteria.cpp
@@ -42,7 +42,7 @@ constexpr qint64 DEFAULT_START_MODIFIER = 2;
  * \param subString Substring to see if partially or fully matches begining.
  * \return score value based on score system values.
  */
-qint64 stringCompare(const QStringRef& string, const QString& subString)
+qint64 stringCompare(QStringView string, const QString& subString)
 {
   qint64 score = 0;
 
@@ -98,7 +98,7 @@ QPair<qint64, int> subStringCompare(const QString& string,
   const int length = string.length();
   for (int i = 0; i < length; ++i)
   {
-    auto result = stringCompare(QStringRef(&string, i, length - i),
+    auto result = stringCompare(QStringView(&string, i, length - i),
                                 subString);
     if (i == 0)
       result *= DEFAULT_START_MODIFIER;


### PR DESCRIPTION
# Description

Required for moving to Qt6. Per [Qt documentation](https://doc.qt.io/qt-6/qstringview.html) const ref to QStringView works but it is slower so I replaced that with just using a QStringView.

```c++
void myfun2(const QStringView &sv); // compiles and works, but slower
```

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement
