### PR TITLE
enable opengl in samples

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -80,6 +80,9 @@ int main(int argc, char *argv[])
 
   Esri::ArcGISRuntime::Toolkit::ArcGISArView::qmlRegisterTypes();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ExploreScenesInFlyoverAR::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   AnalyzeHotspots::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   AnalyzeViewshed::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -64,6 +64,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DistanceMeasurementAnalysis::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Geotriggers::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -69,7 +69,10 @@ int main(int argc, char *argv[])
     arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -70,9 +70,9 @@ int main(int argc, char *argv[])
 #endif
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   LineOfSightLocation::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   StatisticalQuery::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   StatisticalQueryGroupSort::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ViewshedCamera::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ViewshedGeoElement::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ViewshedLocation::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   AddItemsToPortal::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   PortalUserInfo::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SearchForWebmap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowOrgBasemaps::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   TokenAuthentication::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   AddGraphicsWithRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   BuildLegend::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -60,7 +60,10 @@ int main(int argc, char *argv[])
     arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -61,9 +61,9 @@ int main(int argc, char *argv[])
 #endif
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   CreateSymbolStylesFromWebStyles::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayGrid::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GODictionaryRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GODictionaryRenderer_3D::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GOSymbols::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   IdentifyGraphics::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Picture_Marker_Symbol::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -40,6 +40,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   QueryFeaturesWithArcadeExpression::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowCallout::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowLabelsOnLayers::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowPopup::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Simple_Marker_Symbol::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Simple_Renderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SketchOnMap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SymbolizeShapefile::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Unique_Value_Renderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   AddFeaturesFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ContingentValues::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -56,6 +56,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DeleteFeaturesFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   EditAndSyncFeatures::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   EditFeatureAttachments::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   EditFeaturesWithFeatureLinkedAnnotation::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   EditWithBranchVersioning::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -56,6 +56,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   UpdateAttributesFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   UpdateGeometryFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -39,6 +39,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ControlTimeExtentTimeSlider::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   CreateMobileGeodatabase::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerChangeRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
@@ -51,6 +51,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerDictionaryRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerFeatureService/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeoPackage/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayer_GeoPackage::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerGeodatabase/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerGeodatabase::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerQuery::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerSelection::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -61,6 +61,9 @@ int main(int argc, char *argv[])
   //! [Register the mapview for QML]
   //! */
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GenerateGeodatabaseReplicaFromFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample.
   ListRelatedFeatures::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ServiceFeatureTableCache::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ServiceFeatureTableManualCache::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ServiceFeatureTableNoCache::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Buffer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ClipGeometry::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ConvexHull::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   CreateGeometries::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   CutGeometry::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DensifyAndGeneralize::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.cpp
@@ -56,6 +56,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FormatCoordinates::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GeodesicOperations::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ListTransformations::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   NearestVertex::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ProjectGeometry::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SpatialOperations::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SpatialRelationships::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ApplyMosaicRuleToRasters::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ApplyUniqueValuesWithAlternateSymbols::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ArcGISMapImageLayerUrl::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ArcGISTiledLayerUrl::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   BlendRasterLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   BrowseOGCAPIFeatureService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ChangeSublayerRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ChangeSublayerVisibility::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -48,7 +48,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     DisplayAnnotation::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -49,9 +49,9 @@ int main(int argc, char *argv[])
     DisplayAnnotation::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayDimensions::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
@@ -62,7 +62,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     DisplayKml::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
@@ -63,9 +63,9 @@ int main(int argc, char *argv[])
     DisplayKml::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayKmlNetworkLinks::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -49,6 +49,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayOgcApiFeatureCollection::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplaySubtypeFeatureLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ExportTiles::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ExportVectorTiles::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureCollectionLayerFromPortal::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
     //Initialize the sample
     FeatureCollectionLayerQuery::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -54,9 +54,9 @@ int main(int argc, char *argv[])
     FeatureCollectionLayerQuery::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerRenderingModeMap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -61,6 +61,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FeatureLayerRenderingModeScene::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     FeatureLayerShapefile::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerShapefile/main.cpp
@@ -54,9 +54,9 @@ int main(int argc, char *argv[])
     FeatureLayerShapefile::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   //Initialize the sample
   Feature_Collection_Layer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Hillshade_Renderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   IdentifyKmlFeatures::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   IdentifyRasterCell::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ListKmlContents::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   OSM_Layer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   QueryMapImageSublayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   QueryOGCAPICQLFilters::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   //Initialize the sample
   RasterColormapRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   //Initialize the sample
   RasterFunctionFile::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   //Initialize the sample
   RasterFunctionService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   RasterLayerGeoPackage::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   RasterLayerService::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   RasterRenderingRule::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   RasterRgbRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   RasterStretchRenderer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   StyleWmsLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   TileCacheLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   VectorTiledLayerUrl::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   WMTS_Layer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Web_Tiled_Layer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   WmsLayerUrl::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   LocalServerFeatureLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   LocalServerGeoprocessing::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   LocalServerMapImageLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   LocalServerServices::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   BrowseBuildingFloors::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
@@ -39,6 +39,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ChangeBasemap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ChangeViewpoint::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
@@ -36,6 +36,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   CreateAndSaveMap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
  // Initialize the sample
   DisplayDeviceLocation::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayDeviceLocationWithNmeaDataSources::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayDrawingStatus::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayLayerViewDrawState::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   //! [Register the map view for QML]
   */
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -39,6 +39,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayOverviewMap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GenerateOfflineMap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GenerateOfflineMapLocalBasemap::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   GenerateOfflineMap_Overrides::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   IdentifyLayers::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   //! [Register the list model for QML]
   */
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   MapLoaded::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   MapRotation::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   MinMaxScale::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   OpenMapUrl::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -54,7 +54,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     OpenMobileMap_MapPackage::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -55,9 +55,9 @@ int main(int argc, char *argv[])
     OpenMobileMap_MapPackage::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/main.cpp
@@ -52,6 +52,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ReadGeoPackage::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SetInitialMapArea::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SetInitialMapLocation::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SetMapSpatialReference::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SetMaxExtent::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -39,6 +39,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowDeviceLocationUsingIndoorPositioning::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowLocationHistory::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/main.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ShowMagnifier::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   TakeScreenshot::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ClosestFacility::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayRouteLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
@@ -54,7 +54,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     FindRoute::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
@@ -55,9 +55,9 @@ int main(int argc, char *argv[])
     FindRoute::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FindServiceAreasForMultipleFacilities::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   NavigateARouteWithRerouting::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   NavigateRoute::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   OfflineRouting::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   RouteAroundBarriers::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ServiceArea::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
@@ -68,6 +68,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Animate3DSymbols::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   AnimateImagesWithImageOverlay::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
@@ -66,6 +66,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   BasicSceneView::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Display3DLabelsInScene::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplaySceneLayer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DistanceCompositeSymbol::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -65,6 +65,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ExtrudeGraphics::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -62,7 +62,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     FeatureLayerExtrusion::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -63,9 +63,9 @@ int main(int argc, char *argv[])
     FeatureLayerExtrusion::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -69,7 +69,10 @@ int main(int argc, char *argv[])
     arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -70,9 +70,9 @@ int main(int argc, char *argv[])
 #endif
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   OpenScene::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -57,7 +57,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     RealisticLightingAndShadows::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -58,9 +58,9 @@ int main(int argc, char *argv[])
     RealisticLightingAndShadows::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQmlApplicationEngine engine;
     // Add the import Path
     engine.addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SceneLayerSelection::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
@@ -68,6 +68,9 @@ int main(int argc, char *argv[])
   //! [Register the scene view for QML]
   */
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   Symbols::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
 
   TerrainExaggeration::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/main.cpp
@@ -56,6 +56,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   FindAddress::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
@@ -55,7 +55,10 @@ int main(int argc, char *argv[])
     // Initialize the sample
     FindPlace::init();
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
@@ -56,9 +56,9 @@ int main(int argc, char *argv[])
     FindPlace::init();
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/main.cpp
@@ -55,6 +55,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   OfflineGeocode::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ReverseGeocodeOnline::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   SearchDictionarySymbolStyle::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   ConfigureSubnetworkTrace::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   CreateLoadReport::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayContentOfUtilityNetworkContainer::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   DisplayUtilityAssociations::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -49,6 +49,9 @@ int main(int argc, char *argv[])
   // Initialize the sample
   PerformValveIsolationTrace::init();
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -60,6 +60,9 @@ int main(int argc, char *argv[])
   arcGISRuntimeImportPath = arcGISRuntimeImportPath.replace(replaceString, "linux", Qt::CaseSensitive);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
   // Add the import Path

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -66,6 +66,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -61,6 +61,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -35,7 +35,10 @@ int main(int argc, char *argv[])
     QtWebEngine::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -36,9 +36,9 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   QtWebEngine::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
   QtWebEngine::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
     QtWebEngine::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
 QtWebEngine::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -46,6 +46,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -42,6 +42,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -51,6 +51,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -31,6 +31,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/main.cpp
@@ -46,6 +46,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/ContingentValues/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/ContingentValues/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -46,7 +46,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -47,9 +47,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
@@ -47,7 +47,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQmlApplicationEngine engine;
 
     // Add the import Path

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
@@ -48,9 +48,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQmlApplicationEngine engine;
 
     // Add the import Path

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -46,7 +46,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -47,9 +47,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -31,6 +31,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
@@ -42,7 +42,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
@@ -43,9 +43,9 @@ int main(int argc, char *argv[])
   }
 
     // Enable OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
+    qputenv("QSG_RHI_BACKEND", "opengl");
 
-  // Initialize application view
+    // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_FeatureService/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geodatabase/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
@@ -49,6 +49,9 @@ int main(int argc, char *argv[])
   QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
 #endif
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/main.cpp
@@ -46,6 +46,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -45,6 +45,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQmlApplicationEngine engine;
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayDimensions/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayDimensions/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportVectorTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportVectorTiles/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerShapefile/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/main.cpp
@@ -35,6 +35,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/main.cpp
@@ -28,6 +28,9 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("CreateAndSaveMap - QML");
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -42,6 +42,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayOverviewMap/main.cpp
@@ -31,6 +31,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -46,7 +46,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMaxExtent/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMaxExtent/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -25,6 +25,9 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ShowDeviceLocationUsingIndoorPositioning - QML"));
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -50,6 +50,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -50,7 +50,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
@@ -53,7 +53,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
@@ -52,7 +52,10 @@ int main(int argc, char *argv[])
         QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
     }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/main.cpp
@@ -46,7 +46,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/main.cpp
@@ -46,7 +46,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/main.cpp
@@ -46,7 +46,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -44,7 +44,10 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-    // Initialize application view
+    // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
+  // Initialize application view
     QQuickView view;
     view.setResizeMode(QQuickView::SizeRootObjectToView);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
     QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -29,6 +29,9 @@ int main(int argc, char *argv[])
   const QString apiKey = QString("");
   setAPIKey(app, apiKey);
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -41,6 +41,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -44,6 +44,9 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
+  // Enable OpenGL
+  qputenv("QSG_RHI_BACKEND", "opengl");
+
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);


### PR DESCRIPTION
# Description

added the line to each main.cpp file to enable opengl for each sample; I think this change is pretty straightforward since this line is needed to enable opengl but I have had some difficulties running some of the samples in general on my machine so I haven't tested it yet, but I wasn't sure we need to?

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
