### PR TITLE
Tanneryould/cpp samples template update

### DIFF
--- a/sample-templates/templateArcGISRuntimeSDKQt_Cpp/sample.cpp.tmpl
+++ b/sample-templates/templateArcGISRuntimeSDKQt_Cpp/sample.cpp.tmpl
@@ -26,11 +26,13 @@
 @endif
 @if %{ThreeDSample}
 #include "ArcGISTiledElevationSource.h"
+#include "MapTypes.h"
 #include "Scene.h"
 #include "SceneQuickView.h"
 @else
 #include "Map.h"
 #include "MapQuickView.h"
+#include "MapTypes.h"
 @endif
 
 using namespace Esri::ArcGISRuntime;

--- a/sample-templates/templateArcGISRuntimeSDKQt_Cpp/sample.h.tmpl
+++ b/sample-templates/templateArcGISRuntimeSDKQt_Cpp/sample.h.tmpl
@@ -33,6 +33,12 @@ namespace Esri::ArcGISRuntime
 
 #include <QObject>
 
+@if %{ThreeDSample}
+  Q_MOC_INCLUDE("SceneQuickView.h");
+@else
+  Q_MOC_INCLUDE("MapQuickView.h");
+@endif
+
 class %{SampleName} : public QObject
 {
   Q_OBJECT


### PR DESCRIPTION
# Description

Adds changes that the samples templates require to run out of the box on 200.0.0.
Specifically:

* `Q_MOC_INCLUDE("{Map/Scene}QuickView.h");`
* `#include "MapTypes.h"`

The MapTypes.h include is in both map and scene view template variants in order to keep the header list alphabetical.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] macOS