### PR TITLE
Set the map to the generated offline map

### DIFF
--- a/CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
+++ b/CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.cpp
@@ -375,6 +375,7 @@ void GenerateOfflineMap_Overrides::takeMapOffline()
       // show the map
       emit updateStatus("Complete");
       emit hideWindow(1500, true);
+      m_mapView->setMap(generateJob->result()->offlineMap(this));
       break;
     default: // do nothing
       break;


### PR DESCRIPTION
# Description

At some point, we removed the call to set the map to the generated offline map when the job completes. This sample had this call initially when it was [implemented](https://github.com/Esri/arcgis-maps-sdk-samples-qt/commit/88a08929de8355427e9a896a63ed649c0432da78#diff-ea24f7048cef9a2bee6645038066e147ad56945bd16b96df2154ea0ffda8319fR139), but I can't find the commit that removed it. Doesn't really matter though, this fixes the issue. 

<img width="500" height="400" alt="Screenshot 2025-11-17 at 3 51 46 PM" src="https://github.com/user-attachments/assets/e177cf2b-7970-457e-a33d-9fd5d9657fcd" />

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
