### PR TITLE
Portal item collision

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
@@ -195,8 +195,15 @@ void AddItemsToPortal::connectUserSignals()
 
     if (m_user->items()->size() > 0)
     {
-      m_item->setItemId(m_user->items()->at(0)->itemId());
-      m_item->load();
+      for (PortalItem* item : *m_user->items())
+      {
+        if (item->title() == "Add Items Sample")
+        {
+          m_item->setItemId(item->itemId());
+          m_item->load();
+          return;
+        }
+      }
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
@@ -193,16 +193,13 @@ void AddItemsToPortal::connectUserSignals()
     if (!success)
       return;
 
-    if (m_user->items()->size() > 0)
+    for (PortalItem* item : *m_user->items())
     {
-      for (PortalItem* item : *m_user->items())
+      if (item->title() == "Add Items Sample")
       {
-        if (item->title() == "Add Items Sample")
-        {
-          m_item->setItemId(item->itemId());
-          m_item->load();
-          return;
-        }
+        m_item->setItemId(item->itemId());
+        m_item->load();
+        return;
       }
     }
   });

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -90,16 +90,13 @@ Rectangle {
             if (myUser.fetchContentStatus !== Enums.TaskStatusCompleted)
                 return;
 
-            if (myUser.items.count > 0)
-            {
-                myUser.items.forEach(item => {
-                    if (item.title === "Add Items Sample") {
-                        itemToAdd.itemId = item.itemId;
-                        itemToAdd.load();
-                        return;
-                    }
-                });
-            }
+            myUser.items.forEach(item => {
+                if (item.title === "Add Items Sample") {
+                    itemToAdd.itemId = item.itemId;
+                    itemToAdd.load();
+                    return;
+                }
+            });
         }
 
         //! [PortalUser addPortalItemCompleted]

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml
@@ -92,8 +92,13 @@ Rectangle {
 
             if (myUser.items.count > 0)
             {
-                itemToAdd.itemId = myUser.items.get(0).itemId;
-                itemToAdd.load();
+                myUser.items.forEach(item => {
+                    if (item.title === "Add Items Sample") {
+                        itemToAdd.itemId = item.itemId;
+                        itemToAdd.load();
+                        return;
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
# Description

Fixes how we get the duplicate PortalItem's id by searching by item title rather than just getting the first item in the list. Previously we were just retrieving and deleting whatever item was first returned from the AGOL account (I hope we didn't delete anything important while testing...), so we would still encounter collisions on subsequent runs.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS