### PR TITLE
Reorder arguments for Scene c'tors with SceneViewingMode

### DIFF
--- a/CppSamples/Layers/AddBuildingSceneLayer/AddBuildingSceneLayer.cpp
+++ b/CppSamples/Layers/AddBuildingSceneLayer/AddBuildingSceneLayer.cpp
@@ -43,7 +43,7 @@ using namespace Esri::ArcGISRuntime;
 
 AddBuildingSceneLayer::AddBuildingSceneLayer(QObject* parent /* = nullptr */) :
   QObject(parent),
-  m_scene(new Scene(BasemapStyle::ArcGISTopographic, SceneViewingMode::Local, this))
+  m_scene(new Scene(SceneViewingMode::Local, BasemapStyle::ArcGISTopographic, this))
 {
   // create a new elevation source from Terrain3D REST service
   ArcGISTiledElevationSource* elevationSource =

--- a/CppSamples/Layers/AddBuildingSceneLayer/README.md
+++ b/CppSamples/Layers/AddBuildingSceneLayer/README.md
@@ -14,7 +14,7 @@ When loaded, the sample displays a scene with a Building Scene Layer. By default
 
 ## How it works
 
-1. Create a local scene object with the `Scene(BasemapStyle::ArcGISTopographic, SceneViewingMode::Local)` constructor.
+1. Create a local scene object with the `Scene(SceneViewingMode::Local, BasemapStyle::ArcGISTopographic)` constructor.
 2. Create an `ArcGISTiledElevationSource` object and add it to the local scene's base surface.
 3. Create a `BuildingSceneLayer` and add it to the local scene's operational layers.
 4. Create a `LocalSceneView` object to display the scene.

--- a/CppSamples/Scenes/DisplayLocalSceneView/DisplayLocalSceneView.cpp
+++ b/CppSamples/Scenes/DisplayLocalSceneView/DisplayLocalSceneView.cpp
@@ -41,7 +41,7 @@ using namespace Esri::ArcGISRuntime;
 
 DisplayLocalSceneView::DisplayLocalSceneView(QObject* parent /* = nullptr */) :
   QObject(parent),
-  m_scene(new Scene(BasemapStyle::ArcGISTopographic, SceneViewingMode::Local, this))
+  m_scene(new Scene(SceneViewingMode::Local, BasemapStyle::ArcGISTopographic, this))
 {
   // create a new elevation source from Terrain3D REST service
   ArcGISTiledElevationSource* elevationSource =

--- a/CppSamples/Scenes/DisplayLocalSceneView/README.md
+++ b/CppSamples/Scenes/DisplayLocalSceneView/README.md
@@ -18,7 +18,7 @@ This sample displays a local scene clipped to an extent. Pan and zoom to explore
 
 ## How it works
 
-1. Create a local scene object with the `Scene(BasemapStyle::ArcGISTopographic, SceneViewingMode::Local)` constructor.
+1. Create a local scene object with the `Scene(SceneViewingMode::Local, BasemapStyle::ArcGISTopographic)` constructor.
 2. Create an `ArcGISTiledElevationSource` object and add it to the local scene's base surface.
 3. Create an `ArcGISSceneLayer` and add it to the local scene's operational layers.
 4. Create an `Envelope` and set it to the `Scene::setClippingArea`, then enable clipping by setting `Scene::setClippingEnabled` to `true`.

--- a/Templates/CppSampleTemplate/sample.cpp.tmpl
+++ b/Templates/CppSampleTemplate/sample.cpp.tmpl
@@ -38,7 +38,7 @@ using namespace Esri::ArcGISRuntime;
 %{SampleName}::%{SampleName}(QObject* parent /* = nullptr */):
   QObject(parent),
   @if %{ThreeDSample}
-    m_scene(new Scene(BasemapStyle::ArcGISTopographic, %{JS: ( '%{GeoViewType}' === 'globalScene' ? 'SceneViewingMode::Global' : 'SceneViewingMode::Local' )}, this))
+    m_scene(new Scene(%{JS: ( '%{GeoViewType}' === 'globalScene' ? 'SceneViewingMode::Global' : 'SceneViewingMode::Local' )}, BasemapStyle::ArcGISTopographic, this))
   @else
     m_map(new Map(BasemapStyle::ArcGISTopographic, this))
   @endif


### PR DESCRIPTION
# Description

The order of arguments in Scene constructors that take a SceneViewingMode is being revised. That will affect the "Add Building Scene Layer" and "Display Local Scene View" samples, as well as the Sample Template.

| Old | New |
| -- | -- |
| `Scene::Scene(Basemap* basemap, SceneViewingMode viewingMode, QObject* parent)` | `Scene::Scene(SceneViewingMode viewingMode, Basemap* basemap, QObject* parent)` |
| `Scene::Scene(BasemapStyle basemapStyle, SceneViewingMode viewingMode, QObject* parent)` | `Scene::Scene(SceneViewingMode viewingMode, BasemapStyle basemapStyle, QObject* parent)` |

## Type of change

- [X] Other enhancement

**Platforms tested on**:

- [X] Windows
