### PR TITLE
Fix bugs.

### DIFF
--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
@@ -95,11 +95,12 @@ void ControlAnnotationSublayerVisibility::setMapView(MapQuickView* mapView)
     m_mapScale = m_mapView->mapScale();
     emit mapScaleChanged();
 
-    if (!m_annotationSubLayerOpen)
-      return;
-
-    m_visibleAtCurrentExtent = m_annotationSubLayerOpen->isVisibleAtScale(m_mapScale);
-    emit visibleAtCurrentExtentChanged();
+    const bool visibleAtCurrentExtent = m_annotationSubLayerOpen ? m_annotationSubLayerOpen->isVisibleAtScale(m_mapScale) : false;
+    if (m_visibleAtCurrentExtent != visibleAtCurrentExtent)
+    {
+      m_visibleAtCurrentExtent = visibleAtCurrentExtent;
+      emit visibleAtCurrentExtentChanged();
+    }
   });
 
   emit mapViewChanged();
@@ -154,7 +155,7 @@ void ControlAnnotationSublayerVisibility::createMapPackage(const QString& path)
             return;
           }
 
-          const auto contents = m_annoLayer->subLayerContents();
+          const QList<LayerContent*> contents = m_annoLayer->subLayerContents();
           m_annotationSubLayerClosed = dynamic_cast<AnnotationSublayer*>(contents[0]);
           m_annotationSubLayerOpen = dynamic_cast<AnnotationSublayer*>(contents[1]);
           m_closedLayerText = m_annotationSubLayerClosed->name();

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h
@@ -73,7 +73,7 @@ private:
 
   QString m_openLayerText;
   QString m_closedLayerText;
-  bool m_visibleAtCurrentExtent;
+  bool m_visibleAtCurrentExtent = false;
   double m_mapScale = 0.0;
 };
 


### PR DESCRIPTION
There are two problems here:

1. Sometimes (unclear why) when you run the sample, the `m_annotationSubLayerOpen` hasn't been created in this block, so it just returns early.
2. `m_visibleAtCurrentExtent` had no assigned value, so in the case of 1, you would get whatever was sitting in memory at that moment.

I cleaned up a few other things as well. It will only emit if the value actually changed to prevent unnecessary property binding updates. `auto` occurrence changed per our samples standards.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
