### PR TITLE
Validate Network Topology sample hangs

### DIFF
--- a/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.qml
+++ b/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.qml
@@ -74,7 +74,6 @@ Item {
                         text: "Get State"
                         Layout.row: 0
                         Layout.column: 0
-                        Layout.fillWidth: true
                         onClicked: model.onGetState()
                         Layout.preferredWidth: clearBtn.width
                         enabled: model.stateButtonAvailability
@@ -84,7 +83,6 @@ Item {
                         text: "Validate"
                         Layout.row: 0
                         Layout.column: 1
-                        Layout.fillWidth: true
                         enabled: model.validateButtonAvailability
                         onClicked: model.onValidate()
                         Layout.preferredWidth: clearBtn.width
@@ -94,7 +92,6 @@ Item {
                         text: "Trace"
                         Layout.row: 1
                         Layout.column: 0
-                        Layout.fillWidth: true
                         enabled: model.traceButtonAvailability
                         onClicked: model.onTrace()
                         Layout.preferredWidth: clearBtn.width


### PR DESCRIPTION
# Description

Below lines in the `GridLayout`'s child components(buttons, progress bar etc) was causing recursive re-draw was the reason for the hang.
```
Layout.fillWidth: true
Layout.preferredWidth: clearBtn.width
```
One line is redundant in this.

Here we need to make sure that all buttons in the grid are of equal width, matching the width of the longest button, which is the `clearBtn`. So to do that, we set `Layout.fillWidth: true` for `clearBtn` and use the `clearBtn.width` of other components in `GridLayout` will fix the issue.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
