### PR TITLE
Update filter features sample

### DIFF
--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
@@ -147,15 +147,29 @@ void FilterFeaturesInScene::init()
 // Show the detailed buildings scene layer
 void FilterFeaturesInScene::showDetailedBuildings()
 {
+  if (!m_detailedBuildingsSceneLayer)
+  {
+    qWarning() << "Detailed San Fransisco Buildings layer not loaded";
+    return;
+  }
   m_detailedBuildingsSceneLayer->setVisible(true);
 }
 
 // Hide buildings within the detailed building extent so they don't clip
 void FilterFeaturesInScene::filterScene()
 {
+  if (!m_sceneView || !m_sceneView->graphicsOverlays()->first())
+  {
+    return;
+  }
 
   // Show the extent graphic to visualize the polygon filter
   m_sceneView->graphicsOverlays()->first()->graphics()->append(m_sanFranciscoExtentGraphic);
+
+  if (!m_3dBuildings || !m_sceneLayerPolygonFilter)
+  {
+    return;
+  }
 
   // Initially, the building layer does not have a polygon filter, set it
   if (!m_3dBuildings->polygonFilter())
@@ -173,11 +187,23 @@ void FilterFeaturesInScene::filterScene()
 
 void FilterFeaturesInScene::reset()
 {
+  if (!m_detailedBuildingsSceneLayer)
+  {
+    return;
+  }
+
   // Hide the detailed buildings layer from the scene
   m_detailedBuildingsSceneLayer->setVisible(false);
 
+  if (!m_3dBuildings || !m_3dBuildings->polygonFilter())
+
   // Set the OSM buildings polygon filter to an empty list of polygons to clear the filter
   m_3dBuildings->polygonFilter()->setPolygons(QList<Polygon>{});
+
+  if (!m_sceneView || !m_sceneView->graphicsOverlays()->first())
+  {
+    return;
+  }
 
   // Clear the graphics list in the graphics overlay to remove the red extent boundary graphic
   m_sceneView->graphicsOverlays()->first()->graphics()->clear();

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
@@ -61,7 +61,7 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
   surface->elevationSources()->append(new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this));
   m_scene->setBaseSurface(surface);
 
-  // Construct a basemap with the ArcGIS Navigation 3D Basemap then create a scene with it
+  // Construct a basemap with the ArcGIS Navigation 3D Basemap then set it on the Scene
   auto* basemap = new Basemap(QUrl("https://arcgisruntime.maps.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0"), this);
   m_scene->setBasemap(basemap);
 

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
@@ -24,7 +24,6 @@
 // ArcGIS Maps SDK headers
 #include "ArcGISSceneLayer.h"
 #include "ArcGISTiledElevationSource.h"
-#include "ArcGISVectorTiledLayer.h"
 #include "Basemap.h"
 #include "Camera.h"
 #include "ElevationSourceListModel.h"
@@ -39,7 +38,6 @@
 #include "Point.h"
 #include "Polygon.h"
 #include "PolygonBuilder.h"
-#include "PortalItem.h"
 #include "Scene.h"
 #include "SceneLayerPolygonFilter.h"
 #include "SceneQuickView.h"
@@ -55,24 +53,52 @@
 using namespace Esri::ArcGISRuntime;
 
 FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
-  QObject(parent)
+  QObject(parent),
+  m_scene(new Scene(this))
 {
-  // Construct and set the basemap
-  ArcGISVectorTiledLayer* vectorTileLayer = new ArcGISVectorTiledLayer(new PortalItem("1e7d1784d1ef4b79ba6764d0bd6c3150", this), this);
-  m_osmBuildings = new ArcGISSceneLayer(new PortalItem("ca0470dbbddb4db28bad74ed39949e25", this), this);
-  Basemap* basemap = new Basemap(this);
-  basemap->baseLayers()->append(vectorTileLayer);
-  basemap->baseLayers()->append(m_osmBuildings);
-  m_scene = new Scene(basemap, this);
-
   // Construct and set the scene topography
-  Surface* surface = new Surface(this);
+  auto* surface = new Surface(this);
   surface->elevationSources()->append(new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this));
   m_scene->setBaseSurface(surface);
+
+  // Construct a basemap with the ArcGIS Navigation 3D Basemap then create a scene with it
+  auto* basemap = new Basemap(QUrl("https://arcgisruntime.maps.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0"), this);
+  m_scene->setBasemap(basemap);
+
+  connect(basemap, &Basemap::doneLoading, this, [basemap, this](const Error& error)
+  {
+    if (!error.isEmpty())
+    {
+      qWarning() << "Basemap failed to load." << error.message() << error.additionalMessage();
+      return;
+    }
+
+    // Loop through all layers in the basemap and look for the buildings layer
+    for (Layer* baseLayer : *basemap->baseLayers())
+    {
+      // As of 2025, the 3D basemap contains a layer called "Esri 3D Buildings" -- we'll search for a layer
+      // that contains 'building' in case the name is ever updated
+      if (baseLayer->name().contains("building", Qt::CaseInsensitive))
+      {
+        m_3dBuildings = dynamic_cast<ArcGISSceneLayer*>(baseLayer);
+        if (m_3dBuildings)
+        {
+          // Buildings layer found, we can return out of the lambda
+          return;
+        }
+      }
+    }
+    if (!m_3dBuildings)
+    {
+      qWarning() << "Buildings layer not found in base layers. Please check that your basemap"
+                 << "contains an ArcGIS Scene Layer with 'building' in the name";
+    }
+  });
 
   // Construct the detailed buildings scene layer
   m_detailedBuildingsSceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer"), this);
 
+  // When the detailed building scene layer finishes loading, get its extent for the polygon filter
   connect(m_detailedBuildingsSceneLayer, &ArcGISSceneLayer::doneLoading, this, [this](const Error& error)
   {
     if (!error.isEmpty())
@@ -84,23 +110,23 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
     // Construct a red polygon that shows the extent of the detailed buildings scene layer
     const Envelope sfExtent = m_detailedBuildingsSceneLayer->fullExtent();
 
-    PolygonBuilder* builder = new PolygonBuilder(m_sceneView->spatialReference(), this);
-    builder->addPoint(sfExtent.xMin(), sfExtent.yMin());
-    builder->addPoint(sfExtent.xMax(), sfExtent.yMin());
-    builder->addPoint(sfExtent.xMax(), sfExtent.yMax());
-    builder->addPoint(sfExtent.xMin(), sfExtent.yMax());
+    auto* polygonBuilder = new PolygonBuilder(m_sceneView->spatialReference(), this);
+    polygonBuilder->addPoint(sfExtent.xMin(), sfExtent.yMin());
+    polygonBuilder->addPoint(sfExtent.xMax(), sfExtent.yMin());
+    polygonBuilder->addPoint(sfExtent.xMax(), sfExtent.yMax());
+    polygonBuilder->addPoint(sfExtent.xMin(), sfExtent.yMax());
 
-    m_sceneLayerExtentPolygon = builder->toPolygon();
+    m_sceneLayerExtentPolygon = polygonBuilder->toPolygon();
 
     // Create the SceneLayerPolygonFilter to later apply to the OSM buildings layer
     m_sceneLayerPolygonFilter = new SceneLayerPolygonFilter(
-          QList<Polygon>{m_sceneLayerExtentPolygon}, // polygons to filter by
-          SceneLayerPolygonFilterSpatialRelationship::Disjoint, // hide all features within the polygons
-          this);
+      QList<Polygon>{m_sceneLayerExtentPolygon}, // polygons to filter by
+      SceneLayerPolygonFilterSpatialRelationship::Disjoint, // hide all features within the polygons
+      this);
 
     // Create the extent graphic so we can add it later with the detailed buildings scene layer
-    SimpleFillSymbol* sfs = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor(Qt::transparent), new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(Qt::red), 5.0f, this), this);
-    m_sanFranciscoExtentGraphic = new Graphic(m_sceneLayerExtentPolygon, sfs, this);
+    auto* simpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor(Qt::transparent), new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(Qt::red), 5.0f, this), this);
+    m_sanFranciscoExtentGraphic = new Graphic(m_sceneLayerExtentPolygon, simpleFillSymbol, this);
   });
 
   m_detailedBuildingsSceneLayer->load();
