### PR TITLE
Fix Identify KML feature callout height

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -35,7 +35,9 @@ Item {
             id: callout
             calloutData: view.calloutData
             implicitWidth: 150
-            contentItem: Text {
+            implicitHeight: contentText.implicitHeight + (contentText.implicitHeight * .05)
+            contentItem: Label {
+                id: contentText
                 text: model.calloutText
                 wrapMode: Text.WordWrap
                 textFormat: Text.RichText

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.qml
@@ -42,8 +42,9 @@ Rectangle {
             id: callout
             calloutData: parent.calloutData
             implicitWidth: 150
+            implicitHeight: contentText.implicitHeight + (contentText.implicitHeight * .05)
             contentItem: Label {
-                id: componentText
+                id: contentText
                 text: calloutText
                 wrapMode: Text.WordWrap
                 textFormat: Text.RichText


### PR DESCRIPTION
# Description

Fixes a bug where the callout height in "Identify KML features" would not scale with the height of the text.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

![Screen Shot 2022-12-05 at 11 59 56 AM](https://user-images.githubusercontent.com/48941951/205731688-60324fbf-4cb9-431c-88fe-179c4ad13f67.png)
