### PR TITLE
remove openGL module from sample template

### DIFF
--- a/Templates/CppSampleTemplate/sample.pro.tmpl
+++ b/Templates/CppSampleTemplate/sample.pro.tmpl
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = %{SampleName}


### PR DESCRIPTION
# Description

We currently include the `openGL` module in our sample template, but this is unnecessary. OpenGL is the default graphics backend for android and linux, but we already include this module in our internal `.pro` files of our SDK, so the module will already be present. 

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [x] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
