### PR TITLE
TokenAuthentication sample crashes with QtWebEngineQuick error

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
@@ -31,6 +31,11 @@ exists($$TOOLKIT_PRI_PATH/uitools/toolkitqml.pri) {
     error(TOOLKIT_PRI_PATH is missing which is required to build this application.)
 }
 
+qtHaveModule(webenginequick) {
+    QT += webenginequick
+    DEFINES += QT_WEBVIEW_WEBENGINE_BACKEND
+}
+
 CONFIG += c++17
 
 SOURCES += main.cpp

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -18,6 +18,10 @@
 #include <QDir>
 #include <QQmlEngine>
 
+#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
+#include <QtWebEngineQuick>
+#endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
 #include <Esri/ArcGISRuntime/Toolkit/register.h>
 
 #define STRINGIZE(x) #x
@@ -30,6 +34,10 @@ int main(int argc, char *argv[])
 
   QGuiApplication app(argc, argv);
   app.setApplicationName("TokenAuthentication - QML");
+
+#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
+  QtWebEngineQuick::initialize();
+#endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Getting a crash and this error on Windows with the QML TokenAuthentication sample: `QtWebEngineQuick::initialize() must be called from the Qt gui thread.`

The fix is to call `initialize()` in `main()`, like how it is done in the corresponding C++ TokenAuthentication sample.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

