### PR TITLE
Make doubled comments single

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.cpp
@@ -215,7 +215,7 @@ void NavigateARouteWithRerouting::startNavigation()
 
   connectRouteTrackerSignals();
 
-  //  // enable the RouteTracker to know when the QTextToSpeech engine is ready
+  // enable the RouteTracker to know when the QTextToSpeech engine is ready
   //  m_routeTracker->setSpeechEngineReadyFunction([speaker = m_speaker]() -> bool
   //  {
   //    return speaker->state() == QTextToSpeech::State::Ready;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -238,12 +238,12 @@ Rectangle {
             }
         }
 
-        //        // Output new voice guidance
+        // Output new voice guidance
         //        onNewVoiceGuidanceResultChanged: {
         //            speaker.textToSpeech(newVoiceGuidanceResult.text);
         //        }
 
-        //        // Set a callback to indicate if the speech engine is ready to speak
+        // Set a callback to indicate if the speech engine is ready to speak
         //        speechEngineReadyCallback: function() {
         //            return speaker.textToSpeechEngineReady();
         //        }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
@@ -262,19 +262,19 @@ Rectangle {
                 }
             }
 
-//            // output new voice guidance
+// output new voice guidance
 //            onNewVoiceGuidanceResultChanged: {
 //                speaker.textToSpeech(newVoiceGuidanceResult.text);
 //            }
 
-//            // set a callback to indicate if the speech engine is ready to speak
+// set a callback to indicate if the speech engine is ready to speak
 //            speechEngineReadyCallback: function() {
 //                return speaker.textToSpeechEngineReady();
 //            }
         }
     }
 
-//    // NOTE: As of Qt 6.2, QTextToSpeech is not supported. Uses of this class have been commented out for compatibility, but remain for reference
+// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Uses of this class have been commented out for compatibility, but remain for reference
 //    NavigateRouteSpeaker {
 //        id: speaker
 //    }


### PR DESCRIPTION
# Description

I accidentally included comments when commenting out text-to-speech code. This PR reverts those changes.