### PR TITLE
Calcite changes - sample viewer updates

### DIFF
--- a/SampleViewer/mac/Info.plist
+++ b/SampleViewer/mac/Info.plist
@@ -22,8 +22,6 @@
     <string>NSApplication</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
-    <key>NSRequiresAquaSystemAppearance</key>
-    <string>true</string>
     <key>NSLocationUsageDescription</key>
     <string>Application requires location services</string>
     <key>NSLocationWhenInUseUsageDescription</key>

--- a/SampleViewer/qml/AboutView.qml
+++ b/SampleViewer/qml/AboutView.qml
@@ -16,6 +16,7 @@
 import QtQuick
 import QtQuick.Controls
 import Esri.ArcGISRuntimeSamples
+import Calcite
 
 Item {
     visible: false
@@ -39,6 +40,7 @@ Item {
         clip: true
         background: Rectangle {
             radius: 3
+            color: palette.base
         }
 
         SwipeView {
@@ -54,6 +56,7 @@ Item {
                 clip: true
                 background: Rectangle {
                     radius: 3
+                    color: palette.base
                 }
 
                 Column {
@@ -71,7 +74,7 @@ Item {
                         height: 66
                     }
 
-                    Text {
+                    Label {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("ArcGIS Maps SDK for Qt Samples")
                         font {
@@ -82,7 +85,7 @@ Item {
                         }
                     }
 
-                    Text {
+                    Label {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Built with ArcGIS Maps SDK for Qt")
                         font {
@@ -91,7 +94,7 @@ Item {
                         }
                     }
 
-                    Text {
+                    Label {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: buildNum // obtained from main.cpp (engine.rootContext()->setContextProperty)
                         font {
@@ -106,6 +109,7 @@ Item {
                 clip: true
                 background: Rectangle {
                     radius: 3
+                    color: palette.base
                 }
 
                 Column {
@@ -123,7 +127,7 @@ Item {
                         height: 72
                     }
 
-                    Text {
+                    Label {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("View the samples on GitHub")
                         renderType: Text.NativeRendering
@@ -131,7 +135,7 @@ Item {
                             family: fontFamily
                             pixelSize: 13
                         }
-                        color: "blue"
+                        color: Calcite.textLink
 
                         MouseArea {
                             anchors.fill: parent
@@ -139,7 +143,7 @@ Item {
                         }
                     }
 
-                    Text {
+                    Label {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Learn more about the SDK")
                         renderType: Text.NativeRendering
@@ -147,7 +151,7 @@ Item {
                             family: fontFamily
                             pixelSize: 13
                         }
-                        color: "blue"
+                        color: Calcite.textLink
 
                         MouseArea {
                             anchors.fill: parent
@@ -155,7 +159,7 @@ Item {
                         }
                     }
 
-                    Text {
+                    Label {
                         anchors.horizontalCenter: parent.horizontalCenter
                         text: qsTr("Built with Qt %1".arg(qtVersion)) // obtained from main.cpp (engine.rootContext()->setContextProperty)
                         renderType: Text.NativeRendering

--- a/SampleViewer/qml/ManageOfflineDataView.qml
+++ b/SampleViewer/qml/ManageOfflineDataView.qml
@@ -269,7 +269,7 @@ Page {
                                         height: statusLabel.implicitHeight + 10
                                         color: modelData.downloaded ? Calcite.success : Calcite.danger
                                         radius: 12
-                                        opacity: 0.2
+                                        opacity: 1
 
                                         Label {
                                             id: statusLabel

--- a/SampleViewer/qml/ManageOfflineDataView.qml
+++ b/SampleViewer/qml/ManageOfflineDataView.qml
@@ -269,7 +269,6 @@ Page {
                                         height: statusLabel.implicitHeight + 10
                                         color: modelData.downloaded ? Calcite.success : Calcite.danger
                                         radius: 12
-                                        opacity: 1
 
                                         Label {
                                             id: statusLabel

--- a/SampleViewer/qml/ProxySetupView.qml
+++ b/SampleViewer/qml/ProxySetupView.qml
@@ -68,7 +68,7 @@ Item {
                     family: fontFamily
                     pixelSize: 18
                 }
-                color: Calcite.textInverse
+                color: Calcite.offWhite
             }
         }
 

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -68,7 +68,7 @@ ApplicationWindow {
                 pixelSize: 24
                 family: fontFamily
             }
-            color: "white"
+            color: Calcite.offWhite
         }
 
         Image {


### PR DESCRIPTION
# Description

- Removed "NSRequiresAquaSystemAppearance" key from info.plist to allow dark and light mode changes on macOS.
- Proxy settings title fix.
- About view - reacts to theme.
- Download page - red and green icons have better contrast

<! --- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
