### PR TITLE
Remove version numbers

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import Esri.ArcGISArToolkit 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import Esri.ArcGISArToolkit
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/ExploreScenesInFlyoverAR.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/ExploreScenesInFlyoverAR.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import Esri.ArcGISArToolkit 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import Esri.ArcGISArToolkit
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Qt.labs.calendar 1.0
-import QtGraphicalEffects 1.0
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.calendar
+import Qt5Compat.GraphicalEffects
+import QtQuick.Layouts
+import Esri.Samples
 
 AnalyzeHotspotsSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 AnalyzeViewshedSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 DistanceMeasurementAnalysisSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/FeatureInfoPane.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/FeatureInfoPane.qml
@@ -15,8 +15,8 @@
 // [Legal]
 
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Pane {
     id: aboutFeaturePane

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     id: applicationWindowItem

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
     SceneView {

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 LineOfSightLocationSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/StatisticalQuery.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 StatisticalQuerySample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
@@ -11,8 +11,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     id: rootOptionsPage

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/ResultsPage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/ResultsPage.qml
@@ -11,8 +11,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     color: "#F4F4F4"

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 StatisticalQueryGroupSortSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ViewshedCameraSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 ViewshedGeoElementSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ColorDialog.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ColorDialog.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Dialog {
     id: colorDialog

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Window 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import Esri.Samples
 
 ViewshedLocationSample {
     id: viewshedSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedSlider.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedSlider.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Column {
     id: root

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 AddItemsToPortalSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 PortalUserInfoSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
@@ -12,10 +12,10 @@
 // See the Sample code usage restrictions document for further information.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 SearchForWebmapSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 ShowOrgBasemapsSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 TokenAuthenticationSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 AddGraphicsWithRendererSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 BuildLegendSample {
     id: showLegendSample

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.12
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
     id: window

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.1
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 DisplayGridSample {
     id: displayGrid

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 GODictionaryRendererSample {
     id: graphicsOverlayDictionaryRendererSample

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 GODictionaryRenderer_3DSample {
     id: graphicsOverlayDictionaryRenderer_3DSample

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 GOSymbolsSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 IdentifyGraphicsSample {
     id: identifyGraphicsSample

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 Picture_Marker_SymbolSample {
     clip: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.11
-import QtQuick.Controls 2.5
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.11
-import QtQuick.Controls 2.5
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 ComboBox {
     id: rootComboBox

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 ShowCalloutSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ShowLabelsOnLayersSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     id: appWindow

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Simple_Marker_SymbolSample {
     clip: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Simple_RendererSample {
     clip: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchEditorButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchEditorButton.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 // This component defines each of the buttons in the sketch editor control UI
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.15
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 SymbolizeShapefileSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Unique_Value_RendererSample {
     clip: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 AddFeaturesFeatureServiceSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     id: sampleWindow

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 DeleteFeaturesFeatureServiceSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 EditAndSyncFeaturesSample {
     id: editAndSyncSample

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Qt.labs.platform 1.0
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.platform
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 EditFeatureAttachmentsSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.qml
@@ -1,5 +1,5 @@
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/EditKmlGroundOverlay.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/EditKmlGroundOverlay.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 UpdateAttributesFeatureServiceSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 UpdateGeometryFeatureServiceSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/ControlTimeExtentTimeSlider.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/ControlTimeExtentTimeSlider.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime.Toolkit
-import Esri.Samples 1.0
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.2
-import Qt.labs.platform 1.1
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
+import Esri.Samples
 
 Item {
     id: rootItem

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerChangeRendererSample {
     id: changeRendererSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerDictionaryRendererSample {
     id: featureLayerDictionaryRendererSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/FeatureLayerFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerFeatureServiceSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/FeatureLayer_GeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/FeatureLayer_GeoPackage.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 FeatureLayer_GeoPackageSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/FeatureLayerGeodatabase.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 FeatureLayerGeodatabaseSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerQuerySample {
     id: featureLayerQuerySample

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerSelectionSample {
     id: featureLayerSelectionSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 //! [Import the namespace that has QML type that was registered in Cpp]
-import Esri.Samples 1.0
+import Esri.Samples
 //! [Import the namespace that has QML type that was registered in Cpp]
 
 FilterByDefinitionExpressionOrDisplayFilterSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.3
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 GenerateGeodatabaseReplicaFromFeatureServiceSample {
     id: generateSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ListRelatedFeaturesSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/ServiceFeatureTableCache.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 ServiceFeatureTableCacheSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ServiceFeatureTableManualCacheSample {
     id: manualCacheSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ServiceFeatureTableNoCacheSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 BufferSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ClipGeometrySample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.6
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.11
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/CreateGeometries.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/CreateGeometries.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 CreateGeometriesSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 CutGeometrySample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Window 2.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Esri.Samples
 
 DensifyAndGeneralizeSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     clip: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick.Controls 2.2
+import QtQuick.Controls
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 GeodesicOperationsSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/ListTransformations.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ListTransformationsSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Window 2.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 ProjectGeometrySample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Esri.Samples
 
 SpatialOperationsSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Window 2.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Esri.Samples
 
 SpatialRelationshipsSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/AddEncExchangeSet.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/AddEncExchangeSet.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ArcGISMapImageLayerUrlSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ArcGISTiledLayerUrlSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 BlendRasterLayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/ColorRampModel.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/ColorRampModel.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 ListModel {
     ListElement {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/SlopeTypeModel.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/SlopeTypeModel.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 ListModel {
     ListElement {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.12
-import QtQuick.Dialogs 1.2
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
+import QtQuick.Dialogs
 
 Item {
     // Declare the C++ instance which creates the map etc. and supply the view

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     readonly property bool swapAxis: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Window 2.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Esri.Samples
 
 ChangeSublayerRendererSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ChangeSublayerVisibilitySample {
     id: changeSublayerVisibilitySample

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Qt.labs.platform 1.1 as Dialogs
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.platform
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/DisplayAnnotation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/DisplayAnnotation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
-import QtQuick.Dialogs 1.2
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
+import QtQuick.Dialogs
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 DisplayKmlSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Window 2.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import Esri.Samples
 
 DisplayKmlNetworkLinksSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/MessageButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/MessageButton.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Item {
     id: messageButton

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/DisplayOgcApiFeatureCollection.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/DisplayOgcApiFeatureCollection.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
@@ -14,12 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import QtQuick.Shapes 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Shapes
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/DisplayWfsLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/DisplayWfsLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 ExportTilesSample {
     id: exportTilesSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/ExportVectorTiles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/ExportVectorTiles.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
     id: item

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureCollectionLayerQuerySample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerRenderingModeMapSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerRenderingModeSceneSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 FeatureLayerShapefileSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Feature_Collection_LayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/GroupLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/GroupLayers.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtGraphicalEffects 1.0
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Rectangle {
     id: root

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSlopeTypeModel.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSlopeTypeModel.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
+import QtQuick
 
 ListModel {
     ListElement {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Hillshade_RendererSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/ListKmlContents.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/ListKmlContents.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.11
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/LoadWfsXmlQuery.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/LoadWfsXmlQuery.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/OSM_Layer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 OSM_LayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Window 2.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Esri.Samples
 
 QueryMapImageSublayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/QueryOGCAPICQLFilters.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/QueryOGCAPICQLFilters.qml
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // [Legal]
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 RasterColormapRendererSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 RasterFunctionFileSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/RasterFunctionService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 RasterFunctionServiceSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLayerFile.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 RasterLayerFileSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLoader.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/RasterLoader.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Qt.labs.platform 1.0
+import QtQuick
+import Qt.labs.platform
 
 Item {
     id: root

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/main.qml
@@ -1,5 +1,5 @@
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 RasterLayerGeoPackageSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/RasterLayerService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 RasterLayerServiceSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 RasterRenderingRuleSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Esri.Samples
 
 RasterRgbRendererSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/InputWithLabel.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/InputWithLabel.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Row {
     anchors.horizontalCenter: parent.horizontalCenter

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 RasterStretchRendererSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Window 2.3
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import Esri.Samples
 
 StyleWmsLayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/TileCacheLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/TileCacheLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 VectorTiledLayerUrlSample {
     id: vectorTiledLayerUrlSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/WMTS_Layer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 WMTS_LayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Web_Tiled_LayerSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 WmsLayerUrlSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 LocalServerFeatureLayerSample {
     id: localServerFeatureLayerSample

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 LocalServerGeoprocessingSample {
     id: localServerGeoprocessingSample

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 LocalServerMapImageLayerSample {
     id: localServerMapImageLayerSample

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Qt.labs.platform 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.platform
+import Esri.Samples
 
 LocalServerServicesSample {
     id: localServerServicesSample

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.qml
@@ -1,5 +1,5 @@
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/ChangeBasemap.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ChangeViewpointSample {
     id: changeViewpointSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 CreateAndSaveMapSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     RadialGradient {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     RadialGradient {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 DisplayDeviceLocationSample {
     id: deviceLocationSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/DisplayDeviceLocationWithNmeaDataSources.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/DisplayDeviceLocationWithNmeaDataSources.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 DisplayDrawingStatusSample {
     id: displayDrawingStatusSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/DisplayMap.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 DisplayMapSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/DownloadButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/DownloadButton.qml
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.5
+import QtQuick
 
 // Create the download button to export the tile cache
 Rectangle {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 GenerateOfflineMapSample {
     id: offlineMapSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/DownloadButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/DownloadButton.qml
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.5
+import QtQuick
 
 // Create the download button to export the tile cache
 Rectangle {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 GenerateOfflineMapLocalBasemapSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/DownloadButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/DownloadButton.qml
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
+import QtQuick
 
 // Create the download button to export the tile cache
 Rectangle {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 GenerateOfflineMap_OverridesSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     id: overridesPanel

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 IdentifyLayersSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 ManageBookmarksSample {
     id: manageBookmarksSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/MapLoaded.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 MapLoadedSample {
     id: mapLoadedSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/MapReferenceScale.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/MapReferenceScale.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
     readonly property var referenceScales: [500000, 250000, 100000, 50000]

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/MapRotation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 MapRotationSample {
     id: mapRotationSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/MinMaxScale.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/MinMaxScale.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 MinMaxScaleSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 MobileMap_SearchAndRouteSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 OpenMapUrlSample {
     id: openMapUrlSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 OpenMobileMap_MapPackageSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/ReadGeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/ReadGeoPackage.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 ReadGeoPackageSample {
     id: root

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 SetInitialMapAreaSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 SetInitialMapLocationSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 SetMapSpatialReferenceSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/SetMaxExtent.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/SetMaxExtent.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.13
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/ShowMagnifier.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ShowMagnifierSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.Samples
 
 TakeScreenshotSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ClosestFacilitySample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.11
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FindRouteSample {
     id: findRouteSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.11
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import Esri.Samples 1.0
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.11
+import QtQuick
+import Esri.Samples
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import Esri.Samples
-import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.11
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.6
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.11
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.11
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
     readonly property int checkBoxPadding: 20

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ServiceAreaSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/AddAPointSceneLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/AddAPointSceneLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.5
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Animate3DSymbolsSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
@@ -1,5 +1,5 @@
-import QtQuick.Controls 2.2
-import QtQuick 2.6
+import QtQuick.Controls
+import QtQuick
 
 Slider {
     id: slider

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     property var timerIntervals: [17,34,68]

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/BasicSceneView.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 BasicSceneSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     states: [

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/Display3DLabelsInScene.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/Display3DLabelsInScene.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 DisplaySceneLayerSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
+import QtQuick
+import Esri.Samples
 
 DistanceCompositeSymbolSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 ExtrudeGraphicsSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 FeatureLayerExtrusionSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import Esri.Samples 1.0
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import Esri.Samples
+import QtQuick
+import QtQuick.Controls
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/OpenScene.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/OpenScene.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 OpenSceneSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import Esri.Samples 1.0
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.12
+import Esri.Samples
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 SceneLayerSelectionSample {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     id: root

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/Surface_Placement.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/Surface_Placement.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
 
 SurfacePlacementSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/Symbols.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 SymbolsSample {
     width: 800

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     states: [

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 TerrainExaggerationSample {
     id: terrainExaggerationSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/ViewContentBeneathTerrainSurface.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/ViewContentBeneathTerrainSurface.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 FindAddressSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtPositioning 5.6
+import QtQuick
+import QtQuick.Controls
+import QtPositioning
 import Esri.ArcGISRuntime.Toolkit
-import Esri.Samples 1.0
+import Esri.Samples
 
 FindPlaceSample {
     id: findPlaceSample

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/SearchBox.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/SearchBox.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 TextField {
     width: parent.width

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/SearchButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/SearchButton.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 Rectangle {
     property bool pressed: false

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/SuggestionView.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/SuggestionView.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 Rectangle {
     color: "#f7f8fa"

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.Samples 1.0
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import Esri.Samples
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime.Toolkit
 
 OfflineGeocodeSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import QtQuick.Layouts
+import Esri.Samples
 
 SearchDictionarySymbolStyleSample {
     id: searchDictionarySymbolStyleSample

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import QtQuick.Shapes 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Shapes
+import Esri.Samples
 
 Item {
     readonly property var comparisonOperatorModel: ["Equal","NotEqual","GreaterThan","GreaterThanEqual","LessThan","LessThanEqual","IncludesTheValues","DoesNotIncludeTheValues","IncludesAny","DoesNotIncludeAny"]

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     property var phases: ["A", "AB", "ABC", "AC", "B", "BC", "C", "DeEnergized", "Unknown"]

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.qml
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.15
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import Qt.labs.qmlmodels 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import Qt.labs.qmlmodels
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     id: item1

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.12
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
-import QtQuick.Layouts 1.11
-import QtQuick.Dialogs 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.Samples
+import QtQuick.Layouts
+import QtQuick.Dialogs
 
 Item {
     // add a mapView component

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/TerminalPickerView.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/TerminalPickerView.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.12
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 
 Dialog {
     id: terminalPickerView

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import Esri.Samples 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.Samples
 
 Item {
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.qml
@@ -11,8 +11,8 @@
 // See the Sample code usage restrictions document for further information.
 //
 
-import QtQuick.Controls 2.2
-import Esri.Samples 1.0
+import QtQuick.Controls
+import Esri.Samples
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import Esri.ArcGISArToolkit 1.0
-import Esri.Samples 1.0
+import Esri.ArcGISExtras
+import Esri.ArcGISArToolkit
+import Esri.Samples
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/ExploreScenesInFlyoverAR.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/ExploreScenesInFlyoverAR.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import Esri.ArcGISArToolkit 1.0
+import Esri.ArcGISExtras
+import Esri.ArcGISArToolkit
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Qt.labs.calendar 1.0
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.calendar
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.3
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/FeatureInfoPane.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/FeatureInfoPane.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Pane {
     id: aboutFeaturePane

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/Geotriggers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/Geotriggers.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import Qt.labs.platform 1.0
+import Esri.ArcGISExtras
+import Qt.labs.platform
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/LineOfSightLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/LineOfSightLocation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/StatisticalQuery.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/StatisticalQuery.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
@@ -11,8 +11,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     id: rootOptionsPage

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/ResultsPage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/ResultsPage.qml
@@ -11,8 +11,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     color: "#F4F4F4"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/ViewshedCamera.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ColorDialog.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ColorDialog.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Dialog {
     id: colorDialog

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ViewshedLocation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ViewshedSlider.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/ViewshedSlider.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Column {
     id: root

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import QtQuick.Controls 2.2
+import Esri.ArcGISExtras
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.XmlListModel 2.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.XmlListModel
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.XmlListModel 2.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.XmlListModel
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/GOSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/GOSymbols.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.11
-import QtQuick.Controls 2.5
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.11
-import QtQuick.Controls 2.5
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 ComboBox {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/ShowCallout.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/ShowCallout.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/ShowPopup.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/ShowPopup.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchEditorButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchEditorButton.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 // This component defines each of the buttons in the sketch editor control UI
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/SketchOnMap.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/ContingentValues/ContingentValues.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/ContingentValues/ContingentValues.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Qt.labs.platform 1.0
-import QtGraphicalEffects 1.0
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.platform
+import Qt5Compat.GraphicalEffects
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/EditKmlGroundOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/EditKmlGroundOverlay.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.3
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import QtGraphicalEffects 1.0
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/ControlTimeExtentTimeSlider.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/ControlTimeExtentTimeSlider.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
+import QtQuick
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import QtQuick.Controls 2.12
+import Esri.ArcGISExtras
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/FeatureLayer_ChangeRenderer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/FeatureLayer_DictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/FeatureLayer_DictionaryRenderer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/FeatureLayer_FeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/FeatureLayer_FeatureService.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/FeatureLayer_Geodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/FeatureLayer_Geodatabase.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/FeatureLayer_GeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/FeatureLayer_GeoPackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/FeatureLayer_Query.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 //! [Rectangle-mapview-map-viewpoint]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/ListRelatedFeatures.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/ServiceFeatureTable_Cache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/ServiceFeatureTable_Cache.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/ServiceFeatureTable_ManualCache.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/ServiceFeatureTable_NoCache.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/ServiceFeatureTable_NoCache.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/Buffer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/Buffer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/ClipGeometry.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/ConvexHull.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/ConvexHull.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.11
-import QtQuick.Controls 2.6
+import QtQuick.Layouts
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/CreateGeometries.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/CreateGeometries.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/CutGeometry.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/FormatCoordinates.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/FormatCoordinates.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.2
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/GeodesicOperations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/GeodesicOperations.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/ListTransformations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/ListTransformations.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/NearestVertex.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.4
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/ProjectGeometry.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/AddEncExchangeSet.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/AddEncExchangeSet.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/ColorRampModel.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/ColorRampModel.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 ListModel {
     ListElement {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/SlopeTypeModel.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/SlopeTypeModel.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 ListModel {
     ListElement {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 
 Rectangle {
     id: root

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import Qt.labs.platform 1.1 as Dialogs
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.platform
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/DisplayAnnotation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/DisplayAnnotation.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayDimensions/DisplayDimensions.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayDimensions/DisplayDimensions.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import QtQuick.Layouts 1.12
-import QtQuick.Dialogs 1.2
+import Esri.ArcGISExtras
+import QtQuick.Layouts
+import QtQuick.Dialogs
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Window 2.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/MessageButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/MessageButton.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Item {
     id: messageButton

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/DisplayOgcApiFeatureCollection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/DisplayOgcApiFeatureCollection.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import QtQuick.Shapes 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Shapes
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/DisplayWfsLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/DisplayWfsLayer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportVectorTiles/ExportVectorTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportVectorTiles/ExportVectorTiles.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.12
-import Esri.ArcGISExtras 1.1
+import QtQuick.Controls
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/FeatureLayerShapefile.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/GroupLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/GroupLayers.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.5
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtGraphicalEffects 1.0
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSlopeTypeModel.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSlopeTypeModel.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
+import QtQuick
 import Esri.ArcGISRuntime
 
 ListModel {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/ListKmlContents.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/ListKmlContents.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.11
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/LoadWfsXmlQuery.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/LoadWfsXmlQuery.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.5
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.Samples 1.0
+import Esri.Samples
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/OSM_Layer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/PlayAKmlTour.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/PlayAKmlTour.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/QueryOGCAPICQLFilters.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/QueryOGCAPICQLFilters.qml
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // [Legal]
-import QtQuick 2.12
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/RasterFunctionFile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/RasterFunctionFile.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/RasterLayerFile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/RasterLayerFile.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/RasterLoader.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/RasterLoader.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import Qt.labs.platform 1.0 as Dialogs
+import QtQuick
+import Qt.labs.platform
 
 Item {
     id: root

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/main.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/main.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 ApplicationWindow {
     visible: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/RasterLayerService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/RasterLayerService.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/InputWithLabel.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/InputWithLabel.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Row {
     anchors.horizontalCenter: parent.horizontalCenter

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/StyleWmsLayer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/TileCacheLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/TileCacheLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/WMTS_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/WMTS_Layer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/WmsLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/WmsLayerUrl.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.4
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/ChangeBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/ChangeBasemap.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     RadialGradient {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -11,10 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     RadialGradient {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtPositioning 5.3
-import QtSensors 5.3
+import QtQuick
+import QtPositioning
+import QtSensors
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/DisplayDeviceLocationWithNmeaDataSources.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/DisplayDeviceLocationWithNmeaDataSources.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     clip: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/DisplayMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/DisplayMap.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
+import QtQuick
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/DownloadButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/DownloadButton.qml
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.5
+import QtQuick
 
 // Create the download button to export the tile cache
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/DownloadButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/DownloadButton.qml
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.5
+import QtQuick
 
 // Create the download button to export the tile cache
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/DownloadButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/DownloadButton.qml
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
+import QtQuick
 
 // Create the download button to export the tile cache
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.2
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     id: overridesPanel

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/IdentifyLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/IdentifyLayers.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/MapLoaded.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/MapLoaded.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/MapReferenceScale.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/MapReferenceScale.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/MapRotation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/MapRotation.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/MinMaxScale.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/MinMaxScale.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtGraphicalEffects 1.0
+import QtQuick
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/ReadGeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/ReadGeoPackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/SetInitialMapArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/SetInitialMapArea.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMaxExtent/SetMaxExtent.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMaxExtent/SetMaxExtent.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.13
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/ShowLocationHistory.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/ShowLocationHistory.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/ShowMagnifier.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/ShowMagnifier.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/ClosestFacility.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/ClosestFacility.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import Esri.ArcGISRuntime 100.15
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.11
+import QtQuick
+import Esri.ArcGISRuntime
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/FindRoute.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.11
-import QtQuick.Controls 2.2
+import QtQuick.Layouts
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -14,13 +14,13 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.11
-import QtPositioning 5.2
-import Esri.ArcGISExtras 1.1
-import Esri.samples 1.0
+import QtQuick.Layouts
+import QtPositioning
+import Esri.ArcGISExtras
+import Esri.Samples
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.11
-import QtPositioning 5.2
-import Esri.samples 1.0
+import QtQuick.Layouts
+import QtPositioning
+import Esri.Samples
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -14,12 +14,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.6
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import QtQml 2.11
-import QtQuick.Layouts 1.11
+import Esri.ArcGISExtras
+import QtQml
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.11
-import QtQuick.Dialogs 1.1
+import QtQuick.Layouts
+import QtQuick.Dialogs
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/AddAPointSceneLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/AddAPointSceneLayer.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.5
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
@@ -1,5 +1,5 @@
-import QtQuick.Controls 2.2
-import QtQuick 2.6
+import QtQuick.Controls
+import QtQuick
 
 Slider {
     id: slider

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.12
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/BasicSceneView.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.1
+import Esri.ArcGISExtras
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     clip: true

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/Display3DLabelsInScene.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/Display3DLabelsInScene.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     width: 800

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -15,8 +15,8 @@
 // [Legal]
 
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.qml
@@ -15,8 +15,8 @@
 // [Legal]
 
 import Esri.ArcGISRuntime
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/OpenScene.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/OpenScene.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/SceneLayerSelection.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.2
+import QtQuick.Controls
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/Surface_Placement.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/Surface_Placement.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/Symbols.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.2
+import QtQuick
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/ViewContentBeneathTerrainSurface.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/ViewContentBeneathTerrainSurface.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/FindAddress.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/FindAddress.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/FindPlace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/FindPlace.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtPositioning 5.6
+import QtQuick
+import QtQuick.Controls
+import QtPositioning
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/SearchBox.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/SearchBox.qml
@@ -14,8 +14,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 TextField {
     width: parent.width

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/SearchButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/SearchButton.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 Rectangle {
     property bool pressed: false

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/SuggestionView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/SuggestionView.qml
@@ -14,7 +14,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 
 Rectangle {
     color: "#f7f8fa"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/OfflineGeocode.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.6
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
-import Esri.ArcGISExtras 1.1
+import Esri.ArcGISExtras
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.12
-import QtQuick.Shapes 1.12
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Shapes
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.qml
@@ -14,10 +14,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
+import QtQuick
 import Esri.ArcGISRuntime
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -14,11 +14,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 import Esri.ArcGISRuntime
-import QtQuick.Layouts 1.11
-import QtQuick.Dialogs 1.1
+import QtQuick.Layouts
+import QtQuick.Dialogs
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/TerminalPickerView.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/TerminalPickerView.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.0
-import QtQuick.Layouts 1.12
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 
 Dialog {
     id: terminalPickerView

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -14,9 +14,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Layouts 1.12
-import QtQuick.Controls 2.12
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/Imports.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/Imports.qml
@@ -13,23 +13,21 @@
 // limitations under the License.
 // [Legal]
 
-import Qt.labs.calendar 1.0
-import Qt.labs.controls 1.0
-import Qt.labs.platform 1.0
-import QtQuick 2.5
-import QtQuick.Controls 1.4
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.1
-import QtQuick.Shapes 1.12
-import QtQuick.Window 2.0
-import QtQuick.Dialogs 1.2
-import QtSensors 5.3
-import QtPositioning 5.3
-import QtQuick.XmlListModel 2.0
-import QtGraphicalEffects 1.0
-import QtWebView 1.1
-import Esri.ArcGISExtras 1.1
+import Qt.labs.calendar
+import Qt.labs.controls
+import Qt.labs.platform
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Shapes
+import QtQuick.Window
+import QtQuick.Dialogs
+import QtSensors
+import QtPositioning
+import QtQuick.XmlListModel
+import Qt5Compat.GraphicalEffects
+import QtWebView
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/Imports.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/Imports.qml
@@ -13,23 +13,21 @@
 // limitations under the License.
 // [Legal]
 
-import Qt.labs.calendar 1.0
-import Qt.labs.controls 1.0
-import Qt.labs.platform 1.0
-import QtQuick 2.5
-import QtQuick.Controls 1.4
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.1
-import QtQuick.Shapes 1.12
-import QtQuick.Window 2.0
-import QtQuick.Dialogs 1.2
-import QtSensors 5.3
-import QtPositioning 5.3
-import QtQuick.XmlListModel 2.0
-import QtGraphicalEffects 1.0
-import QtWebView 1.1
-import Esri.ArcGISExtras 1.1
+import Qt.labs.calendar
+import Qt.labs.controls
+import Qt.labs.platform
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Shapes
+import QtQuick.Window
+import QtQuick.Dialogs
+import QtSensors
+import QtPositioning
+import QtQuick.XmlListModel
+import Qt5Compat.GraphicalEffects
+import QtWebView
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/qml/QmlArcGISRuntimeEnvironment.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/qml/QmlArcGISRuntimeEnvironment.qml
@@ -13,9 +13,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISRuntimeSamples 1.0
+import Esri.ArcGISRuntimeSamples
 
 Item {
     property string apiKey : "initial_invalid_key"

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/qml/QmlSampleManagerPortalItem.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/qml/QmlSampleManagerPortalItem.qml
@@ -13,9 +13,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
+import QtQuick
 import Esri.ArcGISRuntime
-import Esri.ArcGISRuntimeSamples 1.0
+import Esri.ArcGISRuntimeSamples
 
 Item {
     property PortalItem portalItem: null

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
@@ -13,10 +13,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntimeSamples 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.ArcGISRuntimeSamples
 
 Item {
     visible: false

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
@@ -13,11 +13,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntimeSamples 1.0
-import Telemetry 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.ArcGISRuntimeSamples
+import Telemetry
 
 Component {
     id: categoryDelegate

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryDrawer.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryDrawer.qml
@@ -13,9 +13,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
 
 Drawer {
     clip: true

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
@@ -13,11 +13,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.9
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
-import Esri.ArcGISRuntimeSamples 1.0
-import Telemetry 1.0
+import QtQuick
+import QtQuick.Controls
+import Qt5Compat.GraphicalEffects
+import Esri.ArcGISRuntimeSamples
+import Telemetry
 
 Page {
     id: categoryView

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CppAuthenticationView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CppAuthenticationView.qml
@@ -13,8 +13,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import Esri.ArcGISRuntimeSamples 1.0
+import QtQuick
+import Esri.ArcGISRuntimeSamples
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloadView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloadView.qml
@@ -13,11 +13,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
-import Esri.ArcGISExtras 1.1
-import QtQuick.Layouts 1.12
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
+import Esri.ArcGISExtras
+import QtQuick.Layouts
 
 Page {
     id: page

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
@@ -13,9 +13,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import Esri.ArcGISExtras 1.1
-import Esri.ArcGISRuntimeSamples 1.0
+import QtQuick
+import Esri.ArcGISExtras
+import Esri.ArcGISRuntimeSamples
 
 Item {
     property var currentItem

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DescriptionView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DescriptionView.qml
@@ -13,9 +13,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
 
 Rectangle {
     visible: SampleManager.currentMode === SampleManager.DescriptionView

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -13,12 +13,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.0
-import Telemetry 1.0
-import QtGraphicalEffects 1.0
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.3
-import QtQuick.Layouts 1.0
+import QtQuick
+import Telemetry
+import Qt5Compat.GraphicalEffects
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     id: dialogComponent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/LiveSampleView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/LiveSampleView.qml
@@ -13,8 +13,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import Esri.ArcGISRuntimeSamples 1.0
+import QtQuick
+import Esri.ArcGISRuntimeSamples
 
 Loader {
     anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ManageOfflineDataView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ManageOfflineDataView.qml
@@ -13,12 +13,12 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.2
-import Esri.ArcGISRuntimeSamples 1.0
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Dialogs
+import QtQuick.Layouts
+import Esri.ArcGISRuntimeSamples
+import Esri.ArcGISExtras
 
 Page {
     id: manageOfflineDataViewPage

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/NetworkRequiredView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/NetworkRequiredView.qml
@@ -13,10 +13,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
+import Esri.ArcGISExtras
 
 Page {
     visible: SampleManager.currentMode === SampleManager.NetworkRequiredView

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
@@ -13,11 +13,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtGraphicalEffects 1.0
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.3
-import Esri.ArcGISRuntimeSamples 1.0
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
 
 Item {
     id: dialogComponent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/QmlAuthenticationView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/QmlAuthenticationView.qml
@@ -13,7 +13,7 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
+import QtQuick
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
@@ -13,10 +13,10 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.7
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
-import Telemetry 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
+import Telemetry
 
 Page {
     id: sampleListView

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchBar.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchBar.qml
@@ -13,8 +13,8 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.9
-import QtQuick.Controls 2.2
+import QtQuick
+import QtQuick.Controls
 
 TextField {
     id: searchBar

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchView.qml
@@ -13,11 +13,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.9
+import QtQuick
 
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
-import Telemetry 1.0
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
+import Telemetry
 
 ListView {
     spacing: 10

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
@@ -13,10 +13,9 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import Esri.ArcGISRuntimeSamples 1.0
-import QtQuick.Controls.Material 2.12
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
 
 Rectangle {
     visible: SampleManager.currentMode === SampleManager.SourceCodeView

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/_Imports.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/_Imports.qml
@@ -13,15 +13,14 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.1
-import QtQuick.Window 2.0
-import QtSensors 5.3
-import QtPositioning 5.3
-import QtQuick.XmlListModel 2.0
-import Esri.ArcGISExtras 1.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import QtSensors
+import QtPositioning
+import QtQuick.XmlListModel
+import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit
 
 Item {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -13,12 +13,11 @@
 // limitations under the License.
 // [Legal]
 
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.1
-import Esri.ArcGISRuntimeSamples 1.0
-import Esri.ArcGISExtras 1.1
-import Telemetry 1.0
+import QtQuick
+import QtQuick.Controls
+import Esri.ArcGISRuntimeSamples
+import Esri.ArcGISExtras
+import Telemetry
 
 ApplicationWindow {
     id: window


### PR DESCRIPTION
# Description

Because Qt 6 does not require version numbers when importing QML modules, this PR removes all numbers after import statements in .qml files. I checked for and removed duplicate import statements too after removing (ex QtQuick.Controls 1.0 and QtQuick.Controls 1.6).

I searched the samples repo with this RegEx `(import )([^\s]*)([ |\d])` and then ran a find and replace for any modules with version numbers that removed said numbers.
I then checked for any duplicate imports with: `(import .*\n)(\n|.)*(\1)`

## Type of change

- [x] Other enhancement