@@ -115,25 +141,31 @@ void FilterFeaturesInScene::init()
   qmlRegisterType<FilterFeaturesInScene>("Esri.Samples", 1, 0, "FilterFeaturesInSceneSample");
 }
 
-void FilterFeaturesInScene::loadScene()
+// Show the detailed buildings scene layer
+void FilterFeaturesInScene::showDetailedBuildings()
 {
-  // Show the detailed buildings scene layer and the extent graphic
   m_scene->operationalLayers()->append(m_detailedBuildingsSceneLayer);
-  m_sceneView->graphicsOverlays()->first()->graphics()->append(m_sanFranciscoExtentGraphic);
 }
 
+// Hide buildings within the detailed building extent so they don't clip
 void FilterFeaturesInScene::filterScene()
 {
-  // Hide buildings within the detailed building extent so they don't clip
+
+  // Show the extent graphic to visualize the polygon filter
+  m_sceneView->graphicsOverlays()->first()->graphics()->append(m_sanFranciscoExtentGraphic);
 
   // Initially, the building layer does not have a polygon filter, set it
-  if (!m_osmBuildings->polygonFilter())
-    m_osmBuildings->setPolygonFilter(m_sceneLayerPolygonFilter);
+  if (!m_3dBuildings->polygonFilter())
+  {
+    m_3dBuildings->setPolygonFilter(m_sceneLayerPolygonFilter);
+  }
 
   // After the scene is reset, the layer will have a polygon filter, but that filter will not have polygons set
   // Add the polygon back to the polygon filter
   else
+  {
     m_sceneLayerPolygonFilter->setPolygons({m_sceneLayerExtentPolygon});
+  }
 }
 
 void FilterFeaturesInScene::reset()
