### PR TITLE
hook up the BusyIndicator to the mapDrawing status

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -71,7 +71,7 @@ DisplayDrawingStatusSample {
                 BusyIndicator {
                     anchors.horizontalCenter: parent.horizontalCenter
                     height: 60
-                    running: true
+                    running: displayDrawingStatusSample.mapDrawing
                 }
 
                 Text {


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

For the DisplayDrawingStatus sample, the BusyIndicator no longer appears on Windows. The fix is to hook up BusyIndicator's "running" state to the "mapDrawing" boolean. This gets it going when necessary.

I'm not sure when this regressed; my guess is it's due to the change from Qt 5 to Qt 6.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
