### PR TITLE
Remove opengl module from standalone and SampleViewer pro files

### DIFF
--- a/CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
+++ b/CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
+++ b/CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.pro
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DistanceMeasurementAnalysis

--- a/CppSamples/Analysis/Geotriggers/Geotriggers.pro
+++ b/CppSamples/Analysis/Geotriggers/Geotriggers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = Geotriggers

--- a/CppSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.pro
+++ b/CppSamples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = LineOfSightGeoElement

--- a/CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.pro
+++ b/CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = LineOfSightLocation

--- a/CppSamples/Analysis/StatisticalQuery/StatisticalQuery.pro
+++ b/CppSamples/Analysis/StatisticalQuery/StatisticalQuery.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = StatisticalQuery

--- a/CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.pro
+++ b/CppSamples/Analysis/StatisticalQueryGroupSort/StatisticalQueryGroupSort.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = StatisticalQueryGroupSort

--- a/CppSamples/Analysis/ViewshedCamera/ViewshedCamera.pro
+++ b/CppSamples/Analysis/ViewshedCamera/ViewshedCamera.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ViewshedCamera

--- a/CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.pro
+++ b/CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ViewshedGeoElement

--- a/CppSamples/Analysis/ViewshedLocation/ViewshedLocation.pro
+++ b/CppSamples/Analysis/ViewshedLocation/ViewshedLocation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ViewshedLocation

--- a/CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
+++ b/CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.pro
+++ b/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = IntegratedWindowsAuthentication

--- a/CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
+++ b/CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
+++ b/CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
+++ b/CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
+++ b/CppSamples/CloudAndPortal/TokenAuthentication/TokenAuthentication.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.pro
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/AddGraphicsWithRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddGraphicsWithRenderer

--- a/CppSamples/DisplayInformation/BuildLegend/BuildLegend.pro
+++ b/CppSamples/DisplayInformation/BuildLegend/BuildLegend.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.pro
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ControlAnnotationSublayerVisibility

--- a/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.pro
+++ b/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateSymbolStylesFromWebStyles

--- a/CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.pro
+++ b/CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CustomDictionaryStyle

--- a/CppSamples/DisplayInformation/DisplayClusters/DisplayClusters.pro
+++ b/CppSamples/DisplayInformation/DisplayClusters/DisplayClusters.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayClusters

--- a/CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/CppSamples/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
+++ b/CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
+++ b/CppSamples/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.pro
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = QueryFeaturesWithArcadeExpression

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.pro
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ReadSymbolsFromMobileStyle

--- a/CppSamples/DisplayInformation/RenderMultilayerSymbols/RenderMultilayerSymbols.pro
+++ b/CppSamples/DisplayInformation/RenderMultilayerSymbols/RenderMultilayerSymbols.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RenderMultilayerSymbols

--- a/CppSamples/DisplayInformation/ShowCallout/ShowCallout.pro
+++ b/CppSamples/DisplayInformation/ShowCallout/ShowCallout.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/ShowGrid/ShowGrid.pro
+++ b/CppSamples/DisplayInformation/ShowGrid/ShowGrid.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.pro
+++ b/CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ShowLabelsOnLayers

--- a/CppSamples/DisplayInformation/ShowPopup/ShowPopup.pro
+++ b/CppSamples/DisplayInformation/ShowPopup/ShowPopup.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ShowPopup

--- a/CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
+++ b/CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
+++ b/CppSamples/DisplayInformation/Simple_Renderer/Simple_Renderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.pro
+++ b/CppSamples/DisplayInformation/SymbolizeShapefile/SymbolizeShapefile.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SymbolizeShapefile

--- a/CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
+++ b/CppSamples/DisplayInformation/Unique_Value_Renderer/Unique_Value_Renderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/EditData/ContingentValues/ContingentValues.pro
+++ b/CppSamples/EditData/ContingentValues/ContingentValues.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ContingentValues

--- a/CppSamples/EditData/CreateKmlMultiTrack/CreateKmlMultiTrack.pro
+++ b/CppSamples/EditData/CreateKmlMultiTrack/CreateKmlMultiTrack.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateKmlMultiTrack

--- a/CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
+++ b/CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
+++ b/CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.pro
+++ b/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = EditFeaturesWithFeatureLinkedAnnotation

--- a/CppSamples/EditData/EditGeodatabaseWithTransactions/EditGeodatabaseWithTransactions.pro
+++ b/CppSamples/EditData/EditGeodatabaseWithTransactions/EditGeodatabaseWithTransactions.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = EditGeodatabaseWithTransactions

--- a/CppSamples/EditData/EditGeometriesWithProgrammaticReticleTool/EditGeometriesWithProgrammaticReticleTool.pro
+++ b/CppSamples/EditData/EditGeometriesWithProgrammaticReticleTool/EditGeometriesWithProgrammaticReticleTool.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = EditGeometriesWithProgrammaticReticleTool

--- a/CppSamples/EditData/EditKmlGroundOverlay/EditKmlGroundOverlay.pro
+++ b/CppSamples/EditData/EditKmlGroundOverlay/EditKmlGroundOverlay.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++11
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = EditKmlGroundOverlay

--- a/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.pro
+++ b/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = EditWithBranchVersioning

--- a/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.pro
+++ b/CppSamples/EditData/ManageFeaturesFeatureService/ManageFeaturesFeatureService.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ManageFeaturesFeatureService

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.pro
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SnapGeometryEdits

--- a/CppSamples/EditData/SnapGeometryEditsWithRules/SnapGeometryEditsWithRules.pro
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/SnapGeometryEditsWithRules.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SnapGeometryEditsWithRules

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/ControlTimeExtentTimeSlider.pro
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/ControlTimeExtentTimeSlider.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ControlTimeExtentTimeSlider

--- a/CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.pro
+++ b/CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateMobileGeodatabase

--- a/CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.pro
+++ b/CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.pro
+++ b/CppSamples/Features/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.pro
+++ b/CppSamples/Features/FeatureLayerQuery/FeatureLayerQuery.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.pro
+++ b/CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FeatureLayerSelection

--- a/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.pro
+++ b/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.pro
+++ b/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/GenerateGeodatabaseReplicaFromFeatureService.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
+++ b/CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ListRelatedFeatures

--- a/CppSamples/Features/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.pro
+++ b/CppSamples/Features/ToggleBetweenFeatureRequestModes/ToggleBetweenFeatureRequestModes.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ToggleBetweenFeatureRequestModes

--- a/CppSamples/Geometry/Buffer/Buffer.pro
+++ b/CppSamples/Geometry/Buffer/Buffer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = Buffer

--- a/CppSamples/Geometry/ClipGeometry/ClipGeometry.pro
+++ b/CppSamples/Geometry/ClipGeometry/ClipGeometry.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ClipGeometry

--- a/CppSamples/Geometry/ConvexHull/ConvexHull.pro
+++ b/CppSamples/Geometry/ConvexHull/ConvexHull.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ConvexHull

--- a/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.pro
+++ b/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateAndEditGeometries

--- a/CppSamples/Geometry/CreateGeometries/CreateGeometries.pro
+++ b/CppSamples/Geometry/CreateGeometries/CreateGeometries.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateGeometries

--- a/CppSamples/Geometry/CutGeometry/CutGeometry.pro
+++ b/CppSamples/Geometry/CutGeometry/CutGeometry.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CutGeometry

--- a/CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.pro
+++ b/CppSamples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DensifyAndGeneralize

--- a/CppSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
+++ b/CppSamples/Geometry/FormatCoordinates/FormatCoordinates.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Geometry/GeodesicOperations/GeodesicOperations.pro
+++ b/CppSamples/Geometry/GeodesicOperations/GeodesicOperations.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = GeodesicOperations

