### PR TITLE
Fix certain issues on Android 11+

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
@@ -67,12 +67,12 @@ Component {
                     }
                 }
 
-                Text {
+                Label {
                     width: parent.width
                     antialiasing: true
                     text: displayName
                     visible: drawer.visible
-                    color: "white"
+                    Material.theme: Material.Dark
                     font {
                         capitalization: Font.AllUppercase
                         pixelSize: 11

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
@@ -33,7 +33,7 @@ Page {
                     family: fontFamily
                     pixelSize: 18
                 }
-                color: "white"
+                Material.theme: Material.Dark
             }
             anchors.left: parent.left
             anchors.right: parent.right

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
@@ -73,6 +73,7 @@ Page {
     }
 
     Rectangle {
+        visible: searchBar.text !== ""
         color: "transparent"
         anchors {
             fill: parent
@@ -87,7 +88,6 @@ Page {
                 sourceModel: SampleManager.samples
                 filterString: searchBar.text
             }
-            visible: searchBar.text !== ""
         }
     }
     // Ensure virtual keyboard is not persisted after this item has been

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -61,7 +61,7 @@ Item {
                     family: fontFamily
                     pixelSize: 18
                 }
-                color: "white"
+                Material.theme: Material.Dark
             }
         }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
@@ -64,7 +64,7 @@ Item {
                     family: fontFamily
                     pixelSize: 18
                 }
-                color: "white"
+                Material.theme: Material.Dark
             }
         }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
@@ -53,7 +53,7 @@ Page {
                 pixelSize: 18
                 family: fontFamily
             }
-            color: "white"
+            Material.theme: Material.Dark
         }
     }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -56,7 +56,7 @@ ApplicationWindow {
                 pixelSize: 24
                 family: fontFamily
             }
-            color: "white"
+            Material.theme: Material.Dark
         }
 
         Image {


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Running the C++ Sample Viewer on Android version 11 (or later) exhibits two problems: text is black instead of white; and, the category cards are visually covered over by a white rectangle.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
