### PR TITLE
updating to avoid ambiguous type

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
@@ -15,7 +15,7 @@
 // [Legal]
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Controls as Controls
 import Esri.Samples
 import QtQuick.Layouts
 
@@ -31,7 +31,7 @@ Item {
             forceActiveFocus();
         }
 
-        Button {
+        Controls.Button {
             id: directionsButton
             anchors {
                 bottom: parent.bottom
@@ -43,13 +43,13 @@ Item {
             onClicked: popup.open();
         }
 
-        Popup {
+        Controls.Popup {
             id: popup
-            anchors.centerIn: Overlay.overlay
+            anchors.centerIn: Controls.Overlay.overlay
             width: 300
             height: 320
             focus: true
-            contentItem: ScrollView {
+            contentItem: Controls.ScrollView {
                 contentWidth: parent.width - 30
                 Text {
                     width: parent.width

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -28,7 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayRouteLayer - C++"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.qml
@@ -15,9 +15,9 @@
 // [Legal]
 
 import QtQuick
-import Esri.ArcGISRuntime
-import QtQuick.Controls
+import QtQuick.Controls as Controls
 import QtQuick.Layouts
+import Esri.ArcGISRuntime
 
 Rectangle {
     id: rootRectangle
@@ -87,7 +87,7 @@ Rectangle {
         // Specify the scale
         targetScale: 800000
     }
-    Button {
+    Controls.Button {
         text: "Directions"
         anchors {
             bottom: parent.bottom
@@ -100,13 +100,13 @@ Rectangle {
         }
     }
 
-    Popup {
+    Controls.Popup {
         id: popup
-        anchors.centerIn: Overlay.overlay
+        anchors.centerIn: Controls.Overlay.overlay
         width: 300
         height: 320
         focus: true
-        contentItem: ScrollView {
+        contentItem: Controls.ScrollView {
             contentWidth: parent.width - 30
             Text {
                 width: parent.width

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/main.cpp
@@ -22,7 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayRouteLayer - QML"));
 


### PR DESCRIPTION
# Description

@jared-2016 please review. Popup is ambiguous since there is a Control's Popup and an ArcGIS Popup. Scoping it resolves the issue. Unnecessary for C++, but adding it there as well to avoid confusion. Additionally, removing high DPI call which is obsolete now with Qt 6.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
