### PR TITLE
include map types in widget sample templates

### DIFF
--- a/Templates/CppSampleTemplate/sample.cpp.tmpl
+++ b/Templates/CppSampleTemplate/sample.cpp.tmpl
@@ -27,15 +27,14 @@
 @if %{ThreeDSample}
 #include "ArcGISTiledElevationSource.h"
 #include "ElevationSourceListModel.h"
-#include "MapTypes.h"
 #include "Scene.h"
 #include "SceneQuickView.h"
 #include "Surface.h"
 @else
 #include "Map.h"
 #include "MapQuickView.h"
-#include "MapTypes.h"
 @endif
+#include "MapTypes.h"
 
 using namespace Esri::ArcGISRuntime;
 

--- a/Templates/CppWidgetsSampleTemplate/sample.cpp.tmpl
+++ b/Templates/CppWidgetsSampleTemplate/sample.cpp.tmpl
@@ -28,6 +28,7 @@
 #include "Map.h"
 #include "MapGraphicsView.h"
 @endif
+#include "MapTypes.h"
 
 #include <QVBoxLayout>
 


### PR DESCRIPTION
# Description

Include the MapTypes include for our widget sample template, and move the MapTypes include out of the if else block in our quick sample template

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
