### PR TITLE
QML "Animate 3D Symbols" sample has slider labels with white-text-on-white-background

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/LabeledSlider.qml
@@ -23,6 +23,7 @@ Slider {
             radius: 3
             x: handleNub.x - width / 2 + handleNub.width / 2
             y: handleNub.y - handleNub.height * 2
+            color: progressSlider.background.children[0].color
             Text {
                 id: handleText
                 padding: 3


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Need to pick up the background color from the slider and apply it to the slider labels, elsewise they end up being white text on white background. This was a problem with the QML version only -- the Cpp version already had this line of code.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
