### PR TITLE
Add raster function file to non-mac qml sample viewer

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/samples.pri
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/samples.pri
@@ -247,5 +247,6 @@ SOURCES += \
 
 # Exclude Raster Function File from macOS
 !macx {
-  "$$SAMPLEPATHQML/Layers/RasterFunctionFile/RasterFunctionFile.qrc"
+  RESOURCES += \
+    "$$SAMPLEPATHQML/Layers/RasterFunctionFile/RasterFunctionFile.qrc"
 }


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

The syntax for adding the "Raster function (file)" sample to the QML sample viewer was wrong. This PR fixes the syntax and properly adds the raster function file sample to the QML sample viewers

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
