### PR TITLE
Fix type errors in QML samples

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -268,7 +268,7 @@ Rectangle {
             ComboBox {
                 id: gridTypeComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [latlonGrid, mgrsGrid, utmGrid, usngGrid]
@@ -362,7 +362,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
 
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
@@ -393,7 +393,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo2
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "black", "blue"]
@@ -423,7 +423,7 @@ Rectangle {
             ComboBox {
                 id: positionCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [geographic, bottomLeft, bottomRight, topLeft, topRight, center, allSides]
@@ -455,7 +455,7 @@ Rectangle {
             ComboBox {
                 id: formatCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [dd, dms]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -76,7 +76,7 @@ Rectangle {
             margins: 10
         }
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
         model: geometryOperations
 
         onCurrentIndexChanged: applyGeometryOperation(currentIndex);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -164,7 +164,7 @@ Rectangle {
             ComboBox {
                 id: slopeCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel
@@ -188,7 +188,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.fillWidth: true
                 textRole: "name"
                 model: colorRampModel

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
@@ -81,7 +81,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
 
         model: ["URL", "Local file", "Portal Item"]
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -95,7 +95,7 @@ Rectangle {
             ComboBox {
                 id: slopeBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: HillshadeSlopeTypeModel{}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -139,7 +139,7 @@ Rectangle {
 
             model: stretchTypes
             property int modelWidth: 0
-            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+            Layout.minimumWidth: modelWidth + leftPadding + rightPadding
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -115,7 +115,7 @@ Rectangle {
                 id: stretchTypeCombo
                 anchors.horizontalCenter: parent.horizontalCenter
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding
                 model: stretchTypes
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -57,7 +57,7 @@ Rectangle {
             margins: 15
         }
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova", "World Street Map (Night)"]
         onCurrentTextChanged: {
             // Call this JavaScript function when the current selection changes

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -20,7 +20,6 @@ import QtQuick.Layouts
 import QtQuick.Window
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
-import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -211,7 +211,7 @@ Rectangle {
                     horizontalCenter: parent.horizontalCenter
                 }
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding
                 model: [ "No filter", "FLOW < 500", "FLOW < 300", "FLOW < 100" ]
 
                 onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -156,7 +156,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + rightPadding + leftPadding + indicator.width
+        width: modelWidth + rightPadding + leftPadding
         model: map.bookmarks
 
         Connections {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -221,7 +221,7 @@ Rectangle {
         ComboBox {
             id: modeComboBox
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding + indicator.width
+            width: modelWidth + leftPadding + rightPadding
             model: ["Facility", "Barrier"]
 
             onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -130,7 +130,7 @@ Rectangle {
             ComboBox {
                 id: missionList
                 property real modelWidth: 0
-                Layout.minimumWidth: leftPadding + rightPadding + indicator.width + modelWidth
+                Layout.minimumWidth: leftPadding + rightPadding + modelWidth
                 enabled: !playButton.checked
                 model: missionsModel
                 textRole: "name"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
@@ -23,7 +23,6 @@ Slider {
             radius: 3
             x: handleNub.x - width / 2 + handleNub.width / 2
             y: handleNub.y - handleNub.height * 2
-            color: progressSlider.background.children[0].color
             Text {
                 id: handleText
                 padding: 3


### PR DESCRIPTION
# Description

Fix null width warnings that are breaking the QML samples.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