@@ -142,7 +174,7 @@ void FilterFeaturesInScene::reset()
   m_scene->operationalLayers()->clear();
 
   // Set the OSM buildings polygon filter to an empty list of polygons to clear the filter
-  m_osmBuildings->polygonFilter()->setPolygons(QList<Polygon>{});
+  m_3dBuildings->polygonFilter()->setPolygons(QList<Polygon>{});
 
   // Clear the graphics list in the graphics overlay to remove the red extent boundary graphic
   m_sceneView->graphicsOverlays()->first()->graphics()->clear();
@@ -157,7 +189,9 @@ SceneQuickView* FilterFeaturesInScene::sceneView() const
 void FilterFeaturesInScene::setSceneView(SceneQuickView* sceneView)
 {
   if (!sceneView || sceneView == m_sceneView)
+  {
     return;
+  }
 
   m_sceneView = sceneView;
   m_sceneView->setArcGISScene(m_scene);

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
@@ -149,7 +149,7 @@ void FilterFeaturesInScene::showDetailedBuildings()
 {
   if (!m_detailedBuildingsSceneLayer)
   {
-    qWarning() << "Detailed San Fransisco Buildings layer not loaded";
+    qWarning() << "Detailed San Francisco Buildings layer not loaded";
     return;
   }
   m_detailedBuildingsSceneLayer->setVisible(true);
@@ -196,8 +196,10 @@ void FilterFeaturesInScene::reset()
   m_detailedBuildingsSceneLayer->setVisible(false);
 
   if (!m_3dBuildings || !m_3dBuildings->polygonFilter())
-
-  // Set the OSM buildings polygon filter to an empty list of polygons to clear the filter
+  {
+    return;
+  }
+  // Set the 3D buildings polygon filter to an empty list of polygons to clear the filter
   m_3dBuildings->polygonFilter()->setPolygons(QList<Polygon>{});
 
   if (!m_sceneView || !m_sceneView->graphicsOverlays()->first())

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
@@ -98,6 +98,9 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
   // Construct the detailed buildings scene layer
   m_detailedBuildingsSceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer"), this);
 
+  // Initially hide the detailed buildings so they don't clip into the 3D basemap buildings
+  m_detailedBuildingsSceneLayer->setVisible(false);
+
   // When the detailed building scene layer finishes loading, get its extent for the polygon filter
   connect(m_detailedBuildingsSceneLayer, &ArcGISSceneLayer::doneLoading, this, [this](const Error& error)
   {
@@ -129,7 +132,7 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
     m_sanFranciscoExtentGraphic = new Graphic(m_sceneLayerExtentPolygon, simpleFillSymbol, this);
   });
 
-  m_detailedBuildingsSceneLayer->load();
+  m_scene->operationalLayers()->append(m_detailedBuildingsSceneLayer);
 }
 
 FilterFeaturesInScene::~FilterFeaturesInScene() = default;
@@ -144,7 +147,7 @@ void FilterFeaturesInScene::init()
 // Show the detailed buildings scene layer
 void FilterFeaturesInScene::showDetailedBuildings()
 {
-  m_scene->operationalLayers()->append(m_detailedBuildingsSceneLayer);
+  m_detailedBuildingsSceneLayer->setVisible(true);
 }
 
 // Hide buildings within the detailed building extent so they don't clip
@@ -170,8 +173,8 @@ void FilterFeaturesInScene::filterScene()
 
 void FilterFeaturesInScene::reset()
 {
-  // Remove the detailed buildings layer from the scene
-  m_scene->operationalLayers()->clear();
+  // Hide the detailed buildings layer from the scene
+  m_detailedBuildingsSceneLayer->setVisible(false);
 
   // Set the OSM buildings polygon filter to an empty list of polygons to clear the filter
   m_3dBuildings->polygonFilter()->setPolygons(QList<Polygon>{});

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.cpp
@@ -57,12 +57,12 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
   m_scene(new Scene(this))
 {
   // Construct and set the scene topography
-  auto* surface = new Surface(this);
+  Surface* surface = new Surface(this);
   surface->elevationSources()->append(new ArcGISTiledElevationSource(QUrl("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), this));
   m_scene->setBaseSurface(surface);
 
   // Construct a basemap with the ArcGIS Navigation 3D Basemap then set it on the Scene
-  auto* basemap = new Basemap(QUrl("https://arcgisruntime.maps.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0"), this);
+  Basemap* basemap = new Basemap(QUrl("https://arcgisruntime.maps.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0"), this);
   m_scene->setBasemap(basemap);
 
   connect(basemap, &Basemap::doneLoading, this, [basemap, this](const Error& error)
@@ -96,13 +96,13 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
   });
 
   // Construct the detailed buildings scene layer
-  m_detailedBuildingsSceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer"), this);
+  m_sanFrancisco3DOSceneLayer = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer"), this);
 
   // Initially hide the detailed buildings so they don't clip into the 3D basemap buildings
-  m_detailedBuildingsSceneLayer->setVisible(false);
+  m_sanFrancisco3DOSceneLayer->setVisible(false);
 
   // When the detailed building scene layer finishes loading, get its extent for the polygon filter
-  connect(m_detailedBuildingsSceneLayer, &ArcGISSceneLayer::doneLoading, this, [this](const Error& error)
+  connect(m_sanFrancisco3DOSceneLayer, &ArcGISSceneLayer::doneLoading, this, [this](const Error& error)
   {
     if (!error.isEmpty())
     {
@@ -111,9 +111,9 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
     }
 
     // Construct a red polygon that shows the extent of the detailed buildings scene layer
-    const Envelope sfExtent = m_detailedBuildingsSceneLayer->fullExtent();
+    const Envelope sfExtent = m_sanFrancisco3DOSceneLayer->fullExtent();
 
-    auto* polygonBuilder = new PolygonBuilder(m_sceneView->spatialReference(), this);
+    PolygonBuilder* polygonBuilder = new PolygonBuilder(m_sceneView->spatialReference(), this);
     polygonBuilder->addPoint(sfExtent.xMin(), sfExtent.yMin());
     polygonBuilder->addPoint(sfExtent.xMax(), sfExtent.yMin());
     polygonBuilder->addPoint(sfExtent.xMax(), sfExtent.yMax());
@@ -128,11 +128,11 @@ FilterFeaturesInScene::FilterFeaturesInScene(QObject* parent /* = nullptr */):
       this);
 
     // Create the extent graphic so we can add it later with the detailed buildings scene layer
-    auto* simpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor(Qt::transparent), new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(Qt::red), 5.0f, this), this);
+    SimpleFillSymbol* simpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle::Solid, QColor(Qt::transparent), new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(Qt::red), 5.0f, this), this);
     m_sanFranciscoExtentGraphic = new Graphic(m_sceneLayerExtentPolygon, simpleFillSymbol, this);
   });
 
-  m_scene->operationalLayers()->append(m_detailedBuildingsSceneLayer);
+  m_scene->operationalLayers()->append(m_sanFrancisco3DOSceneLayer);
 }
 
 FilterFeaturesInScene::~FilterFeaturesInScene() = default;
