### PR TITLE
Calcite changes - Display information category

### DIFF
--- a/CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -137,7 +137,7 @@ BuildLegendSample {
                         Label {
                             anchors.verticalCenter: parent.verticalCenter
                             width: 125
-                            text: qsTr(name)
+                            text: name
                             wrapMode: Text.WordWrap
                             font.pixelSize: 12
                         }
@@ -155,7 +155,7 @@ BuildLegendSample {
                         color: palette.highlight
 
                         Label {
-                            text: qsTr(section)
+                            text: section
                             font.bold: true
                             font.pixelSize: 13
                         }

--- a/CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -45,7 +45,7 @@ BuildLegendSample {
         property bool expanded: true
         height: 200
         width: 175
-        color: "lightgrey"
+        color: palette.base
         opacity: 0.95
         radius: 10
         clip: true
@@ -80,7 +80,7 @@ BuildLegendSample {
             Row {
                 spacing: 55
 
-                Text {
+                Label {
                     text: qsTr("Legend")
                     font {
                         pixelSize: 18
@@ -134,10 +134,10 @@ BuildLegendSample {
                             height: width
                             source: symbolUrl
                         }
-                        Text {
+                        Label {
                             anchors.verticalCenter: parent.verticalCenter
                             width: 125
-                            text: name
+                            text: qsTr(name)
                             wrapMode: Text.WordWrap
                             font.pixelSize: 12
                         }
@@ -152,10 +152,10 @@ BuildLegendSample {
                     delegate: Rectangle {
                         width: 180
                         height: childrenRect.height
-                        color: "lightsteelblue"
+                        color: palette.highlight
 
-                        Text {
-                            text: section
+                        Label {
+                            text: qsTr(section)
                             font.bold: true
                             font.pixelSize: 13
                         }

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
@@ -55,7 +55,7 @@ Item {
 
                     Label {
                         id: openBoxText
-                        text: qsTr(controlAnnotationSublayerVisibilityModel.openLayerText)
+                        text: controlAnnotationSublayerVisibilityModel.openLayerText
                         anchors.verticalCenter: openBox.verticalCenter
                         color: scale.color
                     }
@@ -70,7 +70,7 @@ Item {
 
                     Label {
                         id: closedBoxText
-                        text: qsTr(controlAnnotationSublayerVisibilityModel.closedLayerText)
+                        text: controlAnnotationSublayerVisibilityModel.closedLayerText
                         anchors.verticalCenter: closedBox.verticalCenter
                     }
                 }

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qml
@@ -38,13 +38,14 @@ Item {
                 margins: 2
             }
             width: childrenRect.width
-            height: childrenRect.height
-            color: "white"
-            opacity: .75
+            height: childrenRect.height + 16
+            color: palette.base
+            opacity: .9
             radius: 5
 
             ColumnLayout {
-                spacing: 0
+                spacing: 8
+                anchors.centerIn: parent
                 Row {
                     CheckBox {
                         id: openBox
@@ -52,9 +53,9 @@ Item {
                         onCheckStateChanged: controlAnnotationSublayerVisibilityModel.openLayerVisible();
                     }
 
-                    Text {
+                    Label {
                         id: openBoxText
-                        text: controlAnnotationSublayerVisibilityModel.openLayerText
+                        text: qsTr(controlAnnotationSublayerVisibilityModel.openLayerText)
                         anchors.verticalCenter: openBox.verticalCenter
                         color: scale.color
                     }
@@ -67,9 +68,9 @@ Item {
                         onCheckStateChanged: controlAnnotationSublayerVisibilityModel.closedLayerVisible();
                     }
 
-                    Text {
+                    Label {
                         id: closedBoxText
-                        text: controlAnnotationSublayerVisibilityModel.closedLayerText
+                        text: qsTr(controlAnnotationSublayerVisibilityModel.closedLayerText)
                         anchors.verticalCenter: closedBox.verticalCenter
                     }
                 }
@@ -84,11 +85,12 @@ Item {
             }
             width: childrenRect.width
             height: childrenRect.height
+            color: palette.base
 
-            Text {
+            Label {
                 id: scale
-                text: "Current map scale: 1:%1".arg(Math.round(controlAnnotationSublayerVisibilityModel.mapScale))
-                color: controlAnnotationSublayerVisibilityModel.visibleAtCurrentExtent ? "black" : "grey"
+                text: qsTr("Current map scale: 1:%1".arg(Math.round(controlAnnotationSublayerVisibilityModel.mapScale)))
+                color: controlAnnotationSublayerVisibilityModel.visibleAtCurrentExtent ? palette.text : "grey"
                 padding: 2
             }
         }

--- a/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
+++ b/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
@@ -112,7 +112,7 @@ Item {
                             id: symbolText
                             anchors.verticalCenter: parent.verticalCenter
                             width: 110
-                            text: qsTr(name)
+                            text: name
                             wrapMode: Text.Wrap
                             font.pixelSize: 12
                         }

--- a/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
+++ b/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
@@ -47,7 +47,7 @@ Item {
         }
         height: 545
         width: 175
-        color: "lightgrey"
+        color: palette.base
         opacity: 0.9
         clip: true
         border {
@@ -72,7 +72,7 @@ Item {
             Row {
                 spacing: 55
 
-                Text {
+                Label {
                     text: qsTr("Legend")
                     font {
                         pixelSize: 18
@@ -108,11 +108,11 @@ Item {
                             source: symbolUrl
                         }
 
-                        Text {
+                        Label {
                             id: symbolText
                             anchors.verticalCenter: parent.verticalCenter
                             width: 110
-                            text: name
+                            text: qsTr(name)
                             wrapMode: Text.Wrap
                             font.pixelSize: 12
                         }

--- a/CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
+++ b/CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qml
@@ -46,7 +46,7 @@ Item {
         }
         width: radioColumn.width
         height: radioColumn.height
-        color: "white"
+        color: palette.base
         border {
             color: "black"
             width: 1
@@ -58,17 +58,17 @@ Item {
             padding: 5
             spacing: 5
 
-            Text {
-                text: "Custom Dictionary Symbol Style Source"
+            Label {
+                text: qsTr("Custom Dictionary Symbol Style Source")
             }
 
             RadioButton {
-                text: "Local .stylx file"
+                text: qsTr("Local .stylx file")
                 checked: true
             }
 
             RadioButton {
-                text: "Web style"
+                text: qsTr("Web style")
                 onCheckedChanged: {
                     model.changeDictionarySymbolStyleSource();
                 }

--- a/CppSamples/DisplayInformation/DisplayClusters/DisplayClusters.qml
+++ b/CppSamples/DisplayInformation/DisplayClusters/DisplayClusters.qml
@@ -70,6 +70,7 @@ Item {
     BusyIndicator {
         anchors.centerIn: parent
         running: model.taskRunning
+        visible: model.taskRunning
     }
 }
 //"DisplayClusters - C++"

--- a/CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
+++ b/CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
@@ -45,8 +45,8 @@ IdentifyGraphicsSample {
         x: Math.round(parent.width - width) / 2
         y: Math.round(parent.height - height) / 2
         standardButtons: Dialog.Ok
-        Text {
-            text: "Tapped on graphic"
+        Label {
+            text: qsTr("Tapped on graphic")
         }
     }
 }

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
@@ -37,7 +37,7 @@ Item {
                 horizontalCenter: parent.horizontalCenter
                 bottomMargin: 10
             }
-            text: "Clear Graphics"
+            text: qsTr("Clear Graphics")
             onClicked: model.clearGraphics();
         }
     }
@@ -53,7 +53,7 @@ Item {
             fill: optionGrid
             margins: -5
         }
-        color: "#efefef"
+        color: palette.base
     }
 
     GridLayout {
@@ -69,12 +69,12 @@ Item {
         Label {
             Layout.columnSpan: 2
             Layout.alignment: Qt.AlignCenter
-            text: "Change Options to Modify Symbol"
+            text: qsTr("Change Options to Modify Symbol")
             font.underline: true
         }
 
         Label {
-            text: "Eyes"
+            text: qsTr("Eyes")
         }
 
         SymbolComboBox {
@@ -84,7 +84,7 @@ Item {
         }
 
         Label {
-            text: "Mouth"
+            text: qsTr("Mouth")
         }
 
         SymbolComboBox {
@@ -94,7 +94,7 @@ Item {
         }
 
         Label {
-            text: "Hat"
+            text: qsTr("Hat")
         }
 
         SymbolComboBox {
@@ -104,7 +104,7 @@ Item {
         }
 
         Label {
-            text: "Base Color"
+            text: qsTr("Base Color")
         }
 
         ComboBox {
@@ -114,7 +114,7 @@ Item {
         }
 
         Label {
-            text: "Size"
+            text: qsTr("Size")
         }
 
         Slider {
@@ -127,7 +127,7 @@ Item {
         }
 
         Label {
-            text: "Preview:"
+            text: qsTr("Preview:")
         }
 
         Image {

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
@@ -34,7 +34,7 @@ ComboBox {
                 Layout.preferredHeight: 20
             }
             Label {
-                text: qsTr(name)
+                text: name
                 Layout.preferredWidth: cboDelegate.width - img.width
                 elide: Text.ElideRight
             }

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolComboBox.qml
@@ -34,7 +34,7 @@ ComboBox {
                 Layout.preferredHeight: 20
             }
             Label {
-                text: name
+                text: qsTr(name)
                 Layout.preferredWidth: cboDelegate.width - img.width
                 elide: Text.ElideRight
             }

--- a/CppSamples/DisplayInformation/ShowGrid/ShowGrid.qml
+++ b/CppSamples/DisplayInformation/ShowGrid/ShowGrid.qml
@@ -70,18 +70,17 @@ Item {
             width: 100
             height: 30
 
-            color: selected ? "#959595" : "#D6D6D6"
+            color: selected ? palette.highlight : palette.base
             radius: 8
             border {
-                color: selected ? "#7938b6" : "#585858"
+                color: selected ? palette.base : palette.highlight
                 width: selected ? 2 : 1
             }
 
-            Text {
+            Label {
                 anchors.centerIn: parent
-                text: "Map View"
+                text: qsTr("Map View")
                 font.pixelSize: 14
-                color: "#474747"
             }
 
             MouseArea {
@@ -100,18 +99,17 @@ Item {
             width: 100
             height: 30
 
-            color: selected ? "#959595" : "#D6D6D6"
+            color: selected ? palette.highlight : palette.base
             radius: 8
             border {
-                color: selected ? "#7938b6" : "#585858"
+                color: selected ? palette.base : palette.highlight
                 width: selected ? 2 : 1
             }
 
-            Text {
+            Label {
                 anchors.centerIn: parent
-                text: "Scene View"
+                text: qsTr("Scene View")
                 font.pixelSize: 14
-                color: "#474747"
             }
 
             MouseArea {
@@ -141,18 +139,17 @@ Item {
 
         width: 150
         height: 30
-        color: pressed ? "#959595" : "#D6D6D6"
+        color: pressed ? palette.highlight : palette.base
         radius: 8
         border {
             color: "#585858"
             width: 1
         }
 
-        Text {
+        Label {
             anchors.centerIn: parent
-            text: "Change grid style"
+            text: qsTr("Change grid style")
             font.pixelSize: 14
-            color: "#474747"
         }
 
         MouseArea {
@@ -193,7 +190,7 @@ Item {
         height: childrenRect.height
         width: childrenRect.width
 
-        color: "lightgray"
+        color: palette.base
         radius: 4
         border {
             color: "black"
@@ -214,9 +211,9 @@ Item {
             id: grid
             columns: 2
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Grid type"
+                text: qsTr("Grid type")
             }
 
             ComboBox {
@@ -247,9 +244,9 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Grid visible"
+                text: qsTr("Grid visible")
             }
 
             Switch {
@@ -260,10 +257,10 @@ Item {
             }
 
             Text {
-                text: "Labels visible"
+                text: qsTr("Labels visible")
                 Layout.leftMargin: 10
                 enabled: gridVisibleSwitch.checked
-                color: enabled ? "black" : "gray"
+                color: enabled ? palette.text : "gray"
             }
 
             Switch {
@@ -274,9 +271,9 @@ Item {
                 onCheckedChanged: gridSample.setLabelsVisible(checked);
             }
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Grid color"
+                text: qsTr("Grid color")
             }
 
             ComboBox {
@@ -299,9 +296,9 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Label color"
+                text: qsTr("Label color")
             }
 
             ComboBox {
@@ -324,11 +321,11 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Label position"
+                text: qsTr("Label position")
                 enabled: positionCombo.enabled
-                color: enabled ? "black"  : "gray"
+                color: enabled ? palette.text  : "gray"
             }
 
             ComboBox {
@@ -351,11 +348,11 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Label format"
+                text: qsTr("Label format")
                 enabled: formatCombo.enabled
-                color: enabled ? "black"  : "gray"
+                color: enabled ? palette.text  : "gray"
             }
 
             ComboBox {
@@ -379,11 +376,11 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 Layout.leftMargin: 10
-                text: "Label offset"
+                text: qsTr("Label offset")
                 enabled: offsetSlider.enabled
-                color: enabled ? "black"  : "gray"
+                color: enabled ? palette.text  : "gray"
             }
 
             Slider {
@@ -406,13 +403,13 @@ Item {
                     implicitWidth: 26
                     implicitHeight: 26
 
-                    color: offsetSlider.enabled ? "white" : "lightgrey"
+                    color: offsetSlider.enabled ? palette.highlight : "gray"
                     border.color: "gray"
-                    Text {
+                    Label {
                         anchors.centerIn: parent
-                        text: offsetSlider.value.toFixed(0)
+                        text: qsTr(offsetSlider.value.toFixed(0))
                         font.pixelSize: 14
-                        color: offsetSlider.enabled ? "black" : "gray"
+                        color: offsetSlider.enabled ? palette.text : "gray"
                         onWidthChanged: {
                             parent.width = Math.max(width + 10, 26)
                         }
@@ -430,18 +427,17 @@ Item {
 
                 width: 150
                 height: 30
-                color: pressed ? "#959595" : "#D6D6D6"
+                color: pressed ? palette.highlight : palette.base
                 radius: 8
                 border {
                     color: "#585858"
                     width: 1
                 }
 
-                Text {
+                Label {
                     anchors.centerIn: parent
-                    text: "Hide window"
+                    text: qsTr("Hide window")
                     font.pixelSize: 14
-                    color: "#474747"
                 }
 
                 MouseArea {

--- a/CppSamples/DisplayInformation/ShowGrid/ShowGrid.qml
+++ b/CppSamples/DisplayInformation/ShowGrid/ShowGrid.qml
@@ -407,7 +407,7 @@ Item {
                     border.color: "gray"
                     Label {
                         anchors.centerIn: parent
-                        text: qsTr(offsetSlider.value.toFixed(0))
+                        text: offsetSlider.value.toFixed(0)
                         font.pixelSize: 14
                         color: offsetSlider.enabled ? palette.text : "gray"
                         onWidthChanged: {

--- a/CppSamples/DisplayInformation/ShowPopup/ShowPopup.qml
+++ b/CppSamples/DisplayInformation/ShowPopup/ShowPopup.qml
@@ -60,5 +60,6 @@ Item {
     BusyIndicator {
         anchors.centerIn: parent
         running: model.taskRunning
+        visible: model.taskRunning
     }
 }

--- a/CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
+++ b/CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.qml
@@ -42,7 +42,7 @@ SymbolizeShapefileSample {
             top: parent.top
             margins: 10
         }
-        text: "Change Renderer"
+        text: qsTr("Change Renderer")
         onClicked: {
             updateRenderer();
             visible = false;


### PR DESCRIPTION
# Description
Style changes for samples in the display information category. The changes replace hardcoded colors with colors from the `palette`. Changes have also been made to use qsTr() where applicable.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [x] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
