### PR TITLE
Add overall percentage to ZipHelper

### DIFF
--- a/SampleViewer/ZipHelper.cpp
+++ b/SampleViewer/ZipHelper.cpp
@@ -22,6 +22,7 @@
 
 // enable logging
 //#define ZIP_LOGGING_ENABLED
+static constexpr bool TOTAL_PROGRESS_ENABLED = true;
 
 #ifdef Q_OS_WIN
 #include <sys/utime.h>
@@ -156,6 +157,16 @@ bool ZipHelper::extractCurrentFile(const QString& outputFilePath)
 
             emit extractProgress(fileName, outputFilePath, percent);
 
+            if constexpr (TOTAL_PROGRESS_ENABLED)
+            {
+                // check for a new percentage but only by whole numbers
+                auto oldPercentTotal = static_cast<int>(percentTotal());
+                m_bytesExtracted += result;
+                auto newPercentTotal = static_cast<int>(percentTotal());
+                if (newPercentTotal != oldPercentTotal)
+                    emit extractProgressTotal(newPercentTotal);
+            }
+
             outputFile.write(buffer.data(), result);
             readBytes += result;
         }
@@ -182,6 +193,20 @@ bool ZipHelper::extractCurrentFile(const QString& outputFilePath)
 bool ZipHelper::extractAll(QDir& outputDir)
 {
     bool haveFile = gotoFirstFile();
+
+    if constexpr (TOTAL_PROGRESS_ENABLED)
+    {
+        m_bytesExtracted = 0;
+        m_bytesTotalUncompressed = 0;
+        while (haveFile)
+        {
+            auto fileInfo = currentFileInfo();
+            m_bytesTotalUncompressed += fileInfo.uncompressed_size;
+            haveFile = gotoNextFile();
+        }
+        haveFile = gotoFirstFile();
+    }
+
     while (haveFile)
     {
         const auto fileName = currentFileName();
@@ -400,6 +425,15 @@ bool ZipHelper::zrOpen()
     }
 
     return ok;
+}
+
+qreal ZipHelper::percentTotal() const
+{
+    qreal percent = 0.0;
+    if (m_bytesTotalUncompressed != 0)
+        percent = (qreal)m_bytesExtracted / (qreal)m_bytesTotalUncompressed * 100.0;
+
+    return percent;
 }
 
 void ZipHelper::setPath(const QString& path)

--- a/SampleViewer/ZipHelper.cpp
+++ b/SampleViewer/ZipHelper.cpp
@@ -431,7 +431,7 @@ qreal ZipHelper::percentTotal() const
 {
     qreal percent = 0.0;
     if (m_bytesTotalUncompressed != 0)
-        percent = (qreal)m_bytesExtracted / (qreal)m_bytesTotalUncompressed * 100.0;
+        percent = m_bytesExtracted / static_cast<qreal>(m_bytesTotalUncompressed) * 100.0;
 
     return percent;
 }

--- a/SampleViewer/ZipHelper.cpp
+++ b/SampleViewer/ZipHelper.cpp
@@ -22,7 +22,6 @@
 
 // enable logging
 //#define ZIP_LOGGING_ENABLED
-static constexpr bool TOTAL_PROGRESS_ENABLED = false;
 
 #ifdef Q_OS_WIN
 #include <sys/utime.h>
@@ -157,7 +156,7 @@ bool ZipHelper::extractCurrentFile(const QString& outputFilePath)
 
             emit extractProgress(fileName, outputFilePath, percent);
 
