### PR TITLE
Sync map and scene sample fix

### DIFF
--- a/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.cpp
+++ b/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.cpp
@@ -81,6 +81,13 @@ void SyncMapViewSceneView::setSceneView(SceneQuickView* sceneView)
       m_mapView->setViewpointAsync(m_sceneView->currentViewpoint(ViewpointType::CenterAndScale), 0);
     }
   });
+  connect(m_sceneView, &SceneQuickView::mouseWheelChanged, this, [this]
+  {
+    if (m_mapView)
+    {
+      m_mapView->setViewpointAsync(m_sceneView->currentViewpoint(ViewpointType::CenterAndScale), 0);
+    }
+  });
 
   emit sceneViewChanged();
 }
@@ -110,6 +117,14 @@ void SyncMapViewSceneView::setMapView(MapQuickView* mapView)
     }
   });
   connect(m_mapView, &MapQuickView::mousePressed, this, [this]
+  {
+    if (m_sceneView)
+    {
+      m_sceneView->setViewpointAsync(m_mapView->currentViewpoint(ViewpointType::CenterAndScale), 0);
+    }
+  });
+
+  connect(m_mapView, &MapQuickView::mouseWheelChanged, this, [this]
   {
     if (m_sceneView)
     {

--- a/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.cpp
+++ b/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.cpp
@@ -74,6 +74,13 @@ void SyncMapViewSceneView::setSceneView(SceneQuickView* sceneView)
       m_mapView->setViewpointAsync(m_sceneView->currentViewpoint(ViewpointType::CenterAndScale), 0);
     }
   });
+  connect(m_sceneView, &SceneQuickView::mousePressed, this, [this]
+  {
+    if (m_mapView)
+    {
+      m_mapView->setViewpointAsync(m_sceneView->currentViewpoint(ViewpointType::CenterAndScale), 0);
+    }
+  });
 
   emit sceneViewChanged();
 }
@@ -98,6 +105,13 @@ void SyncMapViewSceneView::setMapView(MapQuickView* mapView)
   connect(m_mapView, &MapQuickView::viewpointChanged, this, [this]
   {
     if (m_sceneView && m_mapView->isNavigating() && !m_sceneView->isNavigating())
+    {
+      m_sceneView->setViewpointAsync(m_mapView->currentViewpoint(ViewpointType::CenterAndScale), 0);
+    }
+  });
+  connect(m_mapView, &MapQuickView::mousePressed, this, [this]
+  {
+    if (m_sceneView)
     {
       m_sceneView->setViewpointAsync(m_mapView->currentViewpoint(ViewpointType::CenterAndScale), 0);
     }

--- a/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.cpp
+++ b/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.cpp
@@ -34,7 +34,7 @@
 
 using namespace Esri::ArcGISRuntime;
 
-SyncMapViewSceneView::SyncMapViewSceneView(QObject* parent /* = nullptr */):
+SyncMapViewSceneView::SyncMapViewSceneView(QObject* parent /* = nullptr */) :
   QObject(parent),
   m_scene(new Scene(BasemapStyle::ArcGISImageryStandard, this)),
   m_map(new Map(BasemapStyle::ArcGISImageryStandard, this))
@@ -67,11 +67,12 @@ void SyncMapViewSceneView::setSceneView(SceneQuickView* sceneView)
   m_sceneView = sceneView;
   m_sceneView->setArcGISScene(m_scene);
 
-  connect(m_sceneView, &SceneQuickView::viewpointChanged, this,
-          [this]
+  connect(m_sceneView, &SceneQuickView::viewpointChanged, this, [this]
   {
-    if (m_mapView && m_sceneView->isNavigating())
+    if (m_mapView && m_sceneView->isNavigating() && !m_mapView->isNavigating())
+    {
       m_mapView->setViewpointAsync(m_sceneView->currentViewpoint(ViewpointType::CenterAndScale), 0);
+    }
   });
 
   emit sceneViewChanged();
@@ -94,11 +95,12 @@ void SyncMapViewSceneView::setMapView(MapQuickView* mapView)
   m_mapView->setMap(m_map);
   m_mapView->setRotationByPinchingEnabled(true);
 
-  connect(m_mapView, &MapQuickView::viewpointChanged, this,
-          [this]
+  connect(m_mapView, &MapQuickView::viewpointChanged, this, [this]
   {
-    if (m_sceneView && m_mapView->isNavigating())
+    if (m_sceneView && m_mapView->isNavigating() && !m_sceneView->isNavigating())
+    {
       m_sceneView->setViewpointAsync(m_mapView->currentViewpoint(ViewpointType::CenterAndScale), 0);
+    }
   });
 
   emit mapViewChanged();


### PR DESCRIPTION
# Description

Just checking the isNavigating property before trying to update the adjacent view to avoid the stuttering. Only one will be 'true` at a given time.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [x] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
