### PR TITLE
Check for data at writable location

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
@@ -66,7 +66,11 @@ Item {
 
         for (let i = 0; i < SampleManager.currentSample.dataItems.size; i++) {
             const dataItem = SampleManager.currentSample.dataItems.get(i);
-            fileInfo.filePath = dataItem.path;
+            if (Qt.platform.os === "ios")
+                fileInfo.filePath = System.writableLocation(System.StandardPathsDocumentsLocation) + dataItem.path.substring(1);
+            else
+                fileInfo.filePath = System.writableLocation(System.StandardPathsHomeLocation) + dataItem.path.substring(1);
+            fileInfo.refresh();
             if (fileInfo.exists && (!fileInfo.isFolder))
                 continue;
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -358,7 +358,7 @@ ApplicationWindow {
             fileInfo.refresh();
             if (fileInfo.exists && (!fileInfo.isFolder))
                 continue;
-            dataPackageFileInfo.filePath = dataItem.path + "/dataPackage.zip";
+            dataPackageFileInfo.filePath = fileInfo.filePath + "/dataPackage.zip";
             if (fileInfo.exists && dataPackageFileInfo.exists)
                 continue;
             return false;


### PR DESCRIPTION
# Description

The download data button on Android wouldn't work if there was similar data already downloaded to the sdcard. This PR updates the code so that it checks the correct writable location.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS