### PR TITLE
Cancel challenges as well when switching samples.

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -51,6 +51,7 @@
 #include "ArcGISQt_global.h" // for LOCALSERVER_SUPPORTED
 
 // toolkit authentication support
+#include "AuthenticatorController.h"
 #include "OAuthUserConfigurationManager.h"
 
 #include "ZipHelper.h"
@@ -500,6 +501,11 @@ void SampleManager::resetAuthenticationState()
   {
     // when sample changes, restore the original toolkit challenge handler
     ArcGISRuntimeEnvironment::authenticationManager()->setArcGISAuthenticationChallengeHandler(m_toolkitChallengeHandler);
+  }
+
+  if (auto* authController = Toolkit::AuthenticatorController::instance(); authController)
+  {
+    authController->cancelOutstandingChallenges();
   }
 }
 


### PR DESCRIPTION
# Description

We need to cancel challenges when we switch samples, because unhandled challenges remain in the queue indefinitely and prevent new challenges from being presented to users.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
