### PR TITLE
Tanner/remove qt5 compat

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 // import Qt.labs.calendar // Calendar is not supported in Qt 6.2
-import Qt5Compat.GraphicalEffects
 import QtQuick.Layouts
 import Esri.Samples
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 EditAndSyncFeaturesSample {
@@ -153,13 +152,9 @@ EditAndSyncFeaturesSample {
         clip: true
         visible: false
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -154,7 +154,7 @@ EditAndSyncFeaturesSample {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 import Qt.labs.platform
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 Item {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -117,7 +117,7 @@ GenerateGeodatabaseReplicaFromFeatureServiceSample {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 GenerateGeodatabaseReplicaFromFeatureServiceSample {
@@ -116,13 +115,9 @@ GenerateGeodatabaseReplicaFromFeatureServiceSample {
         visible: false
         clip: true
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.5; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 ExportTilesSample {
@@ -116,13 +115,9 @@ ExportTilesSample {
         visible: false
         clip: true
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -117,7 +117,7 @@ ExportTilesSample {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -15,7 +15,6 @@
 // [Legal]
 
 import QtQuick
-import Qt5Compat.GraphicalEffects
 import QtQuick.Controls
 import QtQuick.Layouts
 import Esri.Samples
@@ -25,13 +24,9 @@ Rectangle {
     color: "transparent"
     visible: false
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -26,7 +26,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -18,7 +18,7 @@ import QtQuick.Controls
 Rectangle {
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     signal createMapSelected(var basemap, var layerList)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -14,16 +14,11 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.5
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "white" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     signal createMapSelected(var basemap, var layerList)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -14,16 +14,11 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.5
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "white" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     signal saveMapClicked(var title, var tags, var description)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -18,7 +18,7 @@ import QtQuick.Layouts
 Rectangle {
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     signal saveMapClicked(var title, var tags, var description)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 DisplayDrawingStatusSample {
@@ -42,13 +41,9 @@ DisplayDrawingStatusSample {
         color: "transparent"
         visible: displayDrawingStatusSample.mapDrawing
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.15
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         // pop up to show if MapView is drawing

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -43,7 +43,7 @@ DisplayDrawingStatusSample {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         // pop up to show if MapView is drawing

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -13,7 +13,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow
@@ -24,13 +23,9 @@ Rectangle {
     property string statusText: "Starting"
     property string progressText: "0"
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -13,7 +13,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow
@@ -24,13 +23,9 @@ Rectangle {
     property string statusText: "Starting"
     property string progressText: "0"
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -13,7 +13,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow
@@ -24,13 +23,9 @@ Rectangle {
     property string statusText: "Starting"
     property string progressText: "0"
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 OpenMapUrlSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -85,13 +85,9 @@ OpenMapUrlSample {
        anchors.fill: parent
        color: "transparent"
 
-       RadialGradient {
+       Rectangle {
            anchors.fill: parent
-           opacity: 0.7
-           gradient: Gradient {
-               GradientStop { position: 0.0; color: "lightgrey" }
-               GradientStop { position: 0.7; color: "black" }
-           }
+           color: "#60000000"
        }
 
        MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.Samples
 
 TakeScreenshotSample {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -58,13 +58,9 @@ TakeScreenshotSample {
         id: imageRect
         anchors.fill: parent
         visible: false
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "white" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#60000000"
         }
 
         Image {

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import QtQuick.Layouts
 import Esri.Samples
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 // import Qt.labs.calendar // Calendar is not supported in Qt 6.2
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import QtQuick.Layouts
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
 
@@ -391,13 +390,9 @@ Rectangle {
         clip: true
         visible: false
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -392,7 +392,7 @@ Rectangle {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -17,7 +17,6 @@
 import QtQuick
 import QtQuick.Controls
 import Qt.labs.platform
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISExtras
 import Esri.ArcGISRuntime
 import Esri.ArcGISRuntime.Toolkit

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -19,7 +19,6 @@ import Esri.ArcGISRuntime
 
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime.Toolkit
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
 
@@ -269,13 +268,9 @@ Rectangle {
         clip: true
         visible: false
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -270,7 +270,7 @@ Rectangle {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
 
@@ -244,13 +243,9 @@ Rectangle {
         visible: false
         clip: true
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/ExportTiles.qml
@@ -245,7 +245,7 @@ Rectangle {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -15,7 +15,6 @@
 // [Legal]
 
 import QtQuick
-import Qt5Compat.GraphicalEffects
 import QtQuick.Controls
 import QtQuick.Layouts
 import Esri.ArcGISRuntime
@@ -25,13 +24,9 @@ Rectangle {
     color: "transparent"
     visible: false
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -26,7 +26,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -18,7 +18,7 @@ import QtQuick.Controls
 Rectangle {
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     signal createMapSelected(var basemap, var layerList)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -14,16 +14,11 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.5
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "white" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     signal createMapSelected(var basemap, var layerList)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -14,16 +14,11 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.5
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "white" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     signal saveMapClicked(var title, var tags, var description)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/SaveOptionsWindow.qml
@@ -18,7 +18,7 @@ import QtQuick.Layouts
 Rectangle {
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     signal saveMapClicked(var title, var tags, var description)

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
 
@@ -72,13 +71,9 @@ Rectangle {
         anchors.fill: parent
         color: "transparent"
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.15
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         // pop up to show if MapView is drawing

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.qml
@@ -73,7 +73,7 @@ Rectangle {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         // pop up to show if MapView is drawing

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -13,7 +13,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow
@@ -24,13 +23,9 @@ Rectangle {
     property string statusText: ""
     property string progressText: ""
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -13,7 +13,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow
@@ -24,13 +23,9 @@ Rectangle {
     property string statusText: ""
     property string progressText: ""
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -25,7 +25,7 @@ Rectangle {
 
     Rectangle {
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -13,7 +13,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     id: exportWindow
@@ -24,13 +23,9 @@ Rectangle {
     property string statusText: ""
     property string progressText: ""
 
-    RadialGradient {
+    Rectangle {
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
     }
 
     MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -15,7 +15,6 @@
 // [Legal]
 
 import QtQuick
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {
@@ -99,13 +98,9 @@ Rectangle {
         anchors.fill: parent
         color: "transparent"
 
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "lightgrey" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -100,7 +100,7 @@ Rectangle {
 
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -16,7 +16,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntime
 
 Rectangle {
@@ -68,13 +67,9 @@ Rectangle {
         id: imageRect
         anchors.fill: parent
         visible: false
-        RadialGradient {
+        Rectangle {
             anchors.fill: parent
-            opacity: 0.7
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "white" }
-                GradientStop { position: 0.7; color: "black" }
-            }
+            color: "#80808080"
         }
 
         Image {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/TakeScreenshot.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/TakeScreenshot.qml
@@ -69,7 +69,7 @@ Rectangle {
         visible: false
         Rectangle {
             anchors.fill: parent
-            color: "#80808080"
+            color: "#60000000"
         }
 
         Image {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/Imports.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/Imports.qml
@@ -26,7 +26,6 @@ import QtQuick.Dialogs
 import QtSensors
 import QtPositioning
 import QtQuick.XmlListModel
-import Qt5Compat.GraphicalEffects
 import QtWebView
 import Esri.ArcGISExtras
 import Esri.ArcGISRuntime.Toolkit

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/Imports.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/Imports.qml
@@ -26,7 +26,6 @@ import QtQuick.Dialogs
 import QtSensors
 import QtPositioning
 import QtQuick.XmlListModel
-import Qt5Compat.GraphicalEffects
 import QtWebView
 import Esri.ArcGISExtras
 import Esri.ArcGISRuntime

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
@@ -23,7 +23,7 @@ Item {
     Rectangle {
         id: overlay
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
 
         MouseArea {
             anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
@@ -21,14 +21,10 @@ import Esri.ArcGISRuntimeSamples
 Item {
     visible: false
 
-    RadialGradient {
+    Rectangle {
         id: overlay
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
 
         MouseArea {
             anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/AboutView.qml
@@ -15,7 +15,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntimeSamples
 
 Item {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
@@ -15,7 +15,6 @@
 
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Esri.ArcGISRuntimeSamples
 import Telemetry
 
@@ -55,7 +54,7 @@ Component {
                     width: 30
                     height: width
                     radius: 30
-                    color: "#333333"
+                    color: "#eeeeee"
 
                     Image {
                         id: thumbnailImage
@@ -65,12 +64,6 @@ Component {
                         source: thumbnailUrl
                         clip: true
                         visible: drawer.visible
-                    }
-
-                    ColorOverlay {
-                        anchors.fill: thumbnailImage
-                        source: thumbnailImage
-                        color: "white"
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -28,14 +28,10 @@ Item {
         dialogComponent.visible = GAnalytics.isVisible;
     }
 
-    RadialGradient {
+    Rectangle {
         id: overlay
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
 
         MouseArea {
             anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -15,7 +15,6 @@
 
 import QtQuick
 import Telemetry
-import Qt5Compat.GraphicalEffects
 import QtQuick.Controls
 import QtQuick.Controls.Material
 import QtQuick.Layouts

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -30,7 +30,7 @@ Item {
     Rectangle {
         id: overlay
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
 
         MouseArea {
             anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
@@ -13,7 +13,6 @@
 // limitations under the License.
 // [Legal]
 
-import Qt5Compat.GraphicalEffects
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
@@ -28,14 +28,12 @@ Item {
     property string user: userName.text
     property string pw: password.text
 
-    RadialGradient {
+
+
+    Rectangle {
         id: overlay
         anchors.fill: parent
-        opacity: 0.7
-        gradient: Gradient {
-            GradientStop { position: 0.0; color: "lightgrey" }
-            GradientStop { position: 0.7; color: "black" }
-        }
+        color: "#80808080"
 
         MouseArea {
             anchors.fill: parent

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
@@ -32,7 +32,7 @@ Item {
     Rectangle {
         id: overlay
         anchors.fill: parent
-        color: "#80808080"
+        color: "#60000000"
 
         MouseArea {
             anchors.fill: parent


### PR DESCRIPTION
# Description

Removes instances of Qt5Compat imports and any QML components that rely on it. There were quite a few samples that imported GraphicalEffects but never used it.

Most RadialGradients I just replaced with a flat semi-transparent gray background.

![Screen Shot 2022-11-04 at 12 12 50 PM](https://user-images.githubusercontent.com/48941951/200056842-0b18ecc7-07bc-40e0-9bde-0f08ebe28b62.png)

I had to remove ColorOverlay from the CategoryCards as well but I think this looks good. I can alternatively switch the color of all the pngs.

![Screen Shot 2022-11-04 at 11 55 51 AM](https://user-images.githubusercontent.com/48941951/200056931-817d634d-7417-4986-ba90-5ad5047cc7b1.png)

