### PR TITLE
Export tiles sample - Hide button after exporting tiles.

### DIFF
--- a/CppSamples/Layers/ExportTiles/ExportTiles.qml
+++ b/CppSamples/Layers/ExportTiles/ExportTiles.qml
@@ -48,6 +48,7 @@ ExportTilesSample {
             text: qsTr("Export tiles")
             leftPadding: 20
             rightPadding: 20
+            hoverEnabled: !exportWindow.visible
             icon {
                 source: "qrc:/Samples/Layers/ExportTiles/download-24.svg"
                 width: 24
@@ -68,7 +69,7 @@ ExportTilesSample {
 
                       if (success) {
                           extentRectangle.visible = false;
-                          downloadButton.visible = false;
+                          exportTilesButton.visible = false;
                       }
                   }
 


### PR DESCRIPTION
# Description
- Layers->Export tiles sample -> hide export button after exporting tiles.
- disable hover when export is in progress.
<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