--- a/CppSamples/Geometry/ListTransformations/ListTransformations.pro
+++ b/CppSamples/Geometry/ListTransformations/ListTransformations.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ListTransformations

--- a/CppSamples/Geometry/NearestVertex/NearestVertex.pro
+++ b/CppSamples/Geometry/NearestVertex/NearestVertex.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = NearestVertex

--- a/CppSamples/Geometry/ProjectGeometry/ProjectGeometry.pro
+++ b/CppSamples/Geometry/ProjectGeometry/ProjectGeometry.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ProjectGeometry

--- a/CppSamples/Geometry/SpatialOperations/SpatialOperations.pro
+++ b/CppSamples/Geometry/SpatialOperations/SpatialOperations.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SpatialOperations

--- a/CppSamples/Geometry/SpatialRelationships/SpatialRelationships.pro
+++ b/CppSamples/Geometry/SpatialRelationships/SpatialRelationships.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SpatialRelationships

--- a/CppSamples/Layers/AddBuildingSceneLayer/AddBuildingSceneLayer.pro
+++ b/CppSamples/Layers/AddBuildingSceneLayer/AddBuildingSceneLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddBuildingSceneLayer

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.pro
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/AddCustomDynamicEntityDataSource.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddCustomDynamicEntityDataSource

--- a/CppSamples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.pro
+++ b/CppSamples/Layers/AddDynamicEntityLayer/AddDynamicEntityLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddDynamicEntityLayer

--- a/CppSamples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.pro
+++ b/CppSamples/Layers/AddVectorTiledLayerFromCustomStyle/AddVectorTiledLayerFromCustomStyle.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddVectorTiledLayerFromCustomStyle

--- a/CppSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.pro
+++ b/CppSamples/Layers/ApplyMosaicRuleToRasters/ApplyMosaicRuleToRasters.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ApplyMosaicRuleToRasters

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.pro
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/ApplyUniqueValuesWithAlternateSymbols.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ApplyUniqueValuesWithAlternateSymbols

--- a/CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
+++ b/CppSamples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/CppSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
+++ b/CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = BlendRasterLayer

--- a/CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.pro
+++ b/CppSamples/Layers/BrowseOGCAPIFeatureService/BrowseOGCAPIFeatureService.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = BrowseOGCAPIFeatureService

--- a/CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.pro
+++ b/CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = BrowseWfsLayers

--- a/CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.pro
+++ b/CppSamples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ChangeSublayerRenderer

--- a/CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
+++ b/CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/ConfigureClusters/ConfigureClusters.pro
+++ b/CppSamples/Layers/ConfigureClusters/ConfigureClusters.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick gui
+QT += qml quick gui
 
 TEMPLATE = app
 TARGET = ConfigureClusters

--- a/CppSamples/Layers/ConfigureElectronicNavigationalCharts/ConfigureElectronicNavigationalCharts.pro
+++ b/CppSamples/Layers/ConfigureElectronicNavigationalCharts/ConfigureElectronicNavigationalCharts.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ConfigureElectronicNavigationalCharts

--- a/CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.pro
+++ b/CppSamples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateAndSaveKmlFile

--- a/CppSamples/Layers/DisplayAnnotation/DisplayAnnotation.pro
+++ b/CppSamples/Layers/DisplayAnnotation/DisplayAnnotation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayAnnotation

--- a/CppSamples/Layers/DisplayDimensions/DisplayDimensions.pro
+++ b/CppSamples/Layers/DisplayDimensions/DisplayDimensions.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayDimensions

--- a/CppSamples/Layers/DisplayKml/DisplayKml.pro
+++ b/CppSamples/Layers/DisplayKml/DisplayKml.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayKml

--- a/CppSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.pro
+++ b/CppSamples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayKmlNetworkLinks

