### PR TITLE
Handle situation where a portal item already exists

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -70,6 +70,20 @@ Rectangle {
 
         onErrorChanged: {
             statusBar.text = error.message + ": " + error.additionalMessage;
+
+            if (error.errorType === 409) // HTTP 409 "Conflict" - item already exists
+                myUser.fetchContent();
+        }
+
+        onFetchContentStatusChanged: {
+            if (myUser.fetchContentStatus !== Enums.TaskStatusCompleted)
+                return;
+
+            if (myUser.items.count > 0)
+            {
+                itemToAdd.itemId = myUser.items.get(0).itemId;
+                itemToAdd.load();
+            }
         }
 
         //! [PortalUser addPortalItemCompleted]


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

In the "Cloud and Portal", "Add Items to Portal" sample (Cpp and QML), you can run into a dead end if a portal item already exists. The "Add" button will error out, and the "Delete" button won't be enabled. This PR detects this scenario and responds by loading the existing item, making it available to be deleted.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
