### PR TITLE
Change data path strings to urls

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
@@ -25,10 +25,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data"
     }
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
@@ -25,10 +25,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/shp/" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/shp/"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/shp/" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/shp/"
     }
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/FeatureLayer_GeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Geopackage/FeatureLayer_GeoPackage.qml
@@ -24,10 +24,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/gpkg/" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/gpkg/"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/gpkg/" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/gpkg/";
     }
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/AddEncExchangeSet.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/AddEncExchangeSet.qml
@@ -24,7 +24,7 @@ Rectangle {
     width: 800
     height: 600
 
-    property url dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
                     System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/" :
                     System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/"
@@ -33,7 +33,7 @@ Rectangle {
 
     Component.onCompleted: {
         // set resource path
-        EncEnvironmentSettings.resourcePath = dataPath + "/ENC/hydrography";
+        EncEnvironmentSettings.resourcePath = dataPath + "ENC/hydrography";
 
         // load the EncExchangeSet
         encExchangeSet.load();
@@ -56,7 +56,7 @@ Rectangle {
 
             EncExchangeSet {
                 id: encExchangeSet
-                paths: [dataPath + "/ENC/ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031"]
+                paths: [dataPath + "ENC/ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031"]
 
                 property var layers: []
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -26,10 +26,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
     }
     property bool editingRenderer: false
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.qml
@@ -26,10 +26,10 @@ Rectangle {
     height: 600
 
     //! [RasterColormapRenderer qml add raster basemap]
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
     }
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/RasterFunctionFile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/RasterFunctionFile.qml
@@ -25,7 +25,7 @@ Rectangle {
     height: 600
 
     property real scaleFactor: 1
-    property url dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
                     System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
                     System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/RasterFunctionService.qml
@@ -25,10 +25,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster/" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster/"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster/" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster/"
     }
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.qml
@@ -24,10 +24,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/gpkg/" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/gpkg/"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/gpkg/" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/gpkg/"
     }
 
     MapView {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -26,10 +26,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
     }
     readonly property string minMax: "Min Max"
     readonly property string percentClip: "Percent Clip"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -25,10 +25,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/raster" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/raster"
     }
     readonly property string minMax: "Min Max"
     readonly property string percentClip: "Percent Clip"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.qml
@@ -26,10 +26,10 @@ Rectangle {
     height: 600
 
     readonly property string tempDataPath: System.temporaryFolder.path + "/" + new Date().getTime()
-    readonly property string origMmpkPath: {
+    readonly property url origMmpkPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) +  "/ArcGIS/Runtime/Data/mmpk/canyonlands/canyonlands.zip" :
-                    System.writableLocation(System.StandardPathsHomeLocation) +  "/ArcGIS/Runtime/Data/mmpk/canyonlands/canyonlands.zip"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) +  "/ArcGIS/Runtime/Data/mmpk/canyonlands/canyonlands.zip" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) +  "/ArcGIS/Runtime/Data/mmpk/canyonlands/canyonlands.zip"
     }
     readonly property string destMmpkPath: tempDataPath + "/canyonlands.zip"
     property MobileMapPackage mmpk

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/ReadGeoPackage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/ReadGeoPackage.qml
@@ -24,10 +24,10 @@ Rectangle {
     width: 800
     height: 600
 
-    readonly property string dataPath: {
+    readonly property url dataPath: {
         Qt.platform.os === "ios" ?
-                    System.writableLocation(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/gpkg/" :
-                    System.writableLocation(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/gpkg/"
+                    System.writableLocationUrl(System.StandardPathsDocumentsLocation) + "/ArcGIS/Runtime/Data/gpkg/" :
+                    System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data/gpkg/"
     }
 
     MapView {


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Resolves an issue where samples could not read offline data paths. Things like raster layers expect urls not strings.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] There is no leftover commented code
