### PR TITLE
"Browse OGC" crashes if Load button is pressed while there's nothing in the list

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -83,7 +83,7 @@ Item {
                 Button {
                     id: loadLayerButton
                     text: "Load selected layer"
-                    enabled: !model.serviceOrFeatureLoading
+                    enabled: !model.serviceOrFeatureLoading && featureList.currentIndex >= 0
                     onClicked: model.loadFeatureCollection(featureList.currentIndex);
                     Layout.columnSpan: 2
                     Layout.fillWidth: true


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

"Browse OGC API Feature Service" Cpp sample crashes if you put in an invalid URL and click on the Load button, because it is attempting to pull index -1 from the empty list. The Load button should be disabled while the list is empty to avoid the problem.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