-            if constexpr (TOTAL_PROGRESS_ENABLED)
+            if (m_trackTotalProgress)
             {
                 // check for a new percentage but only by whole numbers
                 auto oldPercentTotal = static_cast<int>(percentTotal());
@@ -194,14 +193,13 @@ bool ZipHelper::extractAll(QDir& outputDir)
 {
     bool haveFile = gotoFirstFile();
 
-    if constexpr (TOTAL_PROGRESS_ENABLED)
+    if (m_trackTotalProgress)
     {
         m_bytesExtracted = 0;
         m_bytesTotalUncompressed = 0;
         while (haveFile)
         {
-            auto fileInfo = currentFileInfo();
-            m_bytesTotalUncompressed += fileInfo.uncompressed_size;
+            m_bytesTotalUncompressed += currentFileInfo().uncompressed_size;
             haveFile = gotoNextFile();
         }
         haveFile = gotoFirstFile();
@@ -459,13 +457,15 @@ void ZipHelper::setPath(const QString& path)
   \brief Extracts all files from the archive.
   \list
     \li \a outputPath The path to the destination folder.
+    \li \a trackTotalProgress Will enable signals for extract overall percentage
   \endlist
 
   Returns \c true if successful; otherwise \c false.
 */
 
-bool ZipHelper::extractAll(const QString &outputPath)
+bool ZipHelper::extractAll(const QString &outputPath, bool trackTotalProgress)
 {
+    m_trackTotalProgress = trackTotalProgress;
     if (!zrOpen())
     {
 #ifdef ZIP_LOGGING_ENABLED

--- a/SampleViewer/ZipHelper.cpp
+++ b/SampleViewer/ZipHelper.cpp
@@ -22,7 +22,7 @@
 
 // enable logging
 //#define ZIP_LOGGING_ENABLED
-static constexpr bool TOTAL_PROGRESS_ENABLED = true;
+static constexpr bool TOTAL_PROGRESS_ENABLED = false;
 
 #ifdef Q_OS_WIN
 #include <sys/utime.h>

--- a/SampleViewer/ZipHelper.cpp
+++ b/SampleViewer/ZipHelper.cpp
@@ -191,21 +191,17 @@ bool ZipHelper::extractCurrentFile(const QString& outputFilePath)
 
 bool ZipHelper::extractAll(QDir& outputDir)
 {
-    bool haveFile = gotoFirstFile();
-
     if (m_trackTotalProgress)
     {
         m_bytesExtracted = 0;
         m_bytesTotalUncompressed = 0;
-        while (haveFile)
+        for (bool haveFile = gotoFirstFile(); haveFile; haveFile = gotoNextFile())
         {
             m_bytesTotalUncompressed += currentFileInfo().uncompressed_size;
-            haveFile = gotoNextFile();
         }
-        haveFile = gotoFirstFile();
     }
 
-    while (haveFile)
+    for (bool haveFile = gotoFirstFile(); haveFile; haveFile = gotoNextFile())
     {
         const auto fileName = currentFileName();
         const auto path = QFileInfo(fileName).path();
@@ -217,8 +213,6 @@ bool ZipHelper::extractAll(QDir& outputDir)
         auto outputFilePath = outputDir.filePath(fileName);
 
         extractCurrentFile(outputFilePath);
-
-        haveFile = gotoNextFile();
     }
 
     emit extractCompleted();

--- a/SampleViewer/ZipHelper.h
+++ b/SampleViewer/ZipHelper.h
@@ -48,7 +48,7 @@ public:
   Q_ENUM(Result)
 
 public:
-  Q_INVOKABLE bool extractAll(const QString &outputPath);
+  Q_INVOKABLE bool extractAll(const QString &outputPath, bool trackTotalProgress = false);
   void setPath(const QString& path);
 
   explicit ZipHelper(QObject* parent = nullptr);
@@ -109,6 +109,7 @@ private:
   bool zrOpen();
   qreal percentTotal() const;
   const QString& path() const { return m_Path; }
+  bool m_trackTotalProgress = false;
 
 private:
   QString                     m_Path;

--- a/SampleViewer/ZipHelper.h
+++ b/SampleViewer/ZipHelper.h
@@ -60,6 +60,7 @@ signals:
 
   void extractError(const QString& fileName, const QString& outputFileName, ZipHelper::Result result);
   void extractProgress(const QString& fileName, const QString& outputFileName, qreal percent);
+  void extractProgressTotal(qsizetype percentTotal);
   void extractCompleted();
 
 private:
@@ -106,12 +107,15 @@ private:
   void zwClose(const QString& globalComment = QString());
   bool exists() const;
   bool zrOpen();
+  qreal percentTotal() const;
   const QString& path() const { return m_Path; }
 
 private:
   QString                     m_Path;
   unzFile                     m_unzFile;
   zipFile                     m_zipFile;
+  quint64                     m_bytesExtracted = 0;
+  quint64                     m_bytesTotalUncompressed = 0;
 };
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
# Description

Adding properties and signals to allow tracking of the overall extraction progress for the archive.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
