### PR TITLE
Tanner/change main.cpp init orders

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -11,10 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
 
+#include "ArcGISArView.h"
 #include "DisplayScenesInTabletopAR.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -23,7 +21,9 @@
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
 
-#include "ArcGISArView.h"
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ExploreScenesInFlyoverAR.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 // Include the AR view from toolkit
 #include "ArcGISArView.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "Geotriggers.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "LineOfSightGeoElement.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -36,12 +36,12 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
-  QGuiApplication app(argc, argv);
-  app.setApplicationName("Add Items to Portal - C++");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
+  QGuiApplication app(argc, argv);
+  app.setApplicationName("Add Items to Portal - C++");
 
   // Initialize the sample
   AddItemsToPortal::init();

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "IntegratedWindowsAuthentication.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,11 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
+
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
 #include <QtWebEngineQuick>
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -37,6 +37,11 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
+
+#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
+  QtWebEngineQuick::initialize();
+#endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
   QGuiApplication app(argc, argv);
   app.setApplicationName("Portal User Info - C++");
 
@@ -57,10 +62,6 @@ int main(int argc, char *argv[])
   {
       Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
   }
-
-#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
-  QtWebEngineQuick::initialize();
-#endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   // Initialize the sample
   PortalUserInfo::init();

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ControlAnnotationSublayerVisibility.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CreateSymbolStylesFromWebStyles.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CustomDictionaryStyle.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "QueryFeaturesWithArcadeExpression.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ReadSymbolsFromMobileStyle.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ShowPopup.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "SketchOnMap.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ContingentValues.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "EditFeaturesWithFeatureLinkedAnnotation.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "EditKmlGroundOverlay.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "EditWithBranchVersioning.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
 #include <QtWebEngineQuick>

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ControlTimeExtentTimeSlider.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -24,6 +20,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CreateMobileGeodatabase.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ConvexHull.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "NearestVertex.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "AddEncExchangeSet.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ApplyMosaicRuleToRasters.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ApplyUniqueValuesWithAlternateSymbols.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "BrowseOGCAPIFeatureService.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "BrowseWfsLayers.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CreateAndSaveKmlFile.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayAnnotation.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayDimensions.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayOgcApiFeatureCollection.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -22,6 +18,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplaySubtypeFeatureLayer.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayWfsLayer.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ExportVectorTiles.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "FeatureCollectionLayerFromPortal.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "GroupLayers.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "IdentifyKmlFeatures.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "IdentifyRasterCell.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ListKmlContents.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "LoadWfsXmlQuery.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ManageOperationalLayers.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "PlayAKmlTour.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "QueryOGCAPICQLFilters.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "TileCacheLayer.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ApplyScheduledMapUpdates.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "BrowseBuildingFloors.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ChangeBasemap.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -24,6 +20,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
@@ -37,12 +37,12 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
-  QGuiApplication app(argc, argv);
-  app.setApplicationName("CreateAndSaveMap - C++");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
+  QGuiApplication app(argc, argv);
+  app.setApplicationName("CreateAndSaveMap - C++");
 
   // Initialize the sample
   CreateAndSaveMap::init();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayDeviceLocationWithNmeaDataSources.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayLayerViewDrawState.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayOverviewMap.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -24,6 +20,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DownloadPreplannedMap.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "HonorMobileMapPackageExpiration.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "MapReferenceScale.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "SetMaxExtent.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ShowDeviceLocationUsingIndoorPositioning.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ShowLocationHistory.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayRouteLayer.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "FindClosestFacilityToMultipleIncidentsService.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "FindServiceAreasForMultipleFacilities.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "NavigateARouteWithRerouting.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "NavigateRoute.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "OfflineRouting.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "RouteAroundBarriers.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "AddAPointSceneLayer.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "AddIntegratedMeshLayer.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "AnimateImagesWithImageOverlay.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ChangeAtmosphereEffect.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ChooseCameraController.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CreateTerrainSurfaceFromLocalRaster.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CreateTerrainSurfaceFromLocalTilePackage.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "Display3DLabelsInScene.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "GetElevationAtPoint.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "OrbitCameraAroundObject.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "RealisticLightingAndShadows.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ScenePropertiesExpressions.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "SyncMapViewSceneView.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ViewContentBeneathTerrainSurface.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QSurfaceFormat>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ReverseGeocodeOnline.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "ConfigureSubnetworkTrace.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "CreateLoadReport.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayContentOfUtilityNetworkContainer.h"
 
 #include "ArcGISRuntimeEnvironment.h"
@@ -23,6 +19,10 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 void setAPIKey(const QGuiApplication& app, QString apiKey);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "DisplayUtilityAssociations.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "PerformValveIsolationTrace.h"
 #include "ArcGISRuntimeEnvironment.h"
 
@@ -22,6 +18,9 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -11,16 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "TraceUtilityNetwork.h"
 #include "ArcGISRuntimeEnvironment.h"
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -31,12 +31,12 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
-  QGuiApplication app(argc, argv);
-  app.setApplicationName("AddItemsToPortal - QML");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
     QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
+  QGuiApplication app(argc, argv);
+  app.setApplicationName("AddItemsToPortal - QML");
 
     // Initialize application view
     QQuickView view;

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -31,6 +31,10 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
+#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
+  QtWebEngineQuick::initialize();
+#endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IntegratedWindowsAuthentication - QML"));
 
@@ -51,10 +55,6 @@ int main(int argc, char *argv[])
   {
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
-
-#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
-  QtWebEngineQuick::initialize();
-#endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   // Initialize application view
   QQuickView view;

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -31,6 +31,10 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
+#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
+    QtWebEngineQuick::initialize();
+#endif // QT_WEBVIEW_WEBENGINE_BACKEND
+  
   QGuiApplication app(argc, argv);
   app.setApplicationName("SearchForWebmap - QML");
 
@@ -52,9 +56,6 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-#ifdef QT_WEBVIEW_WEBENGINE_BACKEND
-    QtWebEngineQuick::initialize();
-#endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   // Initialize application view
   QQuickView view;

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -32,12 +32,12 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
-  QGuiApplication app(argc, argv);
-  app.setApplicationName("TokenAuthentication - QML");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
+  QGuiApplication app(argc, argv);
+  app.setApplicationName("TokenAuthentication - QML");
 
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -29,12 +29,12 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
-  QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("EditWithBranchVersioning - QML"));
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
+  QGuiApplication app(argc, argv);
+  app.setApplicationName(QStringLiteral("EditWithBranchVersioning - QML"));
 
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/main.cpp
@@ -31,12 +31,12 @@ int main(int argc, char *argv[])
   // Enforce OpenGL
   qputenv("QSG_RHI_BACKEND", "opengl");
 
-  QGuiApplication app(argc, argv);
-  app.setApplicationName("CreateAndSaveMap - QML");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
+
+  QGuiApplication app(argc, argv);
+  app.setApplicationName("CreateAndSaveMap - QML");
 
   // Initialize application view
   QQuickView view;

--- a/sample-templates/templateArcGISRuntimeSDKQt_Cpp/main.cpp.tmpl
+++ b/sample-templates/templateArcGISRuntimeSDKQt_Cpp/main.cpp.tmpl
@@ -11,10 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef Q_OS_WIN
-#include <Windows.h>
-#endif
-
 #include "%{SampleName}.h"
 
 @if %{UseAPIKey}
@@ -28,6 +24,10 @@
 @if %{ThreeDSample}
 #include <QSurfaceFormat>
 @endif
+
+#ifdef Q_OS_WIN
+#include <Windows.h>
+#endif
 
 @if %{UseAPIKey}
 void setAPIKey(const QGuiApplication& app, QString apiKey);


### PR DESCRIPTION
# Description

### Resolves the following warnings

#### This compiler warning

```
QtWebEngineQuick::initialize() called with QCoreApplication object already created and should be call before. This is depreciated and may fail in the future.
```

#### and this clazy warning

![Screen Shot 2022-11-10 at 12 40 54 PM](https://user-images.githubusercontent.com/48941951/201201879-2e6d91bc-5545-4fbd-a980-0609ed5169ad.png)

I updated the cpp template to resolve this as well.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [x] iOS