@@ -147,12 +147,12 @@ void FilterFeaturesInScene::init()
 // Show the detailed buildings scene layer
 void FilterFeaturesInScene::showDetailedBuildings()
 {
-  if (!m_detailedBuildingsSceneLayer)
+  if (!m_sanFrancisco3DOSceneLayer)
   {
     qWarning() << "Detailed San Francisco Buildings layer not loaded";
     return;
   }
-  m_detailedBuildingsSceneLayer->setVisible(true);
+  m_sanFrancisco3DOSceneLayer->setVisible(true);
 }
 
 // Hide buildings within the detailed building extent so they don't clip
@@ -187,13 +187,13 @@ void FilterFeaturesInScene::filterScene()
 
 void FilterFeaturesInScene::reset()
 {
-  if (!m_detailedBuildingsSceneLayer)
+  if (!m_sanFrancisco3DOSceneLayer)
   {
     return;
   }
 
   // Hide the detailed buildings layer from the scene
-  m_detailedBuildingsSceneLayer->setVisible(false);
+  m_sanFrancisco3DOSceneLayer->setVisible(false);
 
   if (!m_3dBuildings || !m_3dBuildings->polygonFilter())
   {

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.h
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.h
@@ -60,7 +60,7 @@ private:
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
   Esri::ArcGISRuntime::ArcGISSceneLayer* m_3dBuildings = nullptr;
-  Esri::ArcGISRuntime::ArcGISSceneLayer* m_detailedBuildingsSceneLayer = nullptr;
+  Esri::ArcGISRuntime::ArcGISSceneLayer* m_sanFrancisco3DOSceneLayer = nullptr;
   Esri::ArcGISRuntime::Polygon m_sceneLayerExtentPolygon;
   Esri::ArcGISRuntime::Graphic* m_sanFranciscoExtentGraphic = nullptr;
   Esri::ArcGISRuntime::SceneLayerPolygonFilter* m_sceneLayerPolygonFilter = nullptr;

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.h
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.h
@@ -25,11 +25,11 @@
 
 namespace Esri::ArcGISRuntime
 {
-class ArcGISSceneLayer;
-class Graphic;
-class Scene;
-class SceneLayerPolygonFilter;
-class SceneQuickView;
+  class ArcGISSceneLayer;
+  class Graphic;
+  class Scene;
+  class SceneLayerPolygonFilter;
+  class SceneQuickView;
 }
 
 Q_MOC_INCLUDE("SceneQuickView.h");
@@ -46,7 +46,7 @@ public:
 
   static void init();
 
-  Q_INVOKABLE void loadScene();
+  Q_INVOKABLE void showDetailedBuildings();
   Q_INVOKABLE void filterScene();
   Q_INVOKABLE void reset();
 
@@ -59,7 +59,7 @@ private:
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
-  Esri::ArcGISRuntime::ArcGISSceneLayer* m_osmBuildings = nullptr;
+  Esri::ArcGISRuntime::ArcGISSceneLayer* m_3dBuildings = nullptr;
   Esri::ArcGISRuntime::ArcGISSceneLayer* m_detailedBuildingsSceneLayer = nullptr;
   Esri::ArcGISRuntime::Polygon m_sceneLayerExtentPolygon;
   Esri::ArcGISRuntime::Graphic* m_sanFranciscoExtentGraphic = nullptr;

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.qml
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.qml
@@ -45,7 +45,7 @@ Item {
 
         property int step: 0
 
-        text: [qsTr("Filter 3D buildings in extent"),qsTr("Load detailed buildings"),qsTr("Reset scene")][step]
+        text: [qsTr("Filter 3D buildings in extent"),qsTr("Show detailed buildings"),qsTr("Reset scene")][step]
         onClicked: {
             switch (step) {
             case 0:

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.qml
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.qml
@@ -45,7 +45,7 @@ Item {
 
         property int step: 0
 
-        text: [qsTr("Filter OSM buildings in extent"),qsTr("Load detailed buildings"),qsTr("Reset scene")][step]
+        text: [qsTr("Filter 3D buildings in extent"),qsTr("Load detailed buildings"),qsTr("Reset scene")][step]
         onClicked: {
             switch (step) {
             case 0:

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.qml
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.qml
@@ -45,18 +45,18 @@ Item {
 
         property int step: 0
 
-        text: [qsTr("Load detailed buildings"),qsTr("Filter OSM buildings in extent"),qsTr("Reset scene")][step]
+        text: [qsTr("Filter OSM buildings in extent"),qsTr("Load detailed buildings"),qsTr("Reset scene")][step]
         onClicked: {
             switch (step) {
             case 0:
-                // Show the detailed buildings scene layer and extent graphic
-                model.loadScene();
+                // Hide buildings within the detailed building extent so they don't clip
+                model.filterScene();
                 step++;
                 break;
 
             case 1:
-                // Hide buildings within the detailed building extent so they don't clip
-                model.filterScene();
+                // Show the detailed buildings scene layer and extent graphic
+                model.showDetailedBuildings();
                 step++;
                 break;
 

--- a/CppSamples/Scenes/FilterFeaturesInScene/README.md
+++ b/CppSamples/Scenes/FilterFeaturesInScene/README.md
@@ -10,7 +10,7 @@ You can directly control what users see within a specific scene view to give a m
 
 ## How to use the sample
 
-The sample initializes showing the "Navigation" 3D Basemap. Click the "Filter 3D buildings in extent" button, to set a `SceneLayerPolygonFilter` and filter out the Esri 3D buildings within the extent of a detailed buildings scene layer. Notice how the Esri 3D buildings within and intersecting the extent of the detailed buildings layer are hidden.  Click the "Load detailed buildings" button to load a scene layer that contains more detailed buildings. Click the "Reset scene" button to hide the detailed buildings scene layer and clear the 3D buildings filter.
+The sample initializes showing the "Navigation" 3D Basemap. Click the "Filter 3D buildings in extent" button, to set a `SceneLayerPolygonFilter` and filter out the Esri 3D buildings within the extent of a detailed buildings scene layer. Notice how the Esri 3D buildings within and intersecting the extent of the detailed buildings layer are hidden. Click the "Show detailed buildings" button to load a scene layer that contains more detailed buildings. Click the "Reset scene" button to hide the detailed buildings scene layer and clear the 3D buildings filter.
 
 ## How it works
 
@@ -29,7 +29,7 @@ The sample initializes showing the "Navigation" 3D Basemap. Click the "Filter 3D
 
 ## About the data
 
-This sample uses the [Navigation 3D Basemap](https://arcgisruntime.maps.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0) which includes commercial 3D buildings data acquired from TomTom and Vantor, in addition to Esri Community Maps and Overture Maps Foundation data. It also uses the [San Francisco 3D Buildings](https://www.arcgis.com/home/item.html?id=d3344ba99c3f4efaa909ccfbcc052ed5) scene layer which provides detailed 3D models of buildings in San Francisco, California, USA.
+This sample uses the [Navigation 3D Basemap](https://www.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0) which includes commercial 3D buildings data acquired from TomTom and Vantor, in addition to Esri Community Maps and Overture Maps Foundation data. It also uses the [San Francisco 3D Buildings](https://www.arcgis.com/home/item.html?id=d3344ba99c3f4efaa909ccfbcc052ed5) scene layer which provides detailed 3D models of buildings in San Francisco, California, USA.
 
 ## Additional information
 

--- a/CppSamples/Scenes/FilterFeaturesInScene/README.md
+++ b/CppSamples/Scenes/FilterFeaturesInScene/README.md
@@ -10,7 +10,7 @@ You can directly control what users see within a specific scene view to give a m
 
 ## How to use the sample
 
-The sample initializes showing the "Navigation" 3D Basemap. Click the "Filter 3D buildings in extent" button, to set a `SceneLayerPolygonFilter` and filter out the Esri 3D buildings within the extent of a detailed buildings scene layer. Notice how the OSM buildings within and intersecting the extent of the detailed buildings layer are hidden.  Click the "Load detailed buildings" button to load a scene layer that contains more detailed buildings. Click the "Reset scene" button to hide the detailed buildings scene layer and clear the 3D buildings filter.
+The sample initializes showing the "Navigation" 3D Basemap. Click the "Filter 3D buildings in extent" button, to set a `SceneLayerPolygonFilter` and filter out the Esri 3D buildings within the extent of a detailed buildings scene layer. Notice how the Esri 3D buildings within and intersecting the extent of the detailed buildings layer are hidden.  Click the "Load detailed buildings" button to load a scene layer that contains more detailed buildings. Click the "Reset scene" button to hide the detailed buildings scene layer and clear the 3D buildings filter.
 
 ## How it works
 

--- a/CppSamples/Scenes/FilterFeaturesInScene/README.md
+++ b/CppSamples/Scenes/FilterFeaturesInScene/README.md
@@ -10,15 +10,16 @@ You can directly control what users see within a specific scene view to give a m
 
 ## How to use the sample
 
-The sample initializes showing the 3D buildings OpenStreetMap layer. Click the "Load detailed buildings" button to load an additional scene layer that contains more detailed buildings. Notice how the two scene layers overlap and clip into each other. Click the "Filter OSM buildings in extent" button, to set a `SceneLayerPolygonFilter` and filter out the OpenStreetMap buildings within the extent of the detailed buildings scene. Notice how the OSM buildings within and intersecting the extent of the detailed buildings layer are hidden. Click the "Reset scene" button to hide the detailed buildings scene layer and clear the OSM buildings filter.
+The sample initializes showing the "Navigation" 3D Basemap. Click the "Filter 3D buildings in extent" button, to set a `SceneLayerPolygonFilter` and filter out the Esri 3D buildings within the extent of a detailed buildings scene layer. Notice how the OSM buildings within and intersecting the extent of the detailed buildings layer are hidden.  Click the "Load detailed buildings" button to load a scene layer that contains more detailed buildings. Click the "Reset scene" button to hide the detailed buildings scene layer and clear the 3D buildings filter.
 
 ## How it works
 
-1. Construct a `Basemap` for the scene using a topographic `ArcGISVectorTileLayer` and the OpenStreetMap 3D Buildings`ArcGISSceneLayer` as baselayers.
-2. Create a `Surface` for the scene and set the World Elevation 3D as an elevation source.
-3. Add the 3D San Francisco Buildings `ArcGISSceneLayer` to the scene's operational layers.
+1. Create a `Surface` for the scene and set the World Elevation 3D as an elevation source.
+2. Construct a `Basemap` for the scene using the "Navigation" 3D Basemap, load it, then search for the "buildings" baselayer.
+3. Add the 3D San Francisco Buildings `ArcGISSceneLayer` to the scene's operational layers and set its visibility to `false` so it does not intersect the 3D basemap buildings.
 4. Construct a `SceneLayerPolygonFilter` with the extent of the San Francisco Buildings Scene Layer and the `SceneLayerPolygonFilterSpatialRelationship::Disjoint` enum to hide all features within the extent.
 5. Set the `SceneLayerPolygonFilter` on the OSM Buildings layer to hide all OSM buildings within the extent of the San Francisco Buildings layer.
+6. Set the visibility of the 3D San Francisco Buildings layer to `true` to show the 3D buildings in the extent.
 
 ## Relevant API
 
@@ -28,7 +29,7 @@ The sample initializes showing the 3D buildings OpenStreetMap layer. Click the "
 
 ## About the data
 
-This sample uses the [OpenStreetMap 3D Buildings](https://www.arcgis.com/home/item.html?id=ca0470dbbddb4db28bad74ed39949e25) which provides generic 3D outlines of buildings throughout the world. It is based on the OSM Daylight map distribution and is hosted by Esri. It uses the [San Francisco 3D Buildings](https://www.arcgis.com/home/item.html?id=d3344ba99c3f4efaa909ccfbcc052ed5) scene layer which provides detailed 3D models of buildings in San Francisco, California, USA.
+This sample uses the [Navigation 3D Basemap](https://arcgisruntime.maps.arcgis.com/home/item.html?id=00a5f468dda941d7bf0b51c144aae3f0) which includes commercial 3D buildings data acquired from TomTom and Vantor, in addition to Esri Community Maps and Overture Maps Foundation data. It also uses the [San Francisco 3D Buildings](https://www.arcgis.com/home/item.html?id=d3344ba99c3f4efaa909ccfbcc052ed5) scene layer which provides detailed 3D models of buildings in San Francisco, California, USA.
 
 ## Additional information
 


### PR DESCRIPTION
# Description

The old OSM buildings layer is deprecated, and this updates the layer.
It also changes the order of operations in the sample such that the Esri buildings are removed before adding the detailed buildings.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows

