### PR TITLE
Fix null width

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
@@ -76,7 +76,7 @@ Item {
             model: sample.layerListModel
             delegate: Component {
                 RowLayout {
-                    width: parent.width
+                    width: 200
                     height: 40
                     spacing: 5
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.qml
@@ -76,7 +76,7 @@ Item {
             model: sample.layerListModel
             delegate: Component {
                 RowLayout {
-                    width: 200
+                    width: layersList.width
                     height: 40
                     spacing: 5
 


### PR DESCRIPTION
# Description
Fix null width with 200 which is technically the parent width in the first place. Addresses UI warnings in the C++ sample.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
