### PR TITLE
Update samples that use OfflineMapTask

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=GenerateOfflineMap, Category=Maps]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file GenerateOfflineMap.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,10 +76,10 @@ void GenerateOfflineMap::componentComplete()
   // Create a Portal Item for use by the Map and OfflineMapTask
   bool loginRequired = false;
   Portal* portal = new Portal(loginRequired, this);
-  m_portalItem = new PortalItem(portal, webMapId(), this);
+  PortalItem* portalItem = new PortalItem(portal, webMapId(), this);
 
   // Create a map from the Portal Item
-  m_map = new Map(m_portalItem, this);
+  m_map = new Map(portalItem, this);
 
   // Update property once map is done loading
   connect(m_map, &Map::doneLoading, this, [this](Error e)
@@ -182,4 +194,3 @@ void GenerateOfflineMap::generateMapByExtent(double xCorner1, double yCorner1, d
   // generate parameters
   m_offlineMapTask->createDefaultGenerateOfflineMapParameters(mapExtent);
 }
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.cpp
@@ -82,8 +82,8 @@ void GenerateOfflineMap::componentComplete()
   // Set map to map view
   m_mapView->setMap(m_map);
 
-  // Create the OfflineMapTask with the PortalItem
-  m_offlineMapTask = new OfflineMapTask(m_portalItem, this);
+  // Create the OfflineMapTask with the online map
+  m_offlineMapTask = new OfflineMapTask(m_map, this);
 
   // connect to the error signal
   connect(m_offlineMapTask, &OfflineMapTask::errorOccurred, this, [](Error e)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.h
@@ -1,6 +1,18 @@
-// [WriteFile Name=GenerateOfflineMap, Category=Maps]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file GenerateOfflineMap.h
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +33,6 @@ namespace Esri::ArcGISRuntime
 {
 class Map;
 class MapQuickView;
-class PortalItem;
 class OfflineMapTask;
 }
 
@@ -57,7 +68,6 @@ private:
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
-  Esri::ArcGISRuntime::PortalItem* m_portalItem = nullptr;
   Esri::ArcGISRuntime::OfflineMapTask* m_offlineMapTask = nullptr;
   static const QString s_webMapId;
   bool m_mapLoaded = false;

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.cpp
@@ -101,8 +101,8 @@ void GenerateOfflineMapLocalBasemap::componentComplete()
   // Set map to map view
   m_mapView->setMap(m_map);
 
-  // Create the OfflineMapTask with the PortalItem
-  m_offlineMapTask = new OfflineMapTask(m_portalItem, this);
+  // Create the OfflineMapTask with the online map
+  m_offlineMapTask = new OfflineMapTask(m_map, this);
 
   // connect to the error signal
   connect(m_offlineMapTask, &OfflineMapTask::errorOccurred, this, [](Error e)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -100,8 +100,8 @@ void GenerateOfflineMap_Overrides::componentComplete()
   // Set map to map view
   m_mapView->setMap(m_map);
 
-  // Create the OfflineMapTask with the PortalItem
-  m_offlineMapTask = new OfflineMapTask(m_portalItem, this);
+  // Create the OfflineMapTask with the online map
+  m_offlineMapTask = new OfflineMapTask(m_map, this);
 
   // connect to the error signal
   connect(m_offlineMapTask, &OfflineMapTask::errorOccurred, this, [](Error e)

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/README.md
@@ -22,11 +22,11 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 
 ## How it works
 
-The sample creates a `PortalItem` object using a web map’s ID. This portal item is also used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask::createDefaultGenerateOfflineMapParameters`. Once the parameters are retrieved, they are used to create a set of `GenerateOfflineMapParameterOverrides` by calling `OfflineMapTask::createGenerateOfflineMapParameterOverrides`. The overrides are then adjusted so that specific layers will be taken offline using custom settings.
+The sample creates a `PortalItem` object using a web map’s ID. Create a `Map` with this portal item. Use the `Map` to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask::createDefaultGenerateOfflineMapParameters`. Once the parameters are retrieved, they are used to create a set of `GenerateOfflineMapParameterOverrides` by calling `OfflineMapTask::createGenerateOfflineMapParameterOverrides`. The overrides are then adjusted so that specific layers will be taken offline using custom settings.
 
 ### Streets basemap (adjust scale range)
 
-In order to minimize the download size for offline map, this sample reduces the scale range for the "World Streets Basemap" layer by adjusting the relevant `ExportTileCacheParameters` in the `GenerateOfflineMapParameterOverrides`. The basemap layer is used to contsruct an `OfflineMapParametersKey`object. The key is then used to retrieve the specific `ExportTileCacheParameters` for the basemap and the `levelIds` are updated to skip unwanted levels of detail (based on the values selected in the UI). Note that the original "Streets" basemap is swapped for the "for export" version of the service - see https://www.arcgis.com/home/item.html?id=e384f5aa4eb1433c92afff09500b073d.
+In order to minimize the download size for offline map, this sample reduces the scale range for the "World Streets Basemap" layer by adjusting the relevant `ExportTileCacheParameters` in the `GenerateOfflineMapParameterOverrides`. The basemap layer is used to contsruct an `OfflineMapParametersKey`object. The key is then used to retrieve the specific `ExportTileCacheParameters` for the basemap and the `levelIds` are updated to skip unwanted levels of detail (based on the values selected in the UI). Note that the original "Streets" basemap is swapped for the "for export" version of the service - see <https://www.arcgis.com/home/item.html?id=e384f5aa4eb1433c92afff09500b073d>.
 
 ### Streets Basemap (buffer extent)
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.qml
@@ -93,7 +93,7 @@ Rectangle {
     // Create Offline Map Task
     OfflineMapTask {
         id: offlineMapTask
-        portalItem: mapPortalItem
+        onlineMap: map
         property var generateJob
 
         onErrorChanged: console.log("error:", error.message, error.additionalMessage);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.qml
@@ -95,7 +95,7 @@ Rectangle {
     // Create Offline Map Task
     OfflineMapTask {
         id: offlineMapTask
-        portalItem: mapPortalItem
+        onlineMap: map
         property var generateJob
 
         onErrorChanged: console.log("error:", error.message, error.additionalMessage);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.qml
@@ -96,7 +96,7 @@ Rectangle {
     // Create Offline Map Task
     OfflineMapTask {
         id: offlineMapTask
-        portalItem: mapPortalItem
+        onlineMap: map
 
         onErrorChanged: console.log("error:", error.message, error.additionalMessage);
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/README.md
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/README.md
@@ -22,11 +22,11 @@ When taking a web map offline, you may adjust the data (such as layers or tiles)
 
 ## How it works
 
-The sample creates a `PortalItem` object using a web map’s ID. This portal item is also used to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask.createDefaultGenerateOfflineMapParameters`. Once the parameters are retrieved, they are used to create a set of `GenerateOfflineMapParameterOverrides` by calling `OfflineMapTask.createGenerateOfflineMapParameterOverrides`. The overrides are then adjusted so that specific layers will be taken offline using custom settings.
+The sample creates a `PortalItem` object using a web map’s ID. Create a `Map` with this portal item. Use the `Map` to initialize an `OfflineMapTask` object. When the button is clicked, the sample requests the default parameters for the task, with the selected extent, by calling `OfflineMapTask.createDefaultGenerateOfflineMapParameters`. Once the parameters are retrieved, they are used to create a set of `GenerateOfflineMapParameterOverrides` by calling `OfflineMapTask.createGenerateOfflineMapParameterOverrides`. The overrides are then adjusted so that specific layers will be taken offline using custom settings.
 
 ### Streets basemap (adjust scale range)
 
-In order to minimize the download size for offline map, this sample reduces the scale range for the "World Streets Basemap" layer by adjusting the relevant `ExportTileCacheParameters` in the `GenerateOfflineMapParameterOverrides`. The basemap layer is used to contsruct an `OfflineMapParametersKey`object. The key is then used to retrieve the specific `ExportTileCacheParameters` for the basemap and the `levelIds` are updated to skip unwanted levels of detail (based on the values selected in the UI). Note that the original "Streets" basemap is swapped for the "for export" version of the service - see https://www.arcgis.com/home/item.html?id=e384f5aa4eb1433c92afff09500b073d.
+In order to minimize the download size for offline map, this sample reduces the scale range for the "World Streets Basemap" layer by adjusting the relevant `ExportTileCacheParameters` in the `GenerateOfflineMapParameterOverrides`. The basemap layer is used to contsruct an `OfflineMapParametersKey`object. The key is then used to retrieve the specific `ExportTileCacheParameters` for the basemap and the `levelIds` are updated to skip unwanted levels of detail (based on the values selected in the UI). Note that the original "Streets" basemap is swapped for the "for export" version of the service - see <https://www.arcgis.com/home/item.html?id=e384f5aa4eb1433c92afff09500b073d>.
 
 ### Streets Basemap (buffer extent)
 


### PR DESCRIPTION
# Description

A couple of the samples dealing with offline map tasks do the following:

> - Create a PortalItem m_portalItem
> - initialize m_map using m_portalItem
> - initialize m_offlineMapTask using m_portalItem

This results in the OfflineMapTask creating its own map from m_portalItem. So there ends up being 2 instances of a map. Although the samples work correctly, if users copy and paste the code, they may run into problems trying to do something outside what the sample indicates. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement
