### PR TITLE
 Programmatic reticle tool sample - dark mode fix

### DIFF
--- a/CppSamples/EditData/EditGeometriesWithProgrammaticReticleTool/EditGeometriesWithProgrammaticReticleTool.qml
+++ b/CppSamples/EditData/EditGeometriesWithProgrammaticReticleTool/EditGeometriesWithProgrammaticReticleTool.qml
@@ -86,10 +86,10 @@ Item {
         }
     }
 
-    Item {
-        id: multifunctionButton
+    Rectangle {
         width: parent.width
         height: parent.height * 0.07
+        color: "white"
         opacity: reticleModel.multifunctionButtonEnabled ? 1.0 : 0.5
         anchors {
             top: mapView.bottom


### PR DESCRIPTION
# Description

Fixed the "Start Geometry Editor" button's black color issue in the dark mode.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
