### PR TITLE
Edit Feature Attachment sample: need "width" to show up

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -167,7 +167,7 @@ EditFeatureAttachmentsSample {
             // create the delegate to specify how the view is arranged
             delegate: Item {
                 height: 45
-                width: parent.width
+                width: attachmentsList.width
                 clip: true
 
                 // show the attachment name

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -167,6 +167,7 @@ EditFeatureAttachmentsSample {
             // create the delegate to specify how the view is arranged
             delegate: Item {
                 height: 45
+                width: parent.width
                 clip: true
 
                 // show the attachment name


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

In the Edit Feature Attachments sample (Cpp), attachment list items are not showing up. The "width" value needs to be set.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
