### PR TITLE
8835-duplicate-toc

### DIFF
--- a/CppSamples/EditData/CreateKmlMultiTrack/README.metadata.json
+++ b/CppSamples/EditData/CreateKmlMultiTrack/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "EditData",
+    "category": "Edit data",
     "description": "Create, save and preview a KML multi-track, captured from a location data source.",
     "featured": true,
     "ignore": false,


### PR DESCRIPTION
# Description
There were 2 category TOC entries: **Edit data** and **EditData** appearing in the Qt samples TOC.
This fix edited the **README.metadata.json** file for the **CreateKmlMultiTrack** sample to use the **Edit data** TOC category.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/15ea3a95-ed76-4961-b34f-c67d716358a0" />

## Type of change
- [x] Bug fix on page: https://developers.arcgis.com/qt/cpp/sample-code/


