### PR TITLE
Replace picture urls

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.cpp
@@ -93,7 +93,7 @@ void Picture_Marker_Symbol::componentComplete()
   m_graphicsOverlay = new GraphicsOverlay(this);
 
   // create a campsite symbol from a URL
-  PictureMarkerSymbol* campSymbol = new PictureMarkerSymbol(QUrl("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae"), this);
+  PictureMarkerSymbol* campSymbol = new PictureMarkerSymbol(QUrl("https://static.arcgis.com/images/Symbols/OutdoorRecreation/Camping.png"), this);
   setWidthAndHeight(campSymbol, 38.0f);
   Point campPoint(-228835, 6550763, SpatialReference::webMercator());
   addGraphic(campPoint, campSymbol);

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qml
@@ -71,7 +71,7 @@ Rectangle {
                 }
 
                 PictureMarkerSymbol {
-                    url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae"
+                    url: "https://static.arcgis.com/images/Symbols/OutdoorRecreation/Camping.png"
                     width: 38.0
                     height: 38.0
                 }


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Updates the URL to the tent graphic used in this sample because it's no longer available. The tent graphic doesn't change, just its source.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] macOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
