### PR TITLE
Update Dockerfile

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/Dockerfile
+++ b/Scripts/CI/README_Metadata_StyleCheck/Dockerfile
@@ -11,8 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Using Debian slim which uses minimum packages necessary; Alpine is not preferred 
-FROM alpine:3.12
+FROM alpine:3.17
 
 LABEL maintainer="Tanner Yould <tyould@esri.com>"
 
@@ -26,9 +25,9 @@ ENV PYTHONUNBUFFERED=1
 ADD entry.py /entry.py
 ADD style.rb /style.rb
 
-# Install dependencies
+# Install dependencies (ruby 3.x, python3, mdl)
 RUN echo "**** Install Ruby and mdl ****" && \
-    apk add --update --no-cache ruby-full && \
+    apk add --update --no-cache ruby ruby-dev ruby-bundler && \
     gem install mdl --no-document && \
     echo "**** Install Python ****" && \
     apk add --no-cache python3 && \


### PR DESCRIPTION
# Description

Resolves this error:
https://github.com/Esri/arcgis-maps-sdk-samples-qt/actions/runs/17250598784/job/48951682025#step:5:81

alpine:3.17 supports Ruby 3.0
Ruby-dev installs only what's needed for the Docker build

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

