### PR TITLE
Remove usage of instance methods

### DIFF
--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
@@ -63,16 +63,6 @@ ControlAnnotationSublayerVisibility::ControlAnnotationSublayerVisibility(QObject
 {
   const QString dataPath = defaultDataPath() + sampleFileAnno;
 
-  // connect to the Mobile Map Package instance to know when errors occur
-  connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
-          [](const Error& error)
-  {
-    if (error.isEmpty())
-      return;
-
-    qDebug() << QString("Error: %1 %2").arg(error.message(), error.additionalMessage());
-  });
-
   // Load the MMPK
   createMapPackage(dataPath);
 }
@@ -121,6 +111,17 @@ void ControlAnnotationSublayerVisibility::createMapPackage(const QString& path)
   //! [open mobile map package cpp snippet]
   // instatiate a mobile map package
   m_mobileMapPackage = new MobileMapPackage(path, this);
+
+  // connect to the Mobile Map Package errorOccurred to know when errors occur
+  connect(m_mobileMapPackage, &MobileMapPackage::errorOccurred, [](const Error& error)
+  {
+    if (error.isEmpty())
+    {
+      return;
+    }
+
+    qDebug() << QString("Error: %1 %2").arg(error.message(), error.additionalMessage());
+  });
 
   // wait for the mobile map package to load
   connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, [this](const Error& error)

--- a/CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.cpp
+++ b/CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.cpp
@@ -58,18 +58,6 @@ HonorMobileMapPackageExpiration::HonorMobileMapPackageExpiration(QObject* parent
   QObject(parent),
   m_dataPath(defaultDataPath() + sampleMmpk)
 {
-  // connect to the Mobile Map Package instance to know when errors occur
-  connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
-          [](const Error& e)
-  {
-    if (e.isEmpty())
-    {
-      return;
-    }
-
-    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
-  });
-
 }
 
 HonorMobileMapPackageExpiration::~HonorMobileMapPackageExpiration() = default;
@@ -103,6 +91,17 @@ void HonorMobileMapPackageExpiration::createMapPackage(const QString& path)
 {
   // instatiate a mobile map package
   m_mobileMapPackage = new MobileMapPackage(path, this);
+
+  // connect to the Mobile Map Package errorOccurred to know when errors occur
+  connect(m_mobileMapPackage, &MobileMapPackage::errorOccurred, [](const Error& e)
+  {
+    if (e.isEmpty())
+    {
+      return;
+    }
+
+    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
+  });
 
   // wait for the mobile map package to load
   connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, [this](const Error& error)

--- a/CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
+++ b/CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.cpp
@@ -57,17 +57,6 @@ const QString sampleFileYellowstone {"/ArcGIS/Runtime/Data/mmpk/Yellowstone.mmpk
 OpenMobileMap_MapPackage::OpenMobileMap_MapPackage(QQuickItem* parent) :
   QQuickItem(parent)
 {
-  // connect to the Mobile Map Package instance to know when errors occur
-  connect(MobileMapPackage::instance(), &MobileMapPackage::errorOccurred,
-          [](const Error& e)
-  {
-    if (e.isEmpty())
-    {
-      return;
-    }
-
-    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
-  });
 }
 
 OpenMobileMap_MapPackage::~OpenMobileMap_MapPackage() = default;
@@ -100,6 +89,17 @@ void OpenMobileMap_MapPackage::createMapPackage(const QString& path)
   //! [open mobile map package cpp snippet]
   // instatiate a mobile map package
   m_mobileMapPackage = new MobileMapPackage(path, this);
+
+  // connect to the Mobile Map Package errorOccurred to know when errors occur
+  connect(m_mobileMapPackage, &MobileMapPackage::errorOccurred, [](const Error& e)
+  {
+    if (e.isEmpty())
+    {
+      return;
+    }
+
+    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
+  });
 
   // wait for the mobile map package to load
   connect(m_mobileMapPackage, &MobileMapPackage::doneLoading, this, [this](const Error& error)

--- a/CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
+++ b/CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.cpp
@@ -58,16 +58,6 @@ OpenMobileScenePackage::OpenMobileScenePackage(QObject* parent /* = nullptr */):
   // separately are specified in the readme.
   const QString dataPath = defaultDataPath() + "/ArcGIS/Runtime/Data/mspk/philadelphia.mspk";
 
-  // connect to the Mobile Scene Package instance to know when errors occur
-  connect(MobileScenePackage::instance(), &MobileScenePackage::errorOccurred,
-          [](const Error& e)
-  {
-    if (e.isEmpty())
-      return;
-
-    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
-  });
-
   // Create the Scene Package
   createScenePackage(dataPath);
 }
@@ -128,6 +118,19 @@ void OpenMobileScenePackage::packageLoaded(const Error& e)
 void OpenMobileScenePackage::createScenePackage(const QString& path)
 {
   m_scenePackage = new MobileScenePackage(path, this);
+
+  // connect to the Mobile Scene Package errorOccurred to know when errors occur
+  connect(m_scenePackage, &MobileScenePackage::errorOccurred, [](const Error& e)
+  {
+    if (e.isEmpty())
+    {
+      return;
+    }
+
+    qDebug() << QString("Error: %1 %2").arg(e.message(), e.additionalMessage());
+  });
+
   connect(m_scenePackage, &MobileScenePackage::doneLoading, this, &OpenMobileScenePackage::packageLoaded);
+
   m_scenePackage->load();
 }


### PR DESCRIPTION
# Description

We have removed some of the `instance` methods from our API, causing our samples to break. Our usage of `instance` in these samples didn't make sense anymore, as we already instantiate an object of whatever the `instance` type was in the sample. We can just connect to the `errorOccurred` signal off of that.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
