### PR TITLE
Aji13187/7830 mouse right double clicks

### DIFF
--- a/CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
+++ b/CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.qml
@@ -60,7 +60,9 @@ AnalyzeHotspotsSample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
     }

--- a/CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
+++ b/CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.qml
@@ -90,7 +90,9 @@ AnalyzeViewshedSample {
 
     MouseArea {
         anchors.fill: statusColumn
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: mouse => mouse.accepted = true
+        onDoubleClicked: mouse => mouse.accepted = true
         onWheel: wheel => wheel.accepted = true
     }
 

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.qml
@@ -46,7 +46,9 @@ Item {
         
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
     }

--- a/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.qml
+++ b/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.qml
@@ -53,8 +53,11 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onPressed: mouse => mouse.accepted = true;
             onWheel: wheel => wheel.accepted = true;
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
         }
 
         ColumnLayout {

--- a/CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
+++ b/CppSamples/DisplayInformation/BuildLegend/BuildLegend.qml
@@ -65,7 +65,9 @@ BuildLegendSample {
         // Catch mouse signals so they don't propagate to the map
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
+++ b/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qml
@@ -58,7 +58,9 @@ Item {
         // Catch mouse signals so they don't propagate to the map
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qml
@@ -57,7 +57,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
     }

--- a/CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
+++ b/CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.qml
@@ -136,7 +136,9 @@ EditAndSyncFeaturesSample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -74,7 +74,9 @@ EditFeatureAttachmentsSample {
         // accept mouse events so they do not propogate down to the map
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
+++ b/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.qml
@@ -49,7 +49,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true;
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true;
         }
 

--- a/CppSamples/EditData/EditGeodatabaseWithTransactions/EditGeodatabaseWithTransactions.qml
+++ b/CppSamples/EditData/EditGeodatabaseWithTransactions/EditGeodatabaseWithTransactions.qml
@@ -45,7 +45,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 
@@ -89,7 +91,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -118,8 +118,10 @@ Item {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         ColumnLayout {
@@ -189,8 +191,10 @@ Item {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         GridLayout {

--- a/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.qml
+++ b/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.qml
@@ -177,8 +177,10 @@ ManageFeaturesFeatureServiceSample {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         Column {

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.qml
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.qml
@@ -64,7 +64,9 @@ Item {
 
                 MouseArea {
                     anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
                     onClicked: mouse => mouse.accepted = true
+                    onDoubleClicked: mouse => mouse.accepted = true
                     onWheel: wheel => wheel.accepted = true
                 }
             }
@@ -193,7 +195,9 @@ Item {
 
         MouseArea {
             anchors.fill: optionPanel
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -54,8 +54,10 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         Column {
@@ -181,8 +183,10 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         Column {
@@ -237,8 +241,10 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         ListView {
@@ -325,8 +331,10 @@ Item {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
         }
 
         Button {

--- a/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
+++ b/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.qml
@@ -100,7 +100,9 @@ GenerateGeodatabaseReplicaFromFeatureServiceSample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Features/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.qml
+++ b/CppSamples/Features/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.qml
@@ -52,7 +52,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
     }

--- a/CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.qml
+++ b/CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.qml
@@ -54,7 +54,9 @@ DensifyAndGeneralizeSample {
             
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Geometry/NearestVertex/NearestVertex.qml
+++ b/CppSamples/Geometry/NearestVertex/NearestVertex.qml
@@ -48,7 +48,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
         

--- a/CppSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
+++ b/CppSamples/Geometry/SpatialRelationships/SpatialRelationships.qml
@@ -53,7 +53,9 @@ SpatialRelationshipsSample {
         
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
     }

--- a/CppSamples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.qml
+++ b/CppSamples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.qml
@@ -63,7 +63,9 @@ Item {
         // Catch mouse signals so they don't propagate to the map
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.qml
+++ b/CppSamples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.qml
@@ -47,7 +47,9 @@ Item {
         color: palette.base
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
         Column {

--- a/CppSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.qml
+++ b/CppSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.qml
@@ -45,7 +45,9 @@ Item {
 
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.qml
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.qml
@@ -43,7 +43,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
+++ b/CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.qml
@@ -51,7 +51,9 @@ Item {
                 
                 MouseArea {
                     anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
                     onClicked: mouse => mouse.accepted = true
+                    onDoubleClicked: mouse => mouse.accepted = true
                     onWheel: wheel => wheel.accepted = true
                 }
             }

--- a/CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -48,7 +48,9 @@ ChangeSublayerVisibilitySample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Layers/ConfigureClusters/ConfigureClusters.qml
+++ b/CppSamples/Layers/ConfigureClusters/ConfigureClusters.qml
@@ -50,7 +50,9 @@ Item {
         
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
     }

--- a/CppSamples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.qml
+++ b/CppSamples/Layers/DisplayFeatureLayers/DisplayFeatureLayers.qml
@@ -52,7 +52,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
         

--- a/CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
+++ b/CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.qml
@@ -48,7 +48,9 @@ Item {
             // catch mouse signals from propagating to parent
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -101,7 +101,9 @@ ExportTilesSample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -31,7 +31,9 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: mouse => mouse.accepted = true
+        onDoubleClicked: mouse => mouse.accepted = true
         onWheel: wheel => wheel.accepted = true
     }
 

--- a/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.qml
+++ b/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.qml
@@ -47,7 +47,9 @@ Item {
         // catch mouse signals from propagating to parent
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
+++ b/CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
@@ -56,8 +56,10 @@ Item {
 
             MouseArea {
                 anchors.fill: controlLayout
-                onClicked: mouse => mouse.accepted = true;
-                onWheel: wheel => wheel.accepted = true;
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
+                onWheel: wheel => wheel.accepted = true
             }
 
             ColumnLayout{

--- a/CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -53,7 +53,9 @@ Item {
         // catch mouse signals from propagating to parent
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
+++ b/CppSamples/Maps/GenerateOfflineMap/GenerateWindow.qml
@@ -30,7 +30,9 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: mouse => mouse.accepted = true
+        onDoubleClicked: mouse => mouse.accepted = true
         onWheel: wheel => wheel.accepted = true
     }
 

--- a/CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
+++ b/CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateWindow.qml
@@ -30,7 +30,9 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: mouse => mouse.accepted = true
+        onDoubleClicked: mouse => mouse.accepted = true
         onWheel: wheel => wheel.accepted = true
     }
 

--- a/CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
+++ b/CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateWindow.qml
@@ -30,7 +30,9 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked: mouse => mouse.accepted = true
+        onDoubleClicked: mouse => mouse.accepted = true
         onWheel: wheel => wheel.accepted = true
     }
 

--- a/CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
+++ b/CppSamples/Maps/OpenMapUrl/OpenMapUrl.qml
@@ -92,7 +92,9 @@ OpenMapUrlSample {
 
        MouseArea {
            anchors.fill: parent
+           acceptedButtons: Qt.LeftButton | Qt.RightButton
            onClicked: mouse => mouse.accepted = true
+           onDoubleClicked: mouse => mouse.accepted = true
            onWheel: wheel => wheel.accepted = true
        }
 

--- a/CppSamples/Maps/SetMaxExtent/SetMaxExtent.qml
+++ b/CppSamples/Maps/SetMaxExtent/SetMaxExtent.qml
@@ -42,9 +42,11 @@ Item {
             radius: 5
 
             MouseArea {
-            anchors.fill: parent
-            onClicked: mouse => mouse.accepted = true
-            onWheel: wheel => wheel.accepted = true
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
+                onWheel: wheel => wheel.accepted = true
             }
 
 

--- a/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.qml
+++ b/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.qml
@@ -47,7 +47,9 @@ Item {
             // catch mouse signals from propagating to parent
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/Routing/NavigateRoute/NavigateRoute.qml
+++ b/CppSamples/Routing/NavigateRoute/NavigateRoute.qml
@@ -44,7 +44,9 @@ Item {
             
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
+++ b/CppSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.qml
@@ -46,7 +46,9 @@ Item {
 
            MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.qml
+++ b/CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.qml
@@ -73,7 +73,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
         

--- a/CppSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
+++ b/CppSamples/Scenes/ChooseCameraController/ChooseCameraController.qml
@@ -55,7 +55,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
         ColumnLayout {

--- a/CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.qml
+++ b/CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.qml
@@ -259,7 +259,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.qml
+++ b/CppSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.qml
@@ -50,7 +50,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
         

--- a/CppSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
+++ b/CppSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.qml
@@ -43,7 +43,9 @@ Item {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Scenes/SetSurfacePlacementMode/SetSurfacePlacementMode.qml
+++ b/CppSamples/Scenes/SetSurfacePlacementMode/SetSurfacePlacementMode.qml
@@ -49,7 +49,9 @@ SetSurfacePlacementModeSample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 
@@ -84,7 +86,9 @@ SetSurfacePlacementModeSample {
 
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 

--- a/CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
+++ b/CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.qml
@@ -53,7 +53,9 @@ TerrainExaggerationSample {
             
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
+++ b/CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.qml
@@ -38,7 +38,9 @@ Item {
                 
                 MouseArea {
                     anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
                     onClicked: mouse => mouse.accepted = true
+                    onDoubleClicked: mouse => mouse.accepted = true
                     onWheel: wheel => wheel.accepted = true
                 }
             }

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.qml
@@ -50,7 +50,9 @@ Item {
             
             MouseArea {
                 anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
                 onClicked: mouse => mouse.accepted = true
+                onDoubleClicked: mouse => mouse.accepted = true
                 onWheel: wheel => wheel.accepted = true
             }
 

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qml
@@ -100,7 +100,9 @@ Item {
         // catch mouse signals from propagating to parent
         MouseArea {
             anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: mouse => mouse.accepted = true
+            onDoubleClicked: mouse => mouse.accepted = true
             onWheel: wheel => wheel.accepted = true
         }
 


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Fixed double right mouse click (zoom out) works through the controls.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
