### PR TITLE
Remove TTS from QML sample

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -20,7 +20,6 @@ import Esri.ArcGISRuntime
 import QtQuick.Layouts
 import QtPositioning
 import Esri.ArcGISExtras
-import Esri.Samples
 
 Rectangle {
     id: rootRectangle
@@ -239,20 +238,21 @@ Rectangle {
             }
         }
 
-        // Output new voice guidance
-        onNewVoiceGuidanceResultChanged: {
-            speaker.textToSpeech(newVoiceGuidanceResult.text);
-        }
+        //        // Output new voice guidance
+        //        onNewVoiceGuidanceResultChanged: {
+        //            speaker.textToSpeech(newVoiceGuidanceResult.text);
+        //        }
 
-        // Set a callback to indicate if the speech engine is ready to speak
-        speechEngineReadyCallback: function() {
-            return speaker.textToSpeechEngineReady();
-        }
+        //        // Set a callback to indicate if the speech engine is ready to speak
+        //        speechEngineReadyCallback: function() {
+        //            return speaker.textToSpeechEngineReady();
+        //        }
     }
 
-    NavigateRouteSpeaker {
-        id: speaker
-    }
+    // NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
+    //    NavigateRouteSpeaker {
+    //        id: speaker
+    //    }
 
     function startNavigation() {
         // Solve the route with the default parameters
@@ -284,8 +284,8 @@ Rectangle {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse.accepted = true;
-            onWheel: wheel.accepted = true;
+            onPressed: mouse => mouse.accepted = true;
+            onWheel: wheel => wheel.accepted = true;
         }
 
         Column {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.cpp
@@ -15,11 +15,13 @@
 // [Legal]
 
 #include "NavigateRouteSpeaker.h"
-#include <QTextToSpeech>
+
+// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
+// #include <QTextToSpeech>
 
 NavigateRouteSpeaker::NavigateRouteSpeaker(QObject* parent):
-  QObject(parent),
-  m_speaker(new QTextToSpeech(this))
+  QObject(parent)/*,
+  m_speaker(new QTextToSpeech(this))*/
 {
 }
 
@@ -27,10 +29,11 @@ NavigateRouteSpeaker::~NavigateRouteSpeaker() = default;
 
 void NavigateRouteSpeaker::textToSpeech(const QString& text)
 {
-  m_speaker->say(text);
+  // m_speaker->say(text);
 }
 
 bool NavigateRouteSpeaker::textToSpeechEngineReady() const
 {
-  return m_speaker->state() == QTextToSpeech::State::Ready;
+  return false;
+  // return m_speaker->state() == QTextToSpeech::State::Ready;
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.h
@@ -19,7 +19,8 @@
 
 #include <QObject>
 
-class QTextToSpeech;
+// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
+// class QTextToSpeech;
 class NavigateRouteSpeaker : public QObject
 {
   Q_OBJECT
@@ -31,8 +32,8 @@ public:
   Q_INVOKABLE void textToSpeech(const QString& text);
   Q_INVOKABLE bool textToSpeechEngineReady() const;
 
-private:
-  QTextToSpeech* m_speaker = nullptr;
+  // private:
+  //   QTextToSpeech* m_speaker = nullptr;
 };
 
 #endif // NAVIGATEROUTESPEAKER_H


### PR DESCRIPTION
# Description

I somehow missed getting rid of the TTS from the QML sample, so here that is again.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS