### PR TITLE
Add LocalSceneView support to the new widget sample template

### DIFF
--- a/Templates/CppWidgetsSampleTemplate/sample.cpp.tmpl
+++ b/Templates/CppWidgetsSampleTemplate/sample.cpp.tmpl
@@ -22,14 +22,19 @@
 @endif
 @if %{ThreeDSample}
 #include "ArcGISTiledElevationSource.h"
+#include "ElevationSourceListModel.h"
 #include "Scene.h"
-#include "SceneGraphicsView.h"
+#include "Surface.h"
+#include %{JS: ( '%{GeoViewType}' === 'globalScene' ? '"SceneGraphicsView.h"' : '"LocalSceneWidget.h"' )}
 @else
 #include "Map.h"
 #include "MapGraphicsView.h"
 @endif
 #include "MapTypes.h"
 
+@if %{UseFeatureLayer} || %{ThreeDSample}
+#include <QUrl>
+@endif
 #include <QVBoxLayout>
 
 using namespace Esri::ArcGISRuntime;
@@ -48,7 +53,7 @@ using namespace Esri::ArcGISRuntime;
   m_scene->baseSurface()->elevationSources()->append(elevationSource);
 
   // Create a scene view, and pass in the scene
-  m_sceneView = new SceneGraphicsView(m_scene, this);
+  m_sceneView = new %{JS: ( '%{GeoViewType}' === 'globalScene' ? 'SceneGraphicsView' : 'LocalSceneWidget' )}(m_scene, this);
 
 @else
   // Create a map using the topo basemap
@@ -78,7 +83,7 @@ using namespace Esri::ArcGISRuntime;
     m_scene->baseSurface()->elevationSources()->append(elevationSource);
 
     // Create a scene view, and pass in the scene
-    m_sceneView = new SceneGraphicsView(m_scene, this);
+    m_sceneView = new %{JS: ( '%{GeoViewType}' === 'globalScene' ? 'SceneGraphicsView' : 'LocalSceneWidget' )}(m_scene, this);
 
   @else
     // Create a map using the imagery basemap
@@ -109,7 +114,7 @@ void %{SampleName}::createUi()
 @if %{ThreeDSample}
   vBoxLayout->addWidget(m_sceneView);
 @else
-    vBoxLayout->addWidget(m_mapView);
+  vBoxLayout->addWidget(m_mapView);
 @endif
   setLayout(vBoxLayout);
 }

--- a/Templates/CppWidgetsSampleTemplate/sample.h.tmpl
+++ b/Templates/CppWidgetsSampleTemplate/sample.h.tmpl
@@ -1,4 +1,4 @@
-// [WriteFile Name=GORenderers, Category=DisplayInformation]
+// [WriteFile Name=%{SampleName}, Category=%{SampleCategory}]
 // [Legal]
 // Copyright %{CurrentYear} Esri.
 //
@@ -26,7 +26,7 @@ namespace Esri::ArcGISRuntime
 @endif
 @if %{ThreeDSample}
   class Scene;
-  class SceneGraphicsView;
+  class %{JS: ( '%{GeoViewType}' === 'globalScene' ? 'SceneGraphicsView' : 'LocalSceneWidget' )};
 @else
   class Map;
   class MapGraphicsView;
@@ -48,7 +48,7 @@ private:
 
 @if %{ThreeDSample}
   Esri::ArcGISRuntime::Scene* m_scene = nullptr;
-  Esri::ArcGISRuntime::SceneGraphicsView* m_sceneView = nullptr;
+  Esri::ArcGISRuntime::%{JS: ( '%{GeoViewType}' === 'globalScene' ? 'SceneGraphicsView' : 'LocalSceneWidget' )}* m_sceneView = nullptr;
 @else
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapGraphicsView* m_mapView = nullptr;

--- a/Templates/CppWidgetsSampleTemplate/wizard.json
+++ b/Templates/CppWidgetsSampleTemplate/wizard.json
@@ -19,12 +19,11 @@
     { "key": "QtQuickVersion", "value": "%{JS: %{QtVersion}.qtQuickVersion}" },
     { "key": "QtQuickWindowVersion", "value": "%{JS: %{QtVersion}.qtQuickWindowVersion}" },
     { "key": "QtQuickFeature", "value": "QtSupport.Wizards.FeatureQtQuick.%{QtQuickVersion}" },
-    { "key": "DisplayName", "value": "%{JS: Cpp.className('%{DispName}')}" },
+    { "key": "DisplayName", "value": "%{DisplayName}" },
     { "key": "SampleName", "value": "%{JS: '%{Class}'.charAt(0).toUpperCase() + '%{Class}'.substring(1)}" },
     { "key": "SampleDescription", "value": "%{SampleDesc}" },
     { "key": "SampleCategory", "value": "%{SampleCat}" },
     { "key": "IncludeGuard", "value": "%{JS: Cpp.headerGuard('%{Class}' + '_H')}" },
-    { "key": "ThreeDSample", "value": "%{threeD}" },
     { "key": "UseFeatureLayer", "value": "%{JS: ( '%{FeatureLayerURL}'.length === 0 ) ? 'false' : 'true'}" },
     { "key": "UseAPIKey", "value": "%{apiKey}" },
     { "key": "CurrentYear", "value": "%{JS: new Date().getFullYear()}" }
@@ -96,7 +95,7 @@
           }
         },
         {
-          "name": "DispName",
+          "name": "DisplayName",
           "trDisplayName": "Display Name:",
           "mandatory": true,
           "type": "LineEdit",
@@ -120,10 +119,39 @@
           }
         },
         {
-          "name": "threeD",
-          "trDisplayName": "3-D sample",
+          "name": "GeoViewType",
+          "trDisplayName": "GeoView type:",
+          "type": "ComboBox",
+          "trToolTip": "%{JS: ( '%{GeoViewType}' === 'map' ) ? 'A two-dimensional map' : ( '%{GeoViewType}' === 'globalScene') ? 'A three-dimensional scene on a globe' : 'A three-dimensional scene on a projected plane' }",
+          "data":
+          {
+            "index": 0,
+            "items":
+            [
+              {
+                "trKey": "2D Map",
+                "value": "map"
+              },
+              {
+                "trKey": "Global 3D Scene",
+                "value": "globalScene"
+              },
+              {
+                "trKey": "Local 3D Scene",
+                "value": "localScene"
+              }
+            ]
+          }
+        },
+        {
+          "name": "ThreeDSample",
+          "trDisplayName": "3D project",
           "type": "CheckBox",
-          "data":{"checked": false}
+          "visible": false,
+          "data":
+          {
+            "checked": "%{JS: ( '%{GeoViewType}' !== 'map' ) ? 'yes' : ''}"
+          }
         },
         {
           "name": "FeatureLayerURL",


### PR DESCRIPTION
Add LocalSceneView support to our widgets sample template.

The template logic for widgets had fallen out of date. I fixed a few minor, unrelated issues so the generated code will compile.