### PR TITLE
"Create and Save Map" QML sample fails at "Save" button

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -80,7 +80,7 @@ Rectangle {
             }
 
             onSaveMapClicked: (title, tags, description) => {
-                const thumbnail = null;
+                const thumbnail = "";
                 const folder = null;
                 const forceSave = true;
                 const tagsList = tags.split(",");


### PR DESCRIPTION

# Description

"Create and Save Map" QML sample fails when you get to the "Save" button with an error to the console: "Could not convert argument 6 ...". This is because "thumbnail" argument is expecting a url, so it has to be an empty string rather than null. (QML/Javascript must have gotten more picky in Qt 6.)

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
