### PR TITLE
James/explicit base ctors

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -120,7 +120,8 @@ void Geotriggers::initializeSimulatedLocationDisplay()
   SimulationParameters* simulationParameters = new SimulationParameters(QDateTime::currentDateTime(), 5.0, 0.0, 0.0, this);
 
   // Use the polyline as defined above or from this AGOL GeoJSON to define the path. retrieved from https://https://arcgisruntime.maps.arcgis.com/home/item.html?id=2a346cf1668d4564b8413382ae98a956
-  m_simulatedLocationDataSource->setLocationsWithPolyline(Polyline::fromJson(walkingTourPolyineJson), simulationParameters);
+  m_simulatedLocationDataSource->setLocationsWithPolyline(
+        geometry_cast<Polyline>(Polyline::fromJson(walkingTourPolyineJson)), simulationParameters);
 
   m_mapView->locationDisplay()->setDataSource(m_simulatedLocationDataSource);
   m_mapView->locationDisplay()->setAutoPanMode(LocationDisplayAutoPanMode::Recenter);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
@@ -191,7 +191,7 @@ void ViewshedGeoElement::animate()
     return;
 
   // get current location and distance from waypoint
-  Point location = m_tank->geometry();
+  Point location = geometry_cast<Point>(m_tank->geometry());
   const GeodeticDistanceResult distance = GeometryEngine::distanceGeodetic(location, m_waypoint,
                                                                            m_linearUnit, m_angularUnit,
                                                                            m_curveType);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.cpp
@@ -140,7 +140,7 @@ void AddGraphicsWithRenderer::addEllipseGraphic()
   parameters.setLinearUnit(LinearUnit(LinearUnitId::Kilometers));
   parameters.setMaxSegmentLength(20);
 
-  const Polygon ellipsePolygon = GeometryEngine::ellipseGeodesic(parameters);
+  const Polygon ellipsePolygon = geometry_cast<Polygon>(GeometryEngine::ellipseGeodesic(parameters));
 
   SimpleFillSymbol* ellipseSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor(125, 0, 125), this);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/GOSymbols.cpp
@@ -184,7 +184,7 @@ void GOSymbols::addBoatTrip(GraphicsOverlay* graphicsOverlay)
                          "\"spatialReference\":{\"wkid\":4326}}";
 
   // create a polyline from the json
