### PR TITLE
EditGeodatabaseWithTransactions - Fixed color for text when hovered.

### DIFF
--- a/CppSamples/EditData/EditGeodatabaseWithTransactions/EditGeodatabaseWithTransactions.qml
+++ b/CppSamples/EditData/EditGeodatabaseWithTransactions/EditGeodatabaseWithTransactions.qml
@@ -169,6 +169,7 @@ Item {
                 }
 
                 delegate: ItemDelegate {
+                    id: featureTableItem
                     width: tableSelectionList.width
                     implicitHeight: 32
 
@@ -181,7 +182,7 @@ Item {
                         Label {
                             anchors.centerIn: parent
                             text: modelData
-                            color: gdbModel.selectedTableName === modelData ? "#F8F8F8" : palette.text
+                            color: (gdbModel.selectedTableName === modelData || featureTableItem.hovered) ? "#F8F8F8" : palette.text
                         }
                     }
 
@@ -230,6 +231,7 @@ Item {
                 }
 
                 delegate: ItemDelegate {
+                    id: featureTypeItem
                     width: featureTypeList.width
                     implicitHeight: 32
 
@@ -242,7 +244,7 @@ Item {
                         Label {
                             anchors.centerIn: parent
                             text: modelData
-                            color: featureTypeList.currentIndex === index ? "#F8F8F8" : palette.text
+                            color: (featureTypeList.currentIndex === index || featureTypeItem.hovered)? "#F8F8F8" : palette.text
                         }
                     }
 


### PR DESCRIPTION
# Description
EditGeodatabaseWithTransactions sample New Feature menu - updated text contrast on hover to match selected text. This fixes black text on purple highlight in light mode.
<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
