### PR TITLE
Replace QtWebEngine with QtWebEngineQuick in Sample Viewer

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -82,8 +82,8 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
 DEFINES += GANALYTICS_API_KEY=$$(GANALYTICS_API_KEY)
 DEFINES += GANALYTICS_STREAM_ID=$$(GANALYTICS_STREAM_ID)
 
-qtHaveModule(webengine) {
-  QT += webengine
+qtHaveModule(webenginequick) {
+  QT += webenginequick
   DEFINES += QT_WEBVIEW_WEBENGINE_BACKEND
 }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
@@ -62,8 +62,8 @@ exists($$PWD/../../../../DevBuildQml.pri) {
 DEFINES += GANALYTICS_API_KEY=$$(GANALYTICS_API_KEY)
 DEFINES += GANALYTICS_STREAM_ID=$$(GANALYTICS_STREAM_ID)
 
-qtHaveModule(webengine) {
-  QT += webengine
+qtHaveModule(webenginequick) {
+  QT += webenginequick
   DEFINES += QT_WEBVIEW_WEBENGINE_BACKEND
 }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
@@ -29,7 +29,7 @@
 #include "GAnalytics.h"
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
-#  include <QtWebEngine>
+#  include <QtWebEngineQuick>
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
 // Choose a manager based on the type of interface.
@@ -314,7 +314,7 @@ int main(int argc, char *argv[])
   qputenv("QSG_RHI_BACKEND", "opengl");
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
-  QtWebEngine::initialize();
+  QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
 #ifdef CPP_VIEWER


### PR DESCRIPTION
# Description
Replace QtWebEngine with QtWebEngineQuick in Sample Viewer
<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