--- a/CppSamples/Layers/DisplayOgcApiFeatureCollection/DisplayOgcApiFeatureCollection.pro
+++ b/CppSamples/Layers/DisplayOgcApiFeatureCollection/DisplayOgcApiFeatureCollection.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayOgcApiFeatureCollection

--- a/CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.pro
+++ b/CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplaySubtypeFeatureLayer

--- a/CppSamples/Layers/DisplayWfsLayer/DisplayWfsLayer.pro
+++ b/CppSamples/Layers/DisplayWfsLayer/DisplayWfsLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayWfsLayer

--- a/CppSamples/Layers/ExportTiles/ExportTiles.pro
+++ b/CppSamples/Layers/ExportTiles/ExportTiles.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/ExportVectorTiles/ExportVectorTiles.pro
+++ b/CppSamples/Layers/ExportVectorTiles/ExportVectorTiles.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ExportVectorTiles

--- a/CppSamples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.pro
+++ b/CppSamples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FeatureCollectionLayerFromPortal

--- a/CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
+++ b/CppSamples/Layers/FeatureCollectionLayerQuery/FeatureCollectionLayerQuery.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FeatureCollectionLayerQuery

--- a/CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.pro
+++ b/CppSamples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FeatureLayerRenderingModeMap

--- a/CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.pro
+++ b/CppSamples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FeatureLayerRenderingModeScene

--- a/CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
+++ b/CppSamples/Layers/Feature_Collection_Layer/Feature_Collection_Layer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/GroupLayers/GroupLayers.pro
+++ b/CppSamples/Layers/GroupLayers/GroupLayers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = GroupLayers

--- a/CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
+++ b/CppSamples/Layers/Hillshade_Renderer/Hillshade_Renderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.pro
+++ b/CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = IdentifyKmlFeatures

--- a/CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.pro
+++ b/CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = IdentifyRasterCell

--- a/CppSamples/Layers/ListKmlContents/ListKmlContents.pro
+++ b/CppSamples/Layers/ListKmlContents/ListKmlContents.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ListKmlContents

--- a/CppSamples/Layers/LoadWfsXmlQuery/LoadWfsXmlQuery.pro
+++ b/CppSamples/Layers/LoadWfsXmlQuery/LoadWfsXmlQuery.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = LoadWfsXmlQuery

--- a/CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.pro
+++ b/CppSamples/Layers/ManageOperationalLayers/ManageOperationalLayers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ManageOperationalLayers

--- a/CppSamples/Layers/OSM_Layer/OSM_Layer.pro
+++ b/CppSamples/Layers/OSM_Layer/OSM_Layer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = OSM_Layer

--- a/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
+++ b/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = PlayAKmlTour

--- a/CppSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.pro
+++ b/CppSamples/Layers/QueryMapImageSublayer/QueryMapImageSublayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = QueryMapImageSublayer

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/QueryOGCAPICQLFilters.pro
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/QueryOGCAPICQLFilters.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = QueryOGCAPICQLFilters

--- a/CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
+++ b/CppSamples/Layers/RasterColormapRenderer/RasterColormapRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterColormapRenderer

--- a/CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
+++ b/CppSamples/Layers/RasterFunctionFile/RasterFunctionFile.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterFunctionFile

--- a/CppSamples/Layers/RasterFunctionService/RasterFunctionService.pro
+++ b/CppSamples/Layers/RasterFunctionService/RasterFunctionService.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterFunctionService

--- a/CppSamples/Layers/RasterLayerFile/RasterLayerFile.pro
+++ b/CppSamples/Layers/RasterLayerFile/RasterLayerFile.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.pro
+++ b/CppSamples/Layers/RasterLayerGeoPackage/RasterLayerGeoPackage.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterLayerGeoPackage

--- a/CppSamples/Layers/RasterLayerService/RasterLayerService.pro
+++ b/CppSamples/Layers/RasterLayerService/RasterLayerService.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterLayerService

--- a/CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
+++ b/CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterRenderingRule

--- a/CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
+++ b/CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RgbRenderer

--- a/CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
+++ b/CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RasterStretchRenderer

--- a/CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.pro
+++ b/CppSamples/Layers/StyleWmsLayer/StyleWmsLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = StyleWmsLayer

--- a/CppSamples/Layers/TileCacheLayer/TileCacheLayer.pro
+++ b/CppSamples/Layers/TileCacheLayer/TileCacheLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = TileCacheLayer

--- a/CppSamples/Layers/WMTS_Layer/WMTS_Layer.pro
+++ b/CppSamples/Layers/WMTS_Layer/WMTS_Layer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = WMTS_Layer

--- a/CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
+++ b/CppSamples/Layers/Web_Tiled_Layer/Web_Tiled_Layer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = Web_Tiled_Layer

--- a/CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.pro
+++ b/CppSamples/Layers/WmsLayerUrl/WmsLayerUrl.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = WmsLayerUrl

--- a/CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
+++ b/CppSamples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
+++ b/CppSamples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
+++ b/CppSamples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
+++ b/CppSamples/LocalServer/LocalServerServices/LocalServerServices.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.pro
+++ b/CppSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ApplyScheduledMapUpdates

--- a/CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.pro
+++ b/CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = BrowseBuildingFloors

--- a/CppSamples/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/CppSamples/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ChangeBasemap

--- a/CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/ConfigureBasemapStyleLanguage.pro
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/ConfigureBasemapStyleLanguage.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ConfigureBasemapStyleLanguage

--- a/CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.pro
+++ b/CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateAndSaveMap

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.pro
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateDynamicBasemapGallery

--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/displayDeviceLocationWithNmeaDataSources.pro
+++ b/CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/displayDeviceLocationWithNmeaDataSources.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayDeviceLocationWithNmeaDataSources

--- a/CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
+++ b/CppSamples/Maps/DisplayDrawingStatus/DisplayDrawingStatus.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.pro
+++ b/CppSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayLayerViewDrawState

--- a/CppSamples/Maps/DisplayMap/DisplayMap.pro
+++ b/CppSamples/Maps/DisplayMap/DisplayMap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayMap

--- a/CppSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.pro
+++ b/CppSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayOverviewMap

--- a/CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.pro
+++ b/CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DownloadPreplannedMap

--- a/CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
+++ b/CppSamples/Maps/GenerateOfflineMap/GenerateOfflineMap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = GenerateOfflineMap

--- a/CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.pro
+++ b/CppSamples/Maps/GenerateOfflineMapLocalBasemap/GenerateOfflineMapLocalBasemap.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = GenerateOfflineMapLocalBasemap

--- a/CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.pro
+++ b/CppSamples/Maps/GenerateOfflineMap_Overrides/GenerateOfflineMap_Overrides.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = GenerateOfflineMap_Overrides

