### PR TITLE
Resize the map rather than push it off screen

### DIFF
--- a/CppSamples/Routing/FindRoute/FindRoute.qml
+++ b/CppSamples/Routing/FindRoute/FindRoute.qml
@@ -25,7 +25,6 @@ FindRouteSample {
 
     onSolveRouteComplete: solveButton.visible = false
 
-    // Create window for displaying the route directions
     Rectangle {
         id: directionWindow
         anchors {
@@ -34,8 +33,11 @@ FindRouteSample {
             bottom: parent.bottom
         }
         visible: false
-        width: Qt.platform.os === "ios" || Qt.platform.os === "android" ? 250 : 350
+        property int targetWidth: Qt.platform.os === "ios" || Qt.platform.os === "android" ? 250 : 350
+        width: visible ? targetWidth : 0
         color: palette.base
+        clip: true
+        Behavior on width { NumberAnimation { duration: 300; easing.type: Easing.OutQuad } }
 
         //! [FindRoute cpp ListView directionsView]
         ListView {
@@ -66,17 +68,15 @@ FindRouteSample {
             left: parent.left
             top: parent.top
             bottom: parent.bottom
+            right: directionWindow.left
         }
-        // Dynamically shrink when the directions window is visible
-        width: parent.width - (directionWindow.visible ? directionWindow.width : 0)
+
         objectName: "mapView"
 
         Component.onCompleted: {
             // Set the focus on MapView to initially enable keyboard navigation
             forceActiveFocus();
         }
-
-        Behavior on width { NumberAnimation { duration: 300; easing.type: Easing.OutQuad } }
 
         // Create the solve button to solve the route
         Button {

--- a/CppSamples/Routing/FindRoute/FindRoute.qml
+++ b/CppSamples/Routing/FindRoute/FindRoute.qml
@@ -62,7 +62,13 @@ FindRouteSample {
     // add a mapView component
     MapView {
         id: mapView
-        anchors.fill: parent
+        anchors {
+            left: parent.left
+            top: parent.top
+            bottom: parent.bottom
+        }
+        // Dynamically shrink when the directions window is visible
+        width: parent.width - (directionWindow.visible ? directionWindow.width : 0)
         objectName: "mapView"
 
         Component.onCompleted: {
@@ -70,12 +76,7 @@ FindRouteSample {
             forceActiveFocus();
         }
 
-        // set the transform to animate showing the direction window
-        transform: Translate {
-            id: translate
-            x: 0
-            Behavior on x { NumberAnimation { duration: 300; easing.type: Easing.OutQuad } }
-        }
+        Behavior on width { NumberAnimation { duration: 300; easing.type: Easing.OutQuad } }
 
         // Create the solve button to solve the route
         Button {
@@ -128,7 +129,6 @@ FindRouteSample {
                 onReleased: directionButton.pressed = false
                 onClicked: {
                     // Show the direction window when it is clicked
-                    translate.x = directionWindow.visible ? 0 : (directionWindow.width * -1);
                     directionWindow.visible = !directionWindow.visible;
                 }
             }


### PR DESCRIPTION
# Description

This will now dynamically resize the map, keeping the route polyline centered when the directions panel animates over.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [x] iOS


https://github.com/user-attachments/assets/13074ef7-c2cd-4d3e-8cae-50caa9631974

