### PR TITLE
fixing warning

### DIFF
--- a/CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
+++ b/CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml
@@ -77,7 +77,7 @@ SearchDictionarySymbolStyleSample {
                             placeholderText: repeaterModel[index] +" (e.g. "+ hintsModel[index] +")"
                             selectByMouse: true
                             validator: RegularExpressionValidator{ regularExpression: /^\s*[\da-zA-Z_][\da-zA-Z\s_]*$/ }
-                            onAccepted: addCategoryButtonMouseArea.clicked(true);
+                            onAccepted: addCategoryButton.addCategory();
                         }
 
                         Rectangle {
@@ -94,16 +94,18 @@ SearchDictionarySymbolStyleSample {
                             MouseArea {
                                 id: addCategoryButtonMouseArea
                                 anchors.fill: parent
-                                onClicked: {
-                                    if (categoryEntry.text.length === 0)
-                                        return;
+                                onClicked: addCategoryButton.addCategory();
+                            }
 
-                                    const tmp = searchParamList;
-                                    tmp[index].push(categoryEntry.text);
+                            function addCategory() {
+                                if (categoryEntry.text.length === 0)
+                                    return;
 
-                                    searchParamList = tmp;
-                                    categoryEntry.text = "";
-                                }
+                                const tmp = searchParamList;
+                                tmp[index].push(categoryEntry.text);
+
+                                searchParamList = tmp;
+                                categoryEntry.text = "";
                             }
                         }
 


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Fixing simple bug. The enter key was hooked up to emit the mouseClicked signal, but that signal takes a MouseEvent arg, which isn't creatable. We are instead passing a bool and it results in the following error.

```
"Could not convert argument 0 at"
	 "expression for onAccepted@qrc:/Samples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.qml:80"
Passing incompatible arguments to signals is not supported.
```

This breaks out the code so the mouse click and return key call the function.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