--- a/CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.pro
+++ b/CppSamples/Maps/HonorMobileMapPackageExpiration/HonorMobileMapPackageExpiration.pro
@@ -21,7 +21,7 @@ mac {
 
 CONFIG += c++17
 
-QT += opengl qml quick positioning sensors
+QT += qml quick positioning sensors
 
 TEMPLATE = app
 TARGET = HonorMobileMapPackageExpiration

--- a/CppSamples/Maps/IdentifyLayers/IdentifyLayers.pro
+++ b/CppSamples/Maps/IdentifyLayers/IdentifyLayers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = IdentifyLayers

--- a/CppSamples/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/CppSamples/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/MapLoaded/MapLoaded.pro
+++ b/CppSamples/Maps/MapLoaded/MapLoaded.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/MapReferenceScale/MapReferenceScale.pro
+++ b/CppSamples/Maps/MapReferenceScale/MapReferenceScale.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = MapReferenceScale

--- a/CppSamples/Maps/MapRotation/MapRotation.pro
+++ b/CppSamples/Maps/MapRotation/MapRotation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/MinMaxScale/MinMaxScale.pro
+++ b/CppSamples/Maps/MinMaxScale/MinMaxScale.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = MinMaxScale

--- a/CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
+++ b/CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/OpenMapUrl/OpenMapUrl.pro
+++ b/CppSamples/Maps/OpenMapUrl/OpenMapUrl.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
+++ b/CppSamples/Maps/OpenMobileMap_MapPackage/OpenMobileMap_MapPackage.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/ReadGeoPackage/ReadGeoPackage.pro
+++ b/CppSamples/Maps/ReadGeoPackage/ReadGeoPackage.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ReadGeoPackage

--- a/CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/CppSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/CppSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/CppSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/SetMaxExtent/SetMaxExtent.pro
+++ b/CppSamples/Maps/SetMaxExtent/SetMaxExtent.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SetMaxExtent

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.pro
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 android|ios: QT += bluetooth
 
 TEMPLATE = app

--- a/CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.pro
+++ b/CppSamples/Maps/ShowLocationHistory/ShowLocationHistory.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ShowLocationHistory

--- a/CppSamples/Maps/ShowMagnifier/ShowMagnifier.pro
+++ b/CppSamples/Maps/ShowMagnifier/ShowMagnifier.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Maps/TakeScreenshot/TakeScreenshot.pro
+++ b/CppSamples/Maps/TakeScreenshot/TakeScreenshot.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = TakeScreenshot

--- a/CppSamples/Routing/ClosestFacility/ClosestFacility.pro
+++ b/CppSamples/Routing/ClosestFacility/ClosestFacility.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ClosestFacility

--- a/CppSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.pro
+++ b/CppSamples/Routing/DisplayRouteLayer/DisplayRouteLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayRouteLayer

--- a/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.pro
+++ b/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/FindClosestFacilityToMultipleIncidentsService.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FindClosestFacilityToMultipleIncidentsService

--- a/CppSamples/Routing/FindRoute/FindRoute.pro
+++ b/CppSamples/Routing/FindRoute/FindRoute.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.pro
+++ b/CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FindServiceAreasForMultipleFacilities

--- a/CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.pro
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 QT += texttospeech
 
 TEMPLATE = app

--- a/CppSamples/Routing/NavigateRoute/NavigateRoute.pro
+++ b/CppSamples/Routing/NavigateRoute/NavigateRoute.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 QT += texttospeech
 
 TEMPLATE = app

--- a/CppSamples/Routing/OfflineRouting/OfflineRouting.pro
+++ b/CppSamples/Routing/OfflineRouting/OfflineRouting.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = OfflineRouting

--- a/CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.pro
+++ b/CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RouteAroundBarriers

--- a/CppSamples/Routing/ServiceArea/ServiceArea.pro
+++ b/CppSamples/Routing/ServiceArea/ServiceArea.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ServiceArea

--- a/CppSamples/Scenes/Add3DTilesLayer/Add3DTilesLayer.pro
+++ b/CppSamples/Scenes/Add3DTilesLayer/Add3DTilesLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = Add3DTilesLayer

--- a/CppSamples/Scenes/AddAPointSceneLayer/AddAPointSceneLayer.pro
+++ b/CppSamples/Scenes/AddAPointSceneLayer/AddAPointSceneLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddAPointSceneLayer

--- a/CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.pro
+++ b/CppSamples/Scenes/AddIntegratedMeshLayer/AddIntegratedMeshLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AddIntegratedMeshLayer

--- a/CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
+++ b/CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.pro
+++ b/CppSamples/Scenes/AnimateImagesWithImageOverlay/AnimateImagesWithImageOverlay.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = AnimateImagesWithImageOverlay

--- a/CppSamples/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/CppSamples/Scenes/BasicSceneView/BasicSceneView.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = BasicSceneView

--- a/CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.pro
+++ b/CppSamples/Scenes/ChangeAtmosphereEffect/ChangeAtmosphereEffect.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ChangeAtmosphereEffect

--- a/CppSamples/Scenes/ChooseCameraController/ChooseCameraController.pro
+++ b/CppSamples/Scenes/ChooseCameraController/ChooseCameraController.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ChooseCameraController

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.pro
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/CreateTerrainSurfaceFromLocalRaster.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateTerrainSurfaceFromLocalRaster

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.pro
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/CreateTerrainSurfaceFromLocalTilePackage.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateTerrainSurfaceFromLocalTilePackage

--- a/CppSamples/Scenes/Display3DLabelsInScene/Display3DLabelsInScene.pro
+++ b/CppSamples/Scenes/Display3DLabelsInScene/Display3DLabelsInScene.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = Display3DLabelsInScene

--- a/CppSamples/Scenes/DisplayLocalSceneView/DisplayLocalSceneView.pro
+++ b/CppSamples/Scenes/DisplayLocalSceneView/DisplayLocalSceneView.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayLocalSceneView

--- a/CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
+++ b/CppSamples/Scenes/DisplaySceneLayer/DisplaySceneLayer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
+++ b/CppSamples/Scenes/DistanceCompositeSymbol/DistanceCompositeSymbol.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
+++ b/CppSamples/Scenes/ExtrudeGraphics/ExtrudeGraphics.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.pro
+++ b/CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FeatureLayerExtrusion

--- a/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.pro
+++ b/CppSamples/Scenes/FilterFeaturesInScene/FilterFeaturesInScene.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FilterFeaturesInScene

--- a/CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.pro
+++ b/CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = GetElevationAtPoint

--- a/CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.pro
+++ b/CppSamples/Scenes/OpenMobileScenePackage/OpenMobileScenePackage.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = OpenMobileScenePackage

--- a/CppSamples/Scenes/OpenScene/OpenScene.pro
+++ b/CppSamples/Scenes/OpenScene/OpenScene.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = OpenScene

--- a/CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.pro
+++ b/CppSamples/Scenes/OrbitCameraAroundObject/OrbitCameraAroundObject.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = OrbitCameraAroundObject

--- a/CppSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.pro
+++ b/CppSamples/Scenes/RealisticLightingAndShadows/RealisticLightingAndShadows.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = RealisticLightingAndShadows

--- a/CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.pro
+++ b/CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SceneLayerSelection

--- a/CppSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.pro
+++ b/CppSamples/Scenes/ScenePropertiesExpressions/ScenePropertiesExpressions.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ScenePropertiesExpressions

--- a/CppSamples/Scenes/SetSurfacePlacementMode/SetSurfacePlacementMode.pro
+++ b/CppSamples/Scenes/SetSurfacePlacementMode/SetSurfacePlacementMode.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SurfacePlacement

--- a/CppSamples/Scenes/Symbols/Symbols.pro
+++ b/CppSamples/Scenes/Symbols/Symbols.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.pro
+++ b/CppSamples/Scenes/SyncMapViewSceneView/SyncMapViewSceneView.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = SyncMapViewSceneView

--- a/CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.pro
+++ b/CppSamples/Scenes/TerrainExaggeration/TerrainExaggeration.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = TerrainExaggeration

--- a/CppSamples/Scenes/ViewContentBeneathTerrainSurface/ViewContentBeneathTerrainSurface.pro
+++ b/CppSamples/Scenes/ViewContentBeneathTerrainSurface/ViewContentBeneathTerrainSurface.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ViewContentBeneathTerrainSurface

--- a/CppSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.pro
+++ b/CppSamples/Scenes/ViewPointCloudDataOffline/ViewPointCloudDataOffline.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ViewPointCloudDataOffline

--- a/CppSamples/Search/FindAddress/FindAddress.pro
+++ b/CppSamples/Search/FindAddress/FindAddress.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Search/FindPlace/FindPlace.pro
+++ b/CppSamples/Search/FindPlace/FindPlace.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = FindPlace

--- a/CppSamples/Search/OfflineGeocode/OfflineGeocode.pro
+++ b/CppSamples/Search/OfflineGeocode/OfflineGeocode.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.pro
+++ b/CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ReverseGeocodeOnline

--- a/CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
+++ b/CppSamples/Search/SearchDictionarySymbolStyle/SearchDictionarySymbolStyle.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.pro
+++ b/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ConfigureSubnetworkTrace

--- a/CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.pro
+++ b/CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = CreateLoadReport

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.pro
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayContentOfUtilityNetworkContainer

--- a/CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.pro
+++ b/CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = DisplayUtilityAssociations

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.pro
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = PerformValveIsolationTrace

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.pro
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = TraceUtilityNetwork

--- a/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.pro
+++ b/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick
+QT += qml quick
 
 TEMPLATE = app
 TARGET = ValidateUtilityNetworkTopology

--- a/CppWidgetsSamples/DisplayInformation/BuildLegend/BuildLegend.pro
+++ b/CppWidgetsSamples/DisplayInformation/BuildLegend/BuildLegend.pro
@@ -22,7 +22,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 TEMPLATE = app
 TARGET = BuildLegend

--- a/CppWidgetsSamples/DisplayInformation/GORenderers/GORenderers.pro
+++ b/CppWidgetsSamples/DisplayInformation/GORenderers/GORenderers.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/DisplayInformation/GOSymbols/GOSymbols.pro
+++ b/CppWidgetsSamples/DisplayInformation/GOSymbols/GOSymbols.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
+++ b/CppWidgetsSamples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/ChangeBasemap/ChangeBasemap.pro
+++ b/CppWidgetsSamples/Maps/ChangeBasemap/ChangeBasemap.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
+++ b/CppWidgetsSamples/Maps/ChangeViewpoint/ChangeViewpoint.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/DisplayMap/DisplayMap.pro
+++ b/CppWidgetsSamples/Maps/DisplayMap/DisplayMap.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/ManageBookmarks/ManageBookmarks.pro
+++ b/CppWidgetsSamples/Maps/ManageBookmarks/ManageBookmarks.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/MapLoaded/MapLoaded.pro
+++ b/CppWidgetsSamples/Maps/MapLoaded/MapLoaded.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/MapRotation/MapRotation.pro
+++ b/CppWidgetsSamples/Maps/MapRotation/MapRotation.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/OpenExistingMap/OpenExistingMap.pro
+++ b/CppWidgetsSamples/Maps/OpenExistingMap/OpenExistingMap.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
+++ b/CppWidgetsSamples/Maps/SetInitialMapArea/SetInitialMapArea.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
+++ b/CppWidgetsSamples/Maps/SetInitialMapLocation/SetInitialMapLocation.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
+++ b/CppWidgetsSamples/Maps/SetMapSpatialReference/SetMapSpatialReference.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/CppWidgetsSamples/Scenes/BasicSceneView/BasicSceneView.pro
+++ b/CppWidgetsSamples/Scenes/BasicSceneView/BasicSceneView.pro
@@ -20,7 +20,7 @@ mac {
 CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl widgets
+QT += widgets
 
 ARCGIS_RUNTIME_VERSION = 300.0.0
 include($$PWD/arcgisruntime.pri)

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -19,7 +19,7 @@
 
 TEMPLATE = app
 QT += core gui xml network qml quick positioning sensors multimedia
-QT += widgets quickcontrols2 opengl webview websockets texttospeech
+QT += widgets quickcontrols2 webview websockets texttospeech
 android|ios: QT += bluetooth
 TARGET = ArcGISQt_Samples
 DEFINES += Qt_Version=\"$$QT_VERSION\"


### PR DESCRIPTION
# Description

Remove the opengl module from all standalone .pro files and the SampleViewer .pro file. The opengl module is already pulled in through our SDK internally, and so we don't need to declare it again in these samples. 

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [x] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
