### PR TITLE
Recalculate VisibleAtCurrentExtent once the layer is available

### DIFF
--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp
@@ -95,12 +95,7 @@ void ControlAnnotationSublayerVisibility::setMapView(MapQuickView* mapView)
     m_mapScale = m_mapView->mapScale();
     emit mapScaleChanged();
 
-    const bool visibleAtCurrentExtent = m_annotationSubLayerOpen ? m_annotationSubLayerOpen->isVisibleAtScale(m_mapScale) : false;
-    if (m_visibleAtCurrentExtent != visibleAtCurrentExtent)
-    {
-      m_visibleAtCurrentExtent = visibleAtCurrentExtent;
-      emit visibleAtCurrentExtentChanged();
-    }
+    recalculateVisibleAtCurrentExtent();
   });
 
   emit mapViewChanged();
@@ -162,6 +157,7 @@ void ControlAnnotationSublayerVisibility::createMapPackage(const QString& path)
           m_openLayerText = QString("%1 (1:%2 - 1:%3)").arg(m_annotationSubLayerOpen->name()).arg(m_annotationSubLayerOpen->maxScale()).arg(m_annotationSubLayerOpen->minScale());
           emit openLayerTextChanged();
           emit closedLayerTextChanged();
+          recalculateVisibleAtCurrentExtent();
         });
         layer->load();
       }
@@ -186,4 +182,14 @@ void ControlAnnotationSublayerVisibility::closedLayerVisible()
     return;
 
   m_annotationSubLayerClosed->setVisible(!m_annotationSubLayerClosed->isVisible());
+}
+
+void ControlAnnotationSublayerVisibility::recalculateVisibleAtCurrentExtent()
+{
+  const bool visibleAtCurrentExtent = m_annotationSubLayerOpen ? m_annotationSubLayerOpen->isVisibleAtScale(m_mapScale) : false;
+  if (m_visibleAtCurrentExtent != visibleAtCurrentExtent)
+  {
+    m_visibleAtCurrentExtent = visibleAtCurrentExtent;
+    emit visibleAtCurrentExtentChanged();
+  }
 }

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h
@@ -62,6 +62,7 @@ private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;
   void setMapView(Esri::ArcGISRuntime::MapQuickView* mapView);
   void createMapPackage(const QString& path);
+  void recalculateVisibleAtCurrentExtent();
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;


### PR DESCRIPTION
# Description

Minnakan found while testing that if the window is large enough, it will initially appear within the extent, but the text is grayed out. That is because the `MapQuickView::mapScaleChanged` signal can fire before the layer has been assigned, and if the viewpoint isn't changed, it just stays with the wrong text color.

Now we fire the new `recalculateVisibleAtCurrentExtent` method as soon as the layer is available, which calculates the value as early as possible, and `MapQuickView::mapScaleChanged` handles all the subsequent updates.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

