### PR TITLE
clarify the status message when we're reusing an existing item

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
@@ -78,7 +78,10 @@ void AddItemsToPortal::componentComplete()
       emit portalItemIdChanged();
       emit portalItemTitleChanged();
       emit portalItemLoadedChanged();
-      setStatusText("Succesfully loaded item from portal." + m_item->itemId());
+      if (m_alreadyExisted)
+        setStatusText("Item already exists; using existing item instead. " + m_item->itemId());
+      else
+        setStatusText("Succesfully loaded item from portal. " + m_item->itemId());
     });
   }
 }
@@ -172,6 +175,7 @@ void AddItemsToPortal::connectUserSignals()
 
     if (static_cast<int>(error.errorType()) == 409) // HTTP 409 "Conflict" - item already exists
     {
+      m_alreadyExisted = true;
       m_user->fetchContent();
       m_busy = true;
     }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.h
@@ -77,6 +77,7 @@ private:
   bool m_itemDeleted = false;
   QString m_statusText;
   bool m_busy = false;
+  bool m_alreadyExisted = false;
 };
 
 #endif // ADDITEMSTOPORTAL_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -26,6 +26,8 @@ Rectangle {
     width: 800
     height: 600
 
+    property bool alreadyExisted: false
+
     PortalItem {
         id: itemToAdd
         portal: portal
@@ -36,7 +38,10 @@ Rectangle {
             if (loadStatus !== Enums.LoadStatusLoaded)
                 return;
 
-            statusBar.text = "Succesfully loaded item from portal." + itemToAdd.itemId
+            if (alreadyExisted)
+                statusBar.text = "Item already exists; using existing item instead. " + itemToAdd.itemId
+            else
+                statusBar.text = "Succesfully loaded item from portal. " + itemToAdd.itemId
         }
 
         onItemIdChanged: {
@@ -72,7 +77,10 @@ Rectangle {
             statusBar.text = error.message + ": " + error.additionalMessage;
 
             if (error.errorType === 409) // HTTP 409 "Conflict" - item already exists
+            {
+                alreadyExisted = true;
                 myUser.fetchContent();
+            }
         }
 
         onFetchContentStatusChanged: {


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

As a followup to the recent change to the "Add items to the portal" sample, this clarifies the message when at item already exists and you're going to move forward with that one instead.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
