### PR TITLE
Group layers - added busy indicator

### DIFF
--- a/CppSamples/Layers/GroupLayers/GroupLayers.cpp
+++ b/CppSamples/Layers/GroupLayers/GroupLayers.cpp
@@ -53,6 +53,8 @@ GroupLayers::GroupLayers(QObject* parent /* = nullptr */):
   // add the elevation source to the scene to display elevation
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
 
+  m_busy = true;
+
   // Create layers and append to a group layer
   ArcGISSceneLayer* layer1 = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevA_BuildingShells/SceneServer"), this);
   ArcGISSceneLayer* layer2 = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevB_BuildingShells/SceneServer"), this);
@@ -75,6 +77,9 @@ GroupLayers::GroupLayers(QObject* parent /* = nullptr */):
 
   connect(m_scene, &Scene::doneLoading, this, [this](const Error& e)
   {
+    m_busy = false;
+    emit busyChanged();
+
     if (!e.isEmpty())
       return;
 
@@ -96,6 +101,11 @@ void GroupLayers::init()
 SceneQuickView* GroupLayers::sceneView() const
 {
   return m_sceneView;
+}
+
+bool GroupLayers::busy() const
+{
+  return m_busy;
 }
 
 // Set the view (created in QML)

--- a/CppSamples/Layers/GroupLayers/GroupLayers.cpp
+++ b/CppSamples/Layers/GroupLayers/GroupLayers.cpp
@@ -53,8 +53,6 @@ GroupLayers::GroupLayers(QObject* parent /* = nullptr */):
   // add the elevation source to the scene to display elevation
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
 
-  m_busy = true;
-
   // Create layers and append to a group layer
   ArcGISSceneLayer* layer1 = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevA_BuildingShells/SceneServer"), this);
   ArcGISSceneLayer* layer2 = new ArcGISSceneLayer(QUrl("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/DevB_BuildingShells/SceneServer"), this);
@@ -101,11 +99,6 @@ void GroupLayers::init()
 SceneQuickView* GroupLayers::sceneView() const
 {
   return m_sceneView;
-}
-
-bool GroupLayers::busy() const
-{
-  return m_busy;
 }
 
 // Set the view (created in QML)

--- a/CppSamples/Layers/GroupLayers/GroupLayers.h
+++ b/CppSamples/Layers/GroupLayers/GroupLayers.h
@@ -38,6 +38,7 @@ class GroupLayers : public QObject
 
   Q_PROPERTY(Esri::ArcGISRuntime::SceneQuickView* sceneView READ sceneView WRITE setSceneView NOTIFY sceneViewChanged)
   Q_PROPERTY(Esri::ArcGISRuntime::LayerListModel* layerListModel MEMBER m_layerListModel NOTIFY layerListModelChanged)
+  Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
 
 public:
   explicit GroupLayers(QObject* parent = nullptr);
@@ -48,6 +49,7 @@ public:
 signals:
   void sceneViewChanged();
   void layerListModelChanged();
+  void busyChanged();
 
 public:
   Q_INVOKABLE Esri::ArcGISRuntime::LayerListModel* getGroupLayerListModel(int layerId);
@@ -55,10 +57,13 @@ public:
 private:
   Esri::ArcGISRuntime::SceneQuickView* sceneView() const;
   void setSceneView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
+  bool busy() const;
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
   Esri::ArcGISRuntime::LayerListModel* m_layerListModel = nullptr;
+
+  bool m_busy = true;
 };
 
 #endif // GROUPLAYERS_H

--- a/CppSamples/Layers/GroupLayers/GroupLayers.h
+++ b/CppSamples/Layers/GroupLayers/GroupLayers.h
@@ -38,7 +38,7 @@ class GroupLayers : public QObject
 
   Q_PROPERTY(Esri::ArcGISRuntime::SceneQuickView* sceneView READ sceneView WRITE setSceneView NOTIFY sceneViewChanged)
   Q_PROPERTY(Esri::ArcGISRuntime::LayerListModel* layerListModel MEMBER m_layerListModel NOTIFY layerListModelChanged)
-  Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+  Q_PROPERTY(bool busy MEMBER m_busy NOTIFY busyChanged)
 
 public:
   explicit GroupLayers(QObject* parent = nullptr);
@@ -57,7 +57,6 @@ public:
 private:
   Esri::ArcGISRuntime::SceneQuickView* sceneView() const;
   void setSceneView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
-  bool busy() const;
 
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
   Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;

--- a/CppSamples/Layers/GroupLayers/GroupLayers.qml
+++ b/CppSamples/Layers/GroupLayers/GroupLayers.qml
@@ -41,10 +41,10 @@ Item {
         id: layerVisibilityRect
         color: palette.base
         border.color: "darkgray"
-        opacity: 1
         radius: 5
         width: 250
         height: layerVisibilityListView.contentHeight + 20
+        visible: !sampleModel.busy
 
 
         // Create a list view to display the items
@@ -105,9 +105,23 @@ Item {
                         text: name
                         checked: layerVisible
                         onToggled: layerVisible = checked;
+                        visible: name !== ""
                     }
                 }
             }
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "black"
+        opacity: 0.7
+        visible: sampleModel.busy
+
+        BusyIndicator {
+            anchors.centerIn: parent
+            running: sampleModel.busy
+            visible: running
         }
     }
 }


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->
Group Layers sample - added busy indicator while scene is loading. Check boxes will only be visible when the corresponding layer has loaded `name !== ""`

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
