### PR TITLE
isSupportsApiKey was being ignored on QML side

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SampleManager.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SampleManager.cpp
@@ -361,7 +361,7 @@ void SampleManager::setApiKey(bool isSupportsApiKey)
 #ifdef CPP_VIEWER
   ArcGISRuntimeEnvironment::setApiKey(sampleApiKey);
 #else
-  emit apiKeyRequired(apiKey);
+  emit apiKeyRequired(sampleApiKey);
 #endif
 }
 


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Certain samples are intended to *not* use the supplied API key. The logic around that was busted for the QML side of things. This expressed itself by the "Add items to portal" sample hitting a problem loading the portal item, but only in the QML Sample Viewer -- not in Cpp Sample Viewer, and not if the sample was built and ran separately from the Sample Viewer. This fix matches up the logic from the Cpp side, and probably fixes any QML Sample that is designated as not supporting the API key.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
