### PR TITLE
disable allowNativeHeapPointerTagging to support Android 11+

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/android/AndroidManifest.xml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/android/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
     <!-- %%INSERT_FEATURES -->
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
-    <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:extractNativeLibs="true" android:hardwareAccelerated="true" android:label="Qt Samples - C++" android:allowBackup="true" android:fullBackupOnly="false" android:icon="@drawable/icon">
+    <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:extractNativeLibs="true" android:hardwareAccelerated="true" android:label="Qt Samples - C++" android:allowBackup="true" android:allowNativeHeapPointerTagging="false" android:fullBackupOnly="false" android:icon="@drawable/icon">
         <activity android:name="org.qtproject.qt.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:label="Qt Samples - C++" android:launchMode="singleTop" android:screenOrientation="unspecified" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/android/AndroidManifest.xml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/android/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
     <!-- %%INSERT_FEATURES -->
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
-    <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:extractNativeLibs="true" android:hardwareAccelerated="true" android:label="Qt Samples - QML" android:allowBackup="true" android:fullBackupOnly="false" android:icon="@drawable/icon">
+    <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:extractNativeLibs="true" android:hardwareAccelerated="true" android:label="Qt Samples - QML" android:allowBackup="true" android:allowNativeHeapPointerTagging="false" android:fullBackupOnly="false" android:icon="@drawable/icon">
         <activity android:name="org.qtproject.qt.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:label="Qt Samples - QML" android:launchMode="singleTop" android:screenOrientation="unspecified" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryCard.qml
@@ -67,12 +67,12 @@ Component {
                     }
                 }
 
-                Label {
+                Text {
                     width: parent.width
                     antialiasing: true
                     text: displayName
                     visible: drawer.visible
-                    Material.theme: Material.Dark
+                    color: "white"
                     font {
                         capitalization: Font.AllUppercase
                         pixelSize: 11

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/CategoryGridView.qml
@@ -33,7 +33,7 @@ Page {
                     family: fontFamily
                     pixelSize: 18
                 }
-                Material.theme: Material.Dark
+                color: "white"
             }
             anchors.left: parent.left
             anchors.right: parent.right
@@ -73,7 +73,6 @@ Page {
     }
 
     Rectangle {
-        visible: searchBar.text !== ""
         color: "transparent"
         anchors {
             fill: parent
@@ -88,6 +87,7 @@ Page {
                 sourceModel: SampleManager.samples
                 filterString: searchBar.text
             }
+            visible: searchBar.text !== ""
         }
     }
     // Ensure virtual keyboard is not persisted after this item has been

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/GAnalyticsView.qml
@@ -61,7 +61,7 @@ Item {
                     family: fontFamily
                     pixelSize: 18
                 }
-                Material.theme: Material.Dark
+                color: "white"
             }
         }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ProxySetupView.qml
@@ -64,7 +64,7 @@ Item {
                     family: fontFamily
                     pixelSize: 18
                 }
-                Material.theme: Material.Dark
+                color: "white"
             }
         }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
@@ -53,7 +53,7 @@ Page {
                 pixelSize: 18
                 family: fontFamily
             }
-            Material.theme: Material.Dark
+            color: "white"
         }
     }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -56,7 +56,7 @@ ApplicationWindow {
                 pixelSize: 24
                 family: fontFamily
             }
-            Material.theme: Material.Dark
+            color: "white"
         }
 
         Image {


### PR DESCRIPTION
Qt 6 on Android 11+ requires allowNativeHeapPointerTagging to be turned off in AndroidManifest.xml. This also eliminates the need for recent workarounds with "color" properties in our QML declarative code, so those changes are undone.

Note that this will require Android SDK android-30 (or newer) to build.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
