### PR TITLE
Fix callout width in IdentifyKmlFeatures

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -34,7 +34,8 @@ Item {
         Callout {
             id: callout
             calloutData: view.calloutData
-            calloutWidth: 150
+            maxWidth: 150
+            autoAdjustWidth: false
             calloutContent: Text {
                 text: model.calloutText
                 wrapMode: Text.WordWrap

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -34,8 +34,7 @@ Item {
         Callout {
             id: callout
             calloutData: view.calloutData
-            maxWidth: 150
-            autoAdjustWidth: false
+            implicitWidth: 150
             calloutContent: Text {
                 text: model.calloutText
                 wrapMode: Text.WordWrap


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

The Cpp version of IdentifyKmlFeatures has a problem where the Callout is too skinny. The QML version does not have this problem. The difference is that the Cpp version sets calloutWidth, while the QML version sets implicitWidth. The Cpp version has been updated to match what the QML version is doing, which corrects the problem.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

