### PR TITLE
Fix extent rectangle

### DIFF
--- a/CppSamples/Layers/ExportVectorTiles/ExportVectorTiles.qml
+++ b/CppSamples/Layers/ExportVectorTiles/ExportVectorTiles.qml
@@ -131,6 +131,7 @@ Item {
                 break;
             case ExportVectorTilesSample.ExportStatusFailed:
                 model.startExport(extentRectangle.x, (extentRectangle.y + extentRectangle.height), (extentRectangle.x + extentRectangle.width), extentRectangle.y);
+                extentRectangle.visible = false;
                 break;
             case ExportVectorTilesSample.ExportStatusCancelling:
                 break;


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->
Fix extent rectangle in export vector tiles sample

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