-  Esri::ArcGISRuntime::Polyline polyline = Polyline::fromJson(polylineJson);
+  Polyline polyline = geometry_cast<Polyline>(Polyline::fromJson(polylineJson));
   // create a new graphic using the polyline geometry
   Graphic* graphic = new Graphic(polyline, this);
   // set the symbology for the graphic

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
@@ -216,7 +216,7 @@ void EditAndSyncFeatures::generateGeodatabaseFromCorners(double xCorner1, double
   const Point corner1 = m_mapView->screenToLocation(xCorner1, yCorner1);
   const Point corner2 = m_mapView->screenToLocation(xCorner2, yCorner2);
   const Envelope extent(corner1, corner2);
-  const Geometry geodatabaseExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
+  const Envelope geodatabaseExtent = geometry_cast<Envelope>(GeometryEngine::project(extent, SpatialReference::webMercator()));
 
   // get the updated parameters
   GenerateGeodatabaseParameters params = getGenerateParameters(geodatabaseExtent);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
@@ -194,7 +194,7 @@ void EditFeaturesWithFeatureLinkedAnnotation::onIdentifyLayersCompleted(QUuid, c
 
         if (selectedFeatureGeomType == GeometryType::Polyline)
         {
-          const Geometry geom = m_selectedFeature->geometry();
+          const Polyline geom = geometry_cast<Polyline>(m_selectedFeature->geometry());
           const PolylineBuilder polylineBuilder(geom);
 
           // if the selected feature is a polyline with any part containing more than one segment
@@ -246,7 +246,7 @@ void EditFeaturesWithFeatureLinkedAnnotation::moveFeature(Point mapPoint)
   {
     // get nearest vertex to the map point on the selected polyline
     const ProximityResult nearestVertex = GeometryEngine::nearestVertex(geom, projectedMapPoint);
-    const PolylineBuilder polylineBuilder(geom);
+    const PolylineBuilder polylineBuilder(geometry_cast<Polyline>(geom));
 
     // get part of polyline nearest to map point
     Part* part = polylineBuilder.parts()->part(nearestVertex.partIndex());

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
@@ -349,7 +349,7 @@ void EditWithBranchVersioning::moveFeature(const Point& mapPoint)
     clearSelectedFeature();
     return;
   }
-  const Polyline geom = m_selectedFeature->geometry();
+  const Polyline geom = geometry_cast<Polyline>(m_selectedFeature->geometry());
   m_selectedFeature->setGeometry(mapPoint);
 
   // update the selected feature with the new geometry

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.cpp
@@ -186,7 +186,7 @@ void GenerateGeodatabaseReplicaFromFeatureService::generateGeodatabaseFromCorner
   const Point corner1 = m_mapView->screenToLocation(xCorner1, yCorner1);
   const Point corner2 = m_mapView->screenToLocation(xCorner2, yCorner2);
   const Envelope extent(corner1, corner2);
-  const Geometry geodatabaseExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
+  const Envelope geodatabaseExtent = geometry_cast<Envelope>(GeometryEngine::project(extent, SpatialReference::webMercator()));
 
   // get the updated parameters
   GenerateGeodatabaseParameters params = getUpdatedParameters(geodatabaseExtent);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/CutGeometry.cpp
@@ -73,7 +73,8 @@ void CutGeometry::componentComplete()
 void CutGeometry::cutPolygon()
 {
   // perform the cut
-  QList<Geometry> geoms = GeometryEngine::cut(m_lakeSuperiorGraphic->geometry(), m_borderGraphic->geometry());
+  QList<Geometry> geoms = GeometryEngine::cut(m_lakeSuperiorGraphic->geometry(),
+                                              geometry_cast<Polyline>(m_borderGraphic->geometry()));
 
   // create graphics for the U.S. side
   SimpleLineSymbol* outline = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor("blue"), 1.0f, this);
@@ -147,7 +148,7 @@ Polygon CutGeometry::createLakeSuperiorPolygon()
   polygonBuilder->addPoint(-10111283.079633, 5933406.315128);
   polygonBuilder->addPoint(-10214761.742852, 5888134.399970);
   polygonBuilder->addPoint(-10254374.668616, 5901877.659929);
-  return polygonBuilder->toGeometry();
+  return polygonBuilder->toPolygon();
 }
 
 // Create the U.S./Canada Border Polyline
@@ -161,5 +162,5 @@ Polyline CutGeometry::createBorderPolyline()
   polylineBuilder->addPoint(-9446115.050097, 5927209.572793);
   polylineBuilder->addPoint(-9430885.393759, 5876081.440801);
   polylineBuilder->addPoint(-9415655.737420, 5860851.784463);
-  return polylineBuilder->toGeometry();
+  return polylineBuilder->toPolyline();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.cpp
@@ -110,17 +110,17 @@ void DensifyAndGeneralize::updateGeometry(bool densify, double maxSegmentLength,
     return;
 
   // Get the initial Geometry
-  Polyline polyline = m_originalLineGraphic->geometry();
+  Polyline polyline = geometry_cast<Polyline>(m_originalLineGraphic->geometry());
   if (polyline.isEmpty())
     return;
 
   // Generalize the polyline
   if (generalize)
-    polyline = GeometryEngine::generalize(polyline, maxDeviation, true);
+    polyline = geometry_cast<Polyline>(GeometryEngine::generalize(polyline, maxDeviation, true));
 
   // Densify the polyline
   if (densify)
-    polyline = GeometryEngine::densify(polyline, maxSegmentLength);
+    polyline = geometry_cast<Polyline>(GeometryEngine::densify(polyline, maxSegmentLength));
 
   // Update the line graphic
   m_resultLineGraphic->setGeometry(polyline);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
@@ -86,7 +86,7 @@ void GeodesicOperations::componentComplete()
   {
     // re-project the point to match the NYC graphic
     const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    const Point destination = GeometryEngine::project(clickedPoint, m_nycGraphic->geometry().spatialReference());
+    const Point destination = geometry_cast<Point>(GeometryEngine::project(clickedPoint, m_nycGraphic->geometry().spatialReference()));
 
     // update the destination graphic
     m_destinationGraphic->setGeometry(destination);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
@@ -136,7 +136,7 @@ void NearestVertex::setupGraphics()
   {
     const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     // normalizing the geometry before performing geometric operations
-    const Geometry normalizedPoint = GeometryEngine::normalizeCentralMeridian(clickedLocation);
+    const Point normalizedPoint = geometry_cast<Point>(GeometryEngine::normalizeCentralMeridian(clickedLocation));
 
     clickedLocationGraphic->setGeometry(normalizedPoint);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
@@ -94,7 +94,7 @@ void ProjectGeometry::onMouseClicked(QMouseEvent& event)
   const SpatialReference spatialReference(4326);
 
   // project the web mercator point to WGS84
-  const Point projectedPoint = GeometryEngine::project(originalPoint, spatialReference);
+  const Point projectedPoint = geometry_cast<Point>(GeometryEngine::project(originalPoint, spatialReference));
 
   // update callout data
   m_calloutData->setLocation(originalPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
@@ -72,7 +72,7 @@ void SpatialRelationships::componentComplete()
   addGraphics();
 
   // Set viewpoint
-  m_mapView->setViewpointCenter(m_pointGraphic->geometry(), 200000000);
+  m_mapView->setViewpointCenter(geometry_cast<Point>(m_pointGraphic->geometry()), 200000000);
 
   // connect signals
   connectSignals();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -92,7 +92,7 @@ void GenerateOfflineMap::generateMapByExtent(double xCorner1, double yCorner1, d
   const Point corner1 = m_mapView->screenToLocation(xCorner1, yCorner1);
   const Point corner2 = m_mapView->screenToLocation(xCorner2, yCorner2);
   const Envelope extent = Envelope(corner1, corner2);
-  const Envelope mapExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
+  const Envelope mapExtent = geometry_cast<Envelope>(GeometryEngine::project(extent, SpatialReference::webMercator()));
 
   // connect to the signal for when the default parameters are generated
   connect(m_offlineMapTask, &OfflineMapTask::createDefaultGenerateOfflineMapParametersCompleted,

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
@@ -119,7 +119,7 @@ void GenerateOfflineMapLocalBasemap::generateMapByExtent(double xCorner1, double
   const Point corner1 = m_mapView->screenToLocation(xCorner1, yCorner1);
   const Point corner2 = m_mapView->screenToLocation(xCorner2, yCorner2);
   const Envelope extent = Envelope(corner1, corner2);
-  const Envelope mapExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
+  const Envelope mapExtent = geometry_cast<Envelope>(GeometryEngine::project(extent, SpatialReference::webMercator()));
   const QString tempPath = m_tempDir.path() + "/OfflineMap.mmpk";
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/tpkx";
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -116,7 +116,7 @@ void GenerateOfflineMap_Overrides::setAreaOfInterest(double xCorner1, double yCo
   const Point corner1 = m_mapView->screenToLocation(xCorner1, yCorner1);
   const Point corner2 = m_mapView->screenToLocation(xCorner2, yCorner2);
   const Envelope extent(corner1, corner2);
-  const Envelope mapExtent = GeometryEngine::project(extent, SpatialReference::webMercator());
+  const Envelope mapExtent = geometry_cast<Envelope>(GeometryEngine::project(extent, SpatialReference::webMercator()));
 
   // generate parameters
   m_offlineMapTask->createDefaultGenerateOfflineMapParameters(mapExtent);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
@@ -291,7 +291,7 @@ void MobileMap_SearchAndRoute::selectMap(int index)
         if (m_currentRouteTask)
         {
           // create a stop based on added graphic
-          m_stops << Stop(bluePinGraphic->geometry());
+          m_stops << Stop(geometry_cast<Point>(bluePinGraphic->geometry()));
 
           // create a Text Symbol to display stop number
           TextSymbol* textSymbol = new TextSymbol(m_stopGraphicParent);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.cpp
@@ -113,7 +113,7 @@ void ShowLocationHistory::handleLocationChanges()
 {
   SimulationParameters* simulationParameters = new SimulationParameters(QDateTime::currentDateTime(), 30.0, 0.0, 0.0, this); // set speed
 
-  m_simulatedLocationDataSource->setLocationsWithPolyline(Polyline::fromJson(polylineJson), simulationParameters);
+  m_simulatedLocationDataSource->setLocationsWithPolyline(geometry_cast<Polyline>(Geometry::fromJson(polylineJson)), simulationParameters);
 
   m_mapView->locationDisplay()->setDataSource(m_simulatedLocationDataSource);
   m_mapView->locationDisplay()->setAutoPanMode(LocationDisplayAutoPanMode::Recenter);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/FindRoute.cpp
@@ -184,9 +184,9 @@ void FindRoute::solveRoute()
       m_routeParameters.clearStops();
 
       // set the stops to the parameters
-      Stop stop1(m_stopsGraphicsOverlay->graphics()->at(0)->geometry());
+      Stop stop1(geometry_cast<Point>(m_stopsGraphicsOverlay->graphics()->at(0)->geometry()));
       stop1.setName("Origin");
-      Stop stop2(m_stopsGraphicsOverlay->graphics()->at(1)->geometry());
+      Stop stop2(geometry_cast<Point>(m_stopsGraphicsOverlay->graphics()->at(1)->geometry()));
       stop2.setName("Destination");
       m_routeParameters.setStops(QList<Stop> { stop1, stop2 });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.cpp
@@ -251,7 +251,7 @@ void NavigateARouteWithRerouting::startNavigation()
   // add a data source for the location display
   SimulationParameters* simulationParameters = new SimulationParameters(QDateTime::currentDateTime(), velocity, horizontalAccuracy, verticalAccuracy, this);
   m_simulatedLocationDataSource = new SimulatedLocationDataSource(this);
-  m_simulatedLocationDataSource->setLocationsWithPolyline(Polyline::fromJson(tourPolyineJson), simulationParameters);
+  m_simulatedLocationDataSource->setLocationsWithPolyline(geometry_cast<Polyline>(Geometry::fromJson(tourPolyineJson)), simulationParameters);
   m_mapView->locationDisplay()->setDataSource(m_simulatedLocationDataSource);
   m_simulatedLocationDataSource->start();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -260,7 +260,7 @@ void OfflineRouting::findRoute()
     QList<Stop> stops;
     for (const Graphic* graphic : *m_stopsOverlay->graphics())
     {
-      stops << Stop(graphic->geometry());
+      stops << Stop(geometry_cast<Point>(graphic->geometry()));
     }
 
     // configure stops and travel mode

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
@@ -115,7 +115,7 @@ void ServiceArea::solveServiceArea()
     if (!g)
       continue;
 
-    facilities.append(ServiceAreaFacility(g->geometry()));
+    facilities.append(ServiceAreaFacility(geometry_cast<Point>(g->geometry())));
   }
   m_parameters.setFacilities(facilities);
 
@@ -128,7 +128,7 @@ void ServiceArea::solveServiceArea()
     if (!g)
       continue;
 
-    barriers.append(PolylineBarrier(g->geometry()));
+    barriers.append(PolylineBarrier(geometry_cast<Polyline>(g->geometry())));
   }
 
   if (!barriers.isEmpty())

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.cpp
@@ -130,9 +130,9 @@ void ExtrudeGraphics::componentComplete()
 }
 
 // helper to create polygon from points
-Esri::ArcGISRuntime::Polygon ExtrudeGraphics::createPolygonFromPoints(QList<Point> points)
+Polygon ExtrudeGraphics::createPolygonFromPoints(QList<Point> points)
 {
-  Esri::ArcGISRuntime::Polygon polygon;
+  Polygon polygon;
   if (points.length() == 0)
     return polygon;
 
@@ -143,6 +143,6 @@ Esri::ArcGISRuntime::Polygon ExtrudeGraphics::createPolygonFromPoints(QList<Poin
     // add each point to the builder object
     pb->addPoint(point);
   }
-  return polygon = pb->toGeometry();
+  return polygon = pb->toPolygon();
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -381,7 +381,7 @@ void PerformValveIsolationTrace::connectSignals()
   {
     // display starting location
     ArcGISFeatureListModel* elementFeaturesList = m_utilityNetwork->featuresForElementsResult();
-    const Point startingLocationGeometry = elementFeaturesList->first()->geometry();
+    const Point startingLocationGeometry = geometry_cast<Point>(elementFeaturesList->first()->geometry());
     Graphic* graphic = new Graphic(startingLocationGeometry, m_graphicParent.get());
     m_startingLocationOverlay->graphics()->append(graphic);
 
@@ -436,7 +436,7 @@ void PerformValveIsolationTrace::onIdentifyLayersCompleted(QUuid, const QList<Id
   {
     if (feature->geometry().geometryType() == GeometryType::Polyline)
     {
-      const Polyline line = GeometryEngine::removeZ(feature->geometry());
+      const Polyline line = geometry_cast<Polyline>(GeometryEngine::removeZ(feature->geometry()));
       // Set how far the element is along the edge.
       const double fraction = GeometryEngine::fractionAlong(line, m_clickPoint, -1);
       m_element->setFractionAlongEdge(fraction);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -360,7 +360,7 @@ void TraceUtilityNetwork::onIdentifyLayersCompleted(QUuid, const QList<IdentifyL
     // Compute how far tapped location is along the edge feature.
     if (m_feature->geometry().geometryType() == GeometryType::Polyline)
     {
-      const Polyline line = GeometryEngine::removeZ(m_feature->geometry());
+      const Polyline line = geometry_cast<Polyline>(GeometryEngine::removeZ(m_feature->geometry()));
       // Set how far the element is along the edge.
       element->setFractionAlongEdge(GeometryEngine::fractionAlong(line, m_clickPoint, -1));
       m_fractionAlongEdge = element->fractionAlongEdge();

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -47,7 +47,7 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
 } else {
   message("Building against the installed SDK")
   CONFIG += build_from_setup
-  CONFIG += c++14
+  CONFIG += c++17
 
   # include the toolkitcpp.pri, which contains all the toolkit resources
   !include($$PWD/../../arcgis-runtime-toolkit-qt/uitools/toolkitcpp.pri) {


### PR DESCRIPTION
# Description

We are soon to mark these API constructors explicit so the code will no longer compiler as-is. It is possible to use `static_cast` or our own `geometry_cast`. Since our version does extra checking, I've opted for that version throughout. These changes can go in now. `geometry_cast` has been around for years.

I also noticed we were specifying C++14, which is not supported with Qt 6. Quick fix added for that as well.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [X] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
