### PR TITLE
Fix null width warnings

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -89,7 +89,7 @@ DisplayGridSample {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: mouse.accepted = true;
+            onClicked: (mouse) => mouse.accepted = true;
         }
     }
 
@@ -129,7 +129,7 @@ DisplayGridSample {
             ComboBox {
                 id: gridTypeComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [latlonGrid, mgrsGrid, utmGrid, usngGrid]
@@ -181,7 +181,7 @@ DisplayGridSample {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "white", "blue"]
@@ -206,7 +206,7 @@ DisplayGridSample {
             ComboBox {
                 id: colorCombo2
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "black", "blue"]
@@ -232,7 +232,7 @@ DisplayGridSample {
             ComboBox {
                 id: positionCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [geographicPosition, bottomLeftPosition, bottomRightPosition, topLeftPosition, topRightPosition, centerPosition, allSidesPosition]
@@ -259,7 +259,7 @@ DisplayGridSample {
             ComboBox {
                 id: formatCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [ddFormat, dmsFormat]

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -89,7 +89,7 @@ DisplayGridSample {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: (mouse) => mouse.accepted = true;
+            onClicked: mouse => mouse.accepted = true;
         }
     }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -46,7 +46,7 @@ SpatialOperationsSample {
             margins: 10
         }
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
         model: geometryOperations
         onCurrentIndexChanged: applyGeometryOperation(currentIndex);
         Component.onCompleted : {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -132,7 +132,7 @@ BlendRasterLayerSample {
             ComboBox {
                 id: slopeCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel
@@ -155,7 +155,7 @@ BlendRasterLayerSample {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.fillWidth: true
                 textRole: "name"
                 model: colorRampModel

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
@@ -43,7 +43,7 @@ DisplayKmlSample {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
 
         model: ["URL", "Local file", "Portal Item"]
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -95,7 +95,7 @@ Rectangle {
             ComboBox {
                 id: slopeBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: HillshadeSlopeTypeModel{}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -115,7 +115,7 @@ RasterRgbRendererSample {
 
             model: stretchTypes
             property int modelWidth: 0
-            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+            Layout.minimumWidth: modelWidth + leftPadding + rightPadding
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -92,7 +92,7 @@ RasterStretchRendererSample {
                 anchors.horizontalCenter: parent.horizontalCenter
                 model: stretchTypes
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -43,7 +43,7 @@ VectorTiledLayerUrlSample {
             margins: 15
         }
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova","World Street Map (Night)"]
         onCurrentTextChanged: {
             // Call C++ invokable function to switch the basemaps

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -18,7 +18,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Esri.Samples
-import Esri.ArcGISRuntime.Toolkit
 
 GenerateOfflineMap_OverridesSample {
     id: offlineMapOverridesSample
@@ -26,9 +25,9 @@ GenerateOfflineMap_OverridesSample {
     width: 800
     height: 600
 
-    onUpdateStatus: generateWindow.statusText = status;
-    onUpdateProgress: generateWindow.progressText = progress;
-    onHideWindow: {
+    onUpdateStatus: status => generateWindow.statusText = status;
+    onUpdateProgress: progress => generateWindow.progressText = progress;
+    onHideWindow: (time, success) => {
         generateWindow.hideWindow(time);
 
         if (success) {
@@ -88,11 +87,11 @@ GenerateOfflineMap_OverridesSample {
         anchors.fill: parent
         visible: overridesReady
 
-        onBasemapLODSelected: setBasemapLOD(min, max);
-        onBasemapBufferChanged: setBasemapBuffer(buffer);
+        onBasemapLODSelected: (min, max) => setBasemapLOD(min, max);
+        onBasemapBufferChanged: (buffer) => setBasemapBuffer(buffer);
         onRemoveSystemValvesChanged: removeSystemValves();
         onRemoveServiceConnectionChanged: removeServiceConnection();
-        onHydrantWhereClauseChanged: setHydrantWhereClause(whereClause);
+        onHydrantWhereClauseChanged: (whereClause) => setHydrantWhereClause(whereClause);
         onClipWaterPipesAOIChanged: setClipWaterPipesAOI(clip);
         onOverridesAccepted: {
             generateWindow.visible = true;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -35,7 +35,7 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
-        onClicked: mouse.accepted = true
+        onClicked: mouse => mouse.accepted = true
         onWheel: wheel.accepted = true
     }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -210,7 +210,7 @@ Rectangle {
                     horizontalCenter: parent.horizontalCenter
                 }
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding
                 model: [ "No filter", "FLOW < 500", "FLOW < 300", "FLOW < 100" ]
 
                 onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -82,7 +82,7 @@ ManageBookmarksSample {
             margins: 15
         }
         property int bestWidth: implicitWidth
-        width: bestWidth + indicator.width + leftPadding + rightPadding
+        width: bestWidth + leftPadding + rightPadding
         // Set the model to the BookmarkListModel
         model: manageBookmarksSample.bookmarks
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -98,7 +98,7 @@ ServiceAreaSample {
             model: ["Facility", "Barrier"]
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding + indicator.width
+            width: modelWidth + leftPadding + rightPadding
 
             onCurrentTextChanged: {
                 if (currentText === "Facility")
@@ -138,6 +138,7 @@ ServiceAreaSample {
 
     Dialog {
         modal: true
+        width: parent.width / 4
         x: Math.round(parent.width - width) / 2
         y: Math.round(parent.height - height) / 2
         standardButtons: Dialog.Ok

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -65,7 +65,7 @@ Animate3DSymbolsSample {
                 model: missionsModel
                 textRole: "display"
                 property real modelWidth: 0
-                Layout.minimumWidth: leftPadding + rightPadding + indicator.width + modelWidth
+                Layout.minimumWidth: leftPadding + rightPadding + modelWidth
 
                 onModelChanged: {
                     for (let i = 0; i < missionsModel.rowCount(); ++i) {
@@ -168,7 +168,7 @@ Animate3DSymbolsSample {
 
                     MouseArea {
                         anchors.fill: parent
-                        onPressed: mouse.accepted
+                        onPressed: mouse => mouse.accepted
                         onWheel: wheel.accepted
                     }
                 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
@@ -23,7 +23,7 @@ Slider {
             radius: 3
             x: handleNub.x - width / 2 + handleNub.width / 2
             y: handleNub.y - handleNub.height * 2
-            color: progressSlider.background.children[0].color
+            color: "purple"
             Text {
                 id: handleText
                 padding: 3

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
@@ -23,7 +23,7 @@ Slider {
             radius: 3
             x: handleNub.x - width / 2 + handleNub.width / 2
             y: handleNub.y - handleNub.height * 2
-            color: "purple"
+            color: progressSlider.background.children[0].color
             Text {
                 id: handleText
                 padding: 3


### PR DESCRIPTION
# Description

This PR primarily removes the code to get the width of a null property which was causing warnings in Qt 6. I also made a few modifications to address other type errors to these samples. 

In one instance there was an error pertaining to using an implicit width, which declaring the width explicitly resolved.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
