### PR TITLE
Create and save KML fix

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.h
@@ -29,6 +29,7 @@ class KmlStyle;
 
 #include <QObject>
 #include <QUrl>
+#include <QTemporaryDir>
 
 #include "Geometry.h"
 #include "Point.h"
@@ -43,6 +44,7 @@ class CreateAndSaveKmlFile : public QObject
 
   Q_PROPERTY(Esri::ArcGISRuntime::MapQuickView* mapView READ mapView WRITE setMapView NOTIFY mapViewChanged)
   Q_PROPERTY(bool busy MEMBER m_busy NOTIFY busyChanged)
+  Q_PROPERTY(QString kmlFilePath READ kmlFilePath NOTIFY kmlFilePathChanged)
 
 public:
   explicit CreateAndSaveKmlFile(QObject* parent = nullptr);
@@ -50,16 +52,18 @@ public:
 
   static void init();
 
-  Q_INVOKABLE void saveKml(const QUrl& url);
+  Q_INVOKABLE void saveKml();
 
 signals:
   void mapViewChanged();
   void busyChanged();
   void kmlSaveCompleted();
+  void kmlFilePathChanged();
 
 private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;
   void setMapView(Esri::ArcGISRuntime::MapQuickView* mapView);
+  QString kmlFilePath() const;
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
@@ -82,6 +86,9 @@ private:
   Esri::ArcGISRuntime::KmlStyle* createKmlStyleWithPointStyle();
   Esri::ArcGISRuntime::KmlStyle* createKmlStyleWithLineStyle();
   Esri::ArcGISRuntime::KmlStyle* createKmlStyleWithPolygonStyle();
+
+  QTemporaryDir m_tempDir;
+  QString m_kmlFilePath;
 
   void addGraphics();
   void addToKmlDocument(const Esri::ArcGISRuntime::Geometry& geometry, Esri::ArcGISRuntime::KmlStyle* kmlStyle);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
@@ -48,8 +48,10 @@ Item {
         }
         text: qsTr("Save kmz file")
 
+        enabled: model.busy === false
+
         onClicked: {
-            fileDialog.visible = true;
+            model.saveKml();
         }
     }
 
@@ -58,26 +60,16 @@ Item {
         visible: model.busy
     }
 
-    FileDialog {
-        id: fileDialog
-        defaultSuffix: "kmz"
-        fileMode: FileDialog.SaveFile
-        nameFilters: ["Kml files (*.kmz *.kml)"]
-        onAccepted: {
-            // Write the KML document to the chosen path.
-            visible: false;
-            model.saveKml(currentFile);
-        }
-        onRejected: {
-            visible: false;
-        }
-    }
-
     Dialog {
         id: saveCompleteDialog
-        x: (parent.width - width) / 2
-        y: (parent.height - height) / 2
+        anchors.centerIn: parent
+        width: parent.width * .8
         standardButtons: Dialog.Ok
-        title: "Item saved."
+        title: "Item saved to temporary location:"
+        Label {
+            text: model.kmlFilePath
+            wrapMode: Text.Wrap
+            width: parent.width
+        }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.qml
@@ -26,6 +26,8 @@ Rectangle {
     width: 800
     height: 600
 
+    property url fileSavePath: ""
+
     MapView {
         id: mapView
         anchors.fill: parent
@@ -82,7 +84,8 @@ Rectangle {
         text: qsTr("Save kmz file")
 
         onClicked: {
-            fileDialog.open();
+            fileSavePath = System.temporaryFolder.url + "/KmlSampleFile_%1.kmz".arg((new Date().getTime() % 1000).toString());
+            kmlDocument.saveAs(fileSavePath);
         }
     }
 
@@ -109,28 +112,17 @@ Rectangle {
         visible: kmlDocument.saveStatus === Enums.TaskStatusInProgress
     }
 
-    FileDialog {
-        id: fileDialog
-        defaultSuffix: "kmz"
-        fileMode: FileDialog.SaveFile
-        nameFilters: ["Kml files (*.kmz *.kml)"]
-        onAccepted: {
-            // Write the KML document to the chosen path.
-            kmlDocument.saveAs(currentFile);
-            close();
-        }
-
-        onRejected: {
-            close();
-        }
-    }
-
     Dialog {
         id: saveCompleteDialog
+        anchors.centerIn: parent
+        width: parent.width * .8
         standardButtons: Dialog.Ok
-        title: "Item saved."
-        x: (parent.width - width) / 2
-        y: (parent.height - height) / 2
+        title: "Item saved to temporary location:"
+        Label {
+            text: fileSavePath
+            wrapMode: Text.Wrap
+            width: parent.width
+        }
     }
 
     KmlStyle {


### PR DESCRIPTION
# Description

Changes the "Create and save KML" sample so it no longer prompts the user for where to save the kmz file -- it just saves it to a temporary location. This is consistent with behavior in the "Create mobile geodatabase" sample.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [x] iOS