### PR TITLE
Tanner/create mobile gdb cleanup

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
@@ -22,21 +22,26 @@
 
 #include "FeatureListModel.h"
 
+#include "FeatureIterator.h"
 #include "FeatureLayer.h"
+#include "FeatureQueryResult.h"
+#include "FieldDescription.h"
+#include "FieldDescriptionListModel.h"
 #include "Geodatabase.h"
 #include "GeodatabaseFeatureTable.h"
+#include "GeometryTypes.h"
+#include "LayerListModel.h"
 #include "Map.h"
 #include "MapQuickView.h"
-#include "TableDescription.h"
 #include "MapTypes.h"
-#include "TaskWatcher.h"
-#include "FieldDescription.h"
-#include "ServiceTypes.h"
-#include "LayerListModel.h"
-#include "FieldDescriptionListModel.h"
+#include "Point.h"
 #include "QueryParameters.h"
-#include "FeatureIterator.h"
-#include "FeatureQueryResult.h"
+#include "TableDescription.h"
+#include "TaskWatcher.h"
+#include "ServiceTypes.h"
+#include "SpatialReference.h"
+#include "Viewpoint.h"
+
 #include <QUuid>
 
 using namespace Esri::ArcGISRuntime;

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.h
@@ -27,8 +27,8 @@ class MapQuickView;
 
 #include <FeatureListModel.h>
 
-#include <QObject>
 #include <QMouseEvent>
