### PR TITLE
build: enum class needs to be public, windows

### DIFF
--- a/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.h
+++ b/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.h
@@ -1,3 +1,18 @@
+// [WriteFile Name=ManageFeaturesFeatureService, Category=EditData]
+// [Legal]
+// Copyright 2025 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
 
 #ifndef MANAGEFEATURESFEATURESERVICE_H
 #define MANAGEFEATURESFEATURESERVICE_H

--- a/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.h
+++ b/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.h
@@ -1,18 +1,3 @@
-// [WriteFile Name=ManageFeaturesFeatureService, Category=EditData]
-// [Legal]
-// Copyright 2025 Esri.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// [Legal]
 
 #ifndef MANAGEFEATURESFEATURESERVICE_H
 #define MANAGEFEATURESFEATURESERVICE_H
@@ -40,6 +25,10 @@ class ManageFeaturesFeatureService : public QQuickItem
 {
   Q_OBJECT
 
+  Q_PROPERTY(QString featureType READ featureType NOTIFY featureTypeChanged)
+  Q_PROPERTY(OperationMode operationMode READ operationMode WRITE setOperationMode NOTIFY operationModeChanged)
+
+public:
   enum class OperationMode
   {
     AddFeatures,
@@ -49,10 +38,6 @@ class ManageFeaturesFeatureService : public QQuickItem
   };
   Q_ENUM(OperationMode)
 
-  Q_PROPERTY(QString featureType READ featureType NOTIFY featureTypeChanged)
-  Q_PROPERTY(OperationMode operationMode READ operationMode WRITE setOperationMode NOTIFY operationModeChanged)
-
-public:
   explicit ManageFeaturesFeatureService(QQuickItem* parent = nullptr);
   ~ManageFeaturesFeatureService() override;
 


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
