### PR TITLE
"Display layer view draw state" not displaying state

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
@@ -81,7 +81,7 @@ Rectangle {
             }
         }
 
-        onLayerViewStateChanged: layer => {
+        onLayerViewStateChanged: (layer, layerViewState) => {
             // only update list if the layer is the feature layer.
             if (layer.name !== featureLayer.name)
                 return;


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->
QML Sample "Display layer view draw state" isn't showing the draw state like it's supposed to. The parameter list just needed to be fixed.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
