### PR TITLE
Prevent duplicate field crash

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
@@ -284,7 +284,8 @@ Rectangle {
                                     checked: text === "State"
                                     onCheckedChanged: {
                                         if (checked) {
-                                            groupingFields.push(text);
+                                            if (groupingFields.indexOf(text) === -1)
+                                                groupingFields.push(text);
                                         } else {
                                             // remove the item from the selected list
                                             const i = groupingFields.indexOf(text);


### PR DESCRIPTION
# Description

Fixes a bug where duplicate fields can be added to the groupingFields list. If that is allowed to happen then running "Get Statistics" will result in an error.