+#include <QObject>
 #include <QTemporaryDir>
 
 Q_MOC_INCLUDE("MapQuickView.h")

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -40,13 +40,16 @@ Item {
 
     Rectangle {
         id: buttonListRectangle
+        anchors {
+            top: parent.top
+            right: parent.right
+            topMargin: 10
+            rightMargin: 10
+        }
+
         width: 250
-        height: column1.height + 20
+        height: buttonColumn.height + 20
         color: "#ffffff"
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: 10
-        anchors.rightMargin: 10
 
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
@@ -56,7 +59,7 @@ Item {
         }
 
         Column {
-            id: column1
+            id: buttonColumn
             anchors {
                 top: parent.top
                 left: parent.left

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -54,8 +54,8 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse.accepted = true;
-            onWheel: wheel.accepted = true;
+            onPressed: mouse => mouse.accepted = true;
+            onWheel: wheel => wheel.accepted = true;
         }
 
         Column {
@@ -243,7 +243,7 @@ Item {
         ListView {
             id: tableView
             anchors {
-                centerIn: parent
+                fill: parent
                 margins: 10
             }
             ScrollBar.vertical: ScrollBar {

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -57,12 +57,14 @@ Item {
 
         Column {
             id: column1
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.rightMargin: 10
-            anchors.leftMargin: 10
-            anchors.topMargin: 10
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+                topMargin: 10
+                leftMargin: 10
+                rightMargin: 10
+            }
             height: children.height
             spacing: 5
 
@@ -72,11 +74,13 @@ Item {
 
             Button {
                 id: createGdbButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("Create new .geodatabase")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: !model.gdbOpen
                 onClicked: {
                     model.createGeodatabase();
@@ -85,11 +89,13 @@ Item {
 
             Button {
                 id: viewGdbTableButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("View feature table")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: model.gdbOpen
                 onClicked: {
                     featureTableDisplay.visible = true;
@@ -98,11 +104,13 @@ Item {
             }
             Button {
                 id: clearFeaturesButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("Clear features")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: model.gdbOpen
                 onClicked: {
                     model.clearFeatures();
@@ -112,11 +120,13 @@ Item {
 
             Button {
                 id: closeGdbButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("Close .geodatabase")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: model.gdbOpen
                 onClicked: {
                     model.closeGdb();
@@ -127,25 +137,29 @@ Item {
 
             Text {
                 id: fileNameText
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: model.gdbFilePath ? "Created new geodatabase:\n" + model.gdbFilePath.split("/").pop() : "Geodatabase path not found"
-                anchors.left: parent.left
-                anchors.right: parent.right
                 font.pixelSize: 12
                 wrapMode: Text.WrapAnywhere
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 visible: model.gdbOpen
             }
 
             Text {
                 id: featureCountText
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: "Number of features: " + model.featureCount + (model.featureCount === 0 ? "\n(Click or tap on the map to add new features)" : "")
-                anchors.left: parent.left
-                anchors.right: parent.right
                 font.pixelSize: 12
                 wrapMode: Text.WordWrap
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 visible: model.gdbOpen
             }
         }
@@ -170,8 +184,10 @@ Item {
 
         Column {
             id: gdbInfoColumn
-            anchors.centerIn: parent
-            anchors.margins: 10
+            anchors {
+                centerIn: parent
+                margins: 10
+            }
             spacing: 10
             width: parent.width - 20
             height: children.height
@@ -223,8 +239,10 @@ Item {
 
         ListView {
             id: tableView
-            anchors.fill: parent
-            anchors.margins: 10
+            anchors {
+                centerIn: parent
+                margins: 10
+            }
             ScrollBar.vertical: ScrollBar {
                 active: true
             }
@@ -291,13 +309,15 @@ Item {
 
     Rectangle {
         id: closeTableButtonRectangle
+        anchors {
+            top: parent.top
+            right: parent.right
+            topMargin: 10
+            rightMargin: 10
+        }
         width: closeTableButton.width + 10
         height: closeTableButton.height + 10
         color: "#ffffff"
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: 10
-        anchors.rightMargin: 10
         visible: featureTableDisplay.visible
 
         // Prevent mouse interaction from propagating to the MapView

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -178,8 +178,8 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse.accepted = true;
-            onWheel: wheel.accepted = true;
+            onPressed: mouse => mouse.accepted = true;
+            onWheel: wheel => wheel.accepted = true;
         }
 
         Column {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -54,6 +54,8 @@ Rectangle {
             if (!featureTable)
                 return;
 
+            const feature = featureTable.createFeatureWithAttributes({"collection_timestamp": new Date()}, mouse.mapPoint);
+
             const addFeatureToFeatureTable = () => {
                 if (featureTable.addFeatureStatus !== Enums.TaskStatusCompleted)
                     return;
@@ -64,7 +66,6 @@ Rectangle {
                 numberOfFeatures = featureTable.numberOfFeatures
             }
 
-            const feature = featureTable.createFeatureWithAttributes({"collection_timestamp": new Date()}, mouse.mapPoint);
             featureTable.addFeatureStatusChanged.connect(addFeatureToFeatureTable);
             featureTable.addFeature(feature);
         }
@@ -85,8 +86,8 @@ Rectangle {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse.accepted = true;
-            onWheel: wheel.accepted = true;
+            onPressed: mouse => mouse.accepted = true;
+            onWheel: wheel => wheel.accepted = true;
         }
 
         Column {
@@ -270,8 +271,10 @@ Rectangle {
 
         ListView {
             id: tableView
-            anchors.fill: parent
-            anchors.margins: 10
+            anchors {
+                fill: parent
+                margins: 10
+            }
             ScrollBar.vertical: ScrollBar {
                 active: true
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -72,13 +72,15 @@ Rectangle {
 
     Rectangle {
         id: buttonListRectangle
+        anchors {
+            top: parent.top
+            right: parent.right
+            topMargin: 10
+            rightMargin: 10
+        }
         width: 250
         height: buttonColumn.height + 20
         color: "#ffffff"
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: 10
-        anchors.rightMargin: 10
 
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
@@ -89,12 +91,14 @@ Rectangle {
 
         Column {
             id: buttonColumn
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.rightMargin: 10
-            anchors.leftMargin: 10
-            anchors.topMargin: 10
+            anchors {
+                top: parent.top
+                left: parent.left
+                right: parent.right
+                topMargin: 10
+                leftMargin: 10
+                rightMargin: 10
+            }
             height: children.height
             spacing: 5
 
@@ -104,11 +108,13 @@ Rectangle {
 
             Button {
                 id: createGdbButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("Create new .geodatabase")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: !gdbOpen
                 onClicked: {
                     createGeodatabase();
@@ -117,11 +123,13 @@ Rectangle {
 
             Button {
                 id: viewGdbTableButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("View feature table")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: gdbOpen
                 onClicked: {
                     featureTableDisplay.visible = true;
@@ -130,11 +138,13 @@ Rectangle {
             }
             Button {
                 id: clearFeaturesButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("Clear features")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: gdbOpen
                 onClicked: {
                     clearTable();
@@ -143,11 +153,13 @@ Rectangle {
 
             Button {
                 id: closeGdbButton
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: qsTr("Close .geodatabase")
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 enabled: gdbOpen
                 onClicked: {
                     closeGeodatabase();
@@ -157,24 +169,28 @@ Rectangle {
             }
 
             Text {
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: mobileGeodatabase ? "Created new geodatabase:\n" + mobileGeodatabase.path.toString().split("/").pop() : "Geodatabase path not found"
-                anchors.left: parent.left
-                anchors.right: parent.right
                 font.pixelSize: 12
                 wrapMode: Text.WrapAnywhere
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 visible: gdbOpen
             }
 
             Text {
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: 0
+                    rightMargin: 0
+                }
                 text: "Number of features: " + numberOfFeatures + (numberOfFeatures === 0 ? "\n(Click or tap the map to add new features)" : "")
-                anchors.left: parent.left
-                anchors.right: parent.right
                 font.pixelSize: 12
                 wrapMode: Text.WordWrap
-                anchors.rightMargin: 0
-                anchors.leftMargin: 0
                 visible: gdbOpen
             }
         }
@@ -199,8 +215,10 @@ Rectangle {
 
         Column {
             id: gdbInfoColumn
-            anchors.centerIn: parent
-            anchors.margins: 10
+            anchors {
+                centerIn: parent
+                margins: 10
+            }
             spacing: 10
             width: parent.width - 20
             height: children.height
@@ -246,8 +264,8 @@ Rectangle {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse.accepted = true;
-            onWheel: wheel.accepted = true;
+            onPressed: mouse => mouse.accepted = true;
+            onWheel: wheel => wheel.accepted = true;
         }
 
         ListView {
@@ -322,14 +340,16 @@ Rectangle {
     }
 
     Rectangle {
-        id: buttonRectangle
+        id: closeTableButtonRectangle
+        anchors {
+            top: parent.top
+            right: parent.right
+            topMargin: 10
+            rightMargin: 10
+        }
         width: closeTableButton.width + 10
         height: closeTableButton.height + 10
         color: "#ffffff"
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: 10
-        anchors.rightMargin: 10
         visible: featureTableDisplay.visible
 
         // Prevent mouse interaction from propagating to the MapView


### PR DESCRIPTION
# Description

Fixes the formatting on the Create Mobile Geodatabase samples to match our standards

## Type of change

- [x] Other enhancement - formatting

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] macOS