### PR TITLE
"Perform valve isolation trace" sample: error message appears immediately

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -123,7 +123,7 @@ Item {
 
     Dialog {
         id: messageDialog
-        visible: sampleModel.errorMessage === ""? false : true
+        visible: sampleModel.noResults
         title: "Isolation trace returned no elements."
         standardButtons: Dialog.Ok
         anchors.centerIn: parent


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

In the "Perform valve isolation trace" Cpp sample, the error message dialog was not attached to the proper property/signal to cause it to become visible when an error occurs. Because of that, it was initially starting out visible, and would never appear again, even on a valid error condition.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
