### PR TITLE
QML JS on Windows did not like this date format

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.qml
@@ -84,7 +84,7 @@ Rectangle {
 
     //! [Portal findItems webmaps part 1]
     // webmaps authored prior to July 2nd, 2014 are not supported - so search only from that date to the current time
-    property string fromDate: "000000" + new Date('Wed, 02 Jul 2014 00:00:00 GMT').getTime()
+    property string fromDate: "000000" + new Date('2014-07-02T00:00:00Z').getTime()
     property string toDate: "000000" + new Date().getTime()
 
     PortalQueryParametersForItems {


### PR DESCRIPTION
# Description

The Qt 6 Javascript engine on Windows no longer honors the date format used here. Switched it to a more rigorous, numbers-only format.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
