### PR TITLE
Download all data fix

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
@@ -66,7 +66,11 @@ Item {
 
         for (let i = 0; i < SampleManager.currentSample.dataItems.size; i++) {
             const dataItem = SampleManager.currentSample.dataItems.get(i);
-            fileInfo.filePath = dataItem.path;
+            if (Qt.platform.os === "ios")
+                fileInfo.filePath = System.writableLocation(System.StandardPathsDocumentsLocation) + dataItem.path.substring(1);
+            else
+                fileInfo.filePath = System.writableLocation(System.StandardPathsHomeLocation) + dataItem.path.substring(1);
+            fileInfo.refresh();
             if (fileInfo.exists && (!fileInfo.isFolder))
                 continue;
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
@@ -44,12 +44,19 @@ Item {
             for (let j = 0; j < sample.dataItems.size; j++) {
                 if (sample.dataItems.size > 0) {
                     const dataItem = sample.dataItems.get(j);
-                    fileInfo.filePath = dataItem.path;
+
+                    // Convert the relative path to a writable path
+                    if (Qt.platform.os === "ios")
+                        fileInfo.filePath = System.writableLocation(System.StandardPathsDocumentsLocation) + dataItem.path.substring(1);
+                    else
+                        fileInfo.filePath = System.writableLocation(System.StandardPathsHomeLocation) + dataItem.path.substring(1);
+                    fileInfo.refresh();
+
                     if (fileInfo.exists && (!fileInfo.isFolder))
                         continue;
 
-                    fileFolder.path = dataItem.path;
-                    dataPackageFileInfo.filePath = dataItem.path + "/dataPackage.zip";
+                    fileFolder.path = fileInfo.filePath;
+                    dataPackageFileInfo.filePath = fileInfo.filePath + "/dataPackage.zip";
                     if (fileFolder.exists && dataPackageFileInfo.exists)
                         continue;
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -358,7 +358,7 @@ ApplicationWindow {
             fileInfo.refresh();
             if (fileInfo.exists && (!fileInfo.isFolder))
                 continue;
-            dataPackageFileInfo.filePath = dataItem.path + "/dataPackage.zip";
+            dataPackageFileInfo.filePath = fileInfo.filePath + "/dataPackage.zip";
             if (fileInfo.exists && dataPackageFileInfo.exists)
                 continue;
             return false;


### PR DESCRIPTION
# Description

The `FileInfo` and `FileFolder` Extras components call `resolvedPath()` on any string passed to the `filePath` property. For Android this means the items with a `~` prefix in their file info path will be set to the sdcard. This PR addresses final changes and has the download all data download function check the writable path and not the sdcard.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS