### PR TITLE
Primary color change visible on application start fix.

### DIFF
--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -20,6 +20,7 @@ import Calcite
 
 ApplicationWindow {
     id: window
+    // Intially hidden - unhide window in Component.onCompleted after overriding color so color switch is not visible
     visible: false
     width: 800
     height: 600

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -20,7 +20,7 @@ import Calcite
 
 ApplicationWindow {
     id: window
-    visible: true
+    visible: false
     width: 800
     height: 600
     minimumWidth: 300
@@ -341,6 +341,8 @@ ApplicationWindow {
         Calcite.brand = Calcite.Theme.Light ? "#7938B6" : "#8F53CA";
         Calcite.brandHover = Calcite.Theme.Light ? "#652E98" : "#7938B6";
         Calcite.brandPress = Calcite.Theme.Light ? "#51247A" : "#652E98";
+
+        window.visible = true;
 
         // initialize the SampleManager singleton
         SampleManager.init();


### PR DESCRIPTION
# Description
When the sample viewer application is launched we override calcite colors(from blue to purple) in the `Component.onCompleted` event ie when the window is fully loaded. This results in the application starting out with the default color(blue) while loading and then switching to purple when it completes loading.

https://github.com/user-attachments/assets/4a03e380-0a26-4912-a8af-11b160b6d9cd

Solution: Set the initial visibility of the window to be hidden with `visible: false` and set it to be visible in the `Component.onCompleted` event.
<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
