### PR TITLE
"Edit and sync features" not deselecting feature after moving

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -88,7 +88,7 @@ Rectangle {
                 featureTable.updateFeatureStatusChanged.connect(()=> {
                     if (featureTable.updateFeatureStatus === Enums.TaskStatusCompleted) {
                         // clear selections
-                        featureTable.featureLayer.clearSelection();
+                        featureTable.layer.clearSelection();
                         selectedFeature = null;
                         instructionText = "Tap the sync button";
                         syncButton.visible = true;


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

The "Edit Data" > "Edit and sync features" QML sample was not working. You could move a feature, but it would not deselect, which prevents you from moving a 2nd feature. This was due to a simple error in the QML javascript.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
