### PR TITLE
Additional changes

### DIFF
--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
@@ -98,7 +98,7 @@ void DistanceMeasurementAnalysis::setSceneView(SceneQuickView* sceneView)
   AnalysisOverlay* analysisOverlay = new AnalysisOverlay(this);
   m_sceneView->analysisOverlays()->append(analysisOverlay);
 
-  // Create and add the LocationDistanceMeasurement
+  // Create and add the ExploratoryLocationDistanceMeasurement
   const Point startLocation(-4.494677, 48.384472, 24.772694, SpatialReference::wgs84());
   const Point endLocation(-4.495646, 48.384377, 58.501115, SpatialReference::wgs84());
   m_distanceAnalysis = new ExploratoryLocationDistanceMeasurement(startLocation, endLocation, this);

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/README.md
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/README.md
@@ -27,7 +27,7 @@ Choose a unit system for the measurement. Click any location in the scene to sta
 
 ## Additional information
 
-The `LocationDistanceMeasurement` analysis only performs planar distance calculations. This may not be appropriate for large distances where the Earth's curvature must be considered.
+The `ExploratoryLocationDistanceMeasurement` analysis only performs planar distance calculations. This may not be appropriate for large distances where the Earth's curvature must be considered.
 
 ## Tags
 

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/README.metadata.json
@@ -12,7 +12,7 @@
         "distance",
         "measure",
         "AnalysisOverlay",
-        "LocationDistanceMeasurement",
+        "ExploratoryLocationDistanceMeasurement",
         "MeasurementChanged"
     ],
     "redirect_from": [

--- a/CppSamples/Analysis/LineOfSightGeoElement/README.md
+++ b/CppSamples/Analysis/LineOfSightGeoElement/README.md
@@ -26,8 +26,8 @@ The taxi will be highlighted when it is visible. You can change the observer hei
 ## Relevant API
 
 * AnalysisOverlay
-* GeoElementLineOfSight
-* LineOfSight::targetVisibility
+* ExploratoryGeoElementLineOfSight
+* LineOfSightTargetVisibility
 
 ## Offline data
 

--- a/CppSamples/Analysis/LineOfSightGeoElement/README.metadata.json
+++ b/CppSamples/Analysis/LineOfSightGeoElement/README.metadata.json
@@ -18,16 +18,16 @@
         "visibility",
         "visibility analysis",
         "AnalysisOverlay",
-        "GeoElementLineOfSight",
-        "LineOfSight::targetVisibility"
+        "ExploratoryGeoElementLineOfSight",
+        "LineOfSightTargetVisibility"
     ],
     "redirect_from": [
         "/qt/latest/cpp/sample-code/sample-qt-lineofsightgeoelement.htm"
     ],
     "relevant_apis": [
         "AnalysisOverlay",
-        "GeoElementLineOfSight",
-        "LineOfSight::targetVisibility"
+        "ExploratoryGeoElementLineOfSight",
+        "LineOfSightTargetVisibility"
     ],
     "snippets": [
         "LineOfSightGeoElement.cpp",

--- a/CppSamples/Analysis/LineOfSightLocation/README.md
+++ b/CppSamples/Analysis/LineOfSightLocation/README.md
@@ -17,14 +17,14 @@ Click and hold to turn on the mouse moved signal, then move the mouse to update 
 ## How it works
 
 1. Create an `AnalysisOverlay` and add it to the scene view.
-2. Create a `LocationLineOfSight` with initial observer and target locations and add it to the analysis overlay.
+2. Create an `ExploratoryLocationLineOfSight` with initial observer and target locations and add it to the analysis overlay.
 3. Connect to the `SceneQuickView::mouseClicked` slot to capture to capture mouse movement. Turn the screen point into a scene point with `sceneView::screenToLocation(screenPoint)`.
-4. Update the target location with `LineOfSight::setTargetLocation(scenePoint)`.
+4. Update the target location with `ExploratoryLocationLineOfSight::setTargetLocation(scenePoint)`.
 
 ## Relevant API
 
 * AnalysisOverlay
-* LocationLineOfSight
+* ExploratoryLocationLineOfSight
 * SceneView
 
 ## Tags

--- a/CppSamples/Analysis/LineOfSightLocation/README.metadata.json
+++ b/CppSamples/Analysis/LineOfSightLocation/README.metadata.json
@@ -12,7 +12,7 @@
         "visibility",
         "visibility analysis",
         "AnalysisOverlay",
-        "LocationLineOfSight",
+        "ExploratoryLocationLineOfSight",
         "SceneView"
     ],
     "redirect_from": [
@@ -20,7 +20,7 @@
     ],
     "relevant_apis": [
         "AnalysisOverlay",
-        "LocationLineOfSight",
+        "ExploratoryLocationLineOfSight",
         "SceneView"
     ],
     "snippets": [

--- a/CppSamples/Analysis/ViewshedCamera/README.md
+++ b/CppSamples/Analysis/ViewshedCamera/README.md
@@ -15,7 +15,7 @@ The sample will start with a viewshed created from the initial camera location, 
 ## How it works
 
 1. Get the current camera from the scene with `SceneView::currentViewpointCamera`.
-2. Create a `LocationViewshed`, passing in the `Camera` and a min/max distance.
+2. Create an `ExploratoryLocationViewshed`, passing in the `Camera` and a min/max distance.
 3. Update the viewshed from a camera.
 
 ## Relevant API
@@ -24,8 +24,8 @@ The sample will start with a viewshed created from the initial camera location, 
 * ArcGISScene
 * ArcGISTiledElevationSource
 * Camera
+* ExploratoryLocationViewshed
 * IntegratedMeshLayer
-* LocationViewshed
 * SceneView
 
 ## About the data

--- a/CppSamples/Analysis/ViewshedCamera/README.metadata.json
+++ b/CppSamples/Analysis/ViewshedCamera/README.metadata.json
@@ -16,8 +16,8 @@
         "ArcGISScene",
         "ArcGISTiledElevationSource",
         "Camera",
+        "ExploratoryLocationViewshed",
         "IntegratedMeshLayer",
-        "LocationViewshed",
         "SceneView"
     ],
     "redirect_from": [
@@ -28,8 +28,8 @@
         "ArcGISScene",
         "ArcGISTiledElevationSource",
         "Camera",
+        "ExploratoryLocationViewshed",
         "IntegratedMeshLayer",
-        "LocationViewshed",
         "SceneView"
     ],
     "snippets": [

--- a/CppSamples/Analysis/ViewshedLocation/README.md
+++ b/CppSamples/Analysis/ViewshedLocation/README.md
@@ -23,7 +23,6 @@ Use the sliders to change the properties (heading, pitch, etc.), of the viewshed
 * ArcGISSceneLayer
 * ArcGISTiledElevationSource
 * ExploratoryLocationViewshed
-* Viewshed
 
 ## About the data
 

--- a/CppSamples/Analysis/ViewshedLocation/README.metadata.json
+++ b/CppSamples/Analysis/ViewshedLocation/README.metadata.json
@@ -15,8 +15,7 @@
         "AnalysisOverlay",
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
-        "ExploratoryLocationViewshed",
-        "Viewshed"
+        "ExploratoryLocationViewshed"
     ],
     "redirect_from": [
         "/qt/latest/cpp/sample-code/sample-qt-viewshedlocation.htm"
@@ -25,8 +24,7 @@
         "AnalysisOverlay",
         "ArcGISSceneLayer",
         "ArcGISTiledElevationSource",
-        "ExploratoryLocationViewshed",
-        "Viewshed"
+        "ExploratoryLocationViewshed"
     ],
     "snippets": [
         "ViewshedLocation.cpp",


### PR DESCRIPTION
# Description

Suggests additional places where we may need to update the API names. I'm opening this PR against https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/1954 so we can evaluate if these cases are also needed.

I removed any mentions of the `Viewshed` API in the ViewshedLocation sample because we don't actually use that API in that sample.

Also `LineOfSightTargetVisibility` shouldn't be `LineOfSight::targetVisibility` because it's its own Class

```cpp
    connect(lineOfSight, &ExploratoryGeoElementLineOfSight::targetVisibilityChanged, this, [this](LineOfSightTargetVisibility targetVisibility)
    {
      // Select taxi whenever there is a clear line of sight from observer position.
      m_taxi->setSelected(targetVisibility == LineOfSightTargetVisibility::Visible);
    });
```