### PR TITLE
these properties were deprecated and removed

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -126,8 +126,8 @@ Rectangle {
     }
 
     function screenRatio() {
-        const width = mv.mapWidth;
-        const height = mv.mapHeight;
+        const width = mv.widthInPixels;
+        const height = mv.heightInPixels;
         return height > width ? width / height : height / width;
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -71,7 +71,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding
 
         model: ["Center","Center and scale","Geometry","Geometry and padding","Rotation","Scale 1:5,000,000","Scale 1:10,000,000","Animation"]
         onCurrentTextChanged: {


### PR DESCRIPTION
# Description

@tanneryould please review. mapWidth and mapHeight were deprecated and now removed at 200. This is the replacement. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [x] If adding a new sample, it is added to the sample viewer
- [x] Cherry-picked to Main branch (if applicable)
