### PR TITLE
using preprocessor ifdef instead of only if

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/DisplayDimensions.cpp
@@ -39,7 +39,7 @@ namespace
   {
     QString dataPath;
 
-    #if Q_OS_IOS
+    #ifdef Q_OS_IOS
       dataPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     #else
       dataPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.cpp
@@ -42,7 +42,7 @@ namespace
   {
     QString dataPath;
 
-    #if Q_OS_IOS
+    #ifdef Q_OS_IOS
       dataPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     #else
       dataPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.cpp
@@ -42,7 +42,7 @@ namespace
   {
     QString dataPath;
 
-    #if Q_OS_IOS
+    #ifdef Q_OS_IOS
       dataPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     #else
       dataPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.cpp
@@ -53,7 +53,7 @@ namespace
   {
     QString dataPath;
 
-    #if Q_OS_IOS
+    #ifdef Q_OS_IOS
       dataPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     #else
       dataPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->
I have been trying to build for IOS the samples viewer cpp but I was getting errors because of `missing expression`. I think that the correct per-processor to be used is `#ifdef`. Interestingly I am not getting any problems when building for mac only.
There have might be a mixup with [this commit](https://github.com/Esri/arcgis-runtime-samples-qt/commit/4571ad74de4c2deb58b59f52a64f11f098c62074), since I see some other `#ifdef Q_OS_IOS`
## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [x] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
