### PR TITLE
Layers/AddBuildingSceneLayerSample - Update to check modelName

### DIFF
--- a/CppSamples/Layers/AddBuildingSceneLayer/AddBuildingSceneLayer.cpp
+++ b/CppSamples/Layers/AddBuildingSceneLayer/AddBuildingSceneLayer.cpp
@@ -107,11 +107,11 @@ void AddBuildingSceneLayer::setLocalSceneView(LocalSceneQuickView* localSceneVie
     // Get the overview and full model sublayers.
     for (BuildingSublayer* sublayer : (*m_buildingSceneLayer->sublayers()))
     {
-      if (sublayer->name() == "Overview")
+      if (sublayer->modelName() == "Overview")
       {
         m_overviewSublayer = sublayer;
       }
-      else if (sublayer->name() == "Full Model")
+      else if (sublayer->modelName() == "FullModel")
       {
         m_fullModelSublayer = sublayer;
       }


### PR DESCRIPTION
# Description
Layers/AddBuildingSceneLayerSample - update to check modelName instead of name.

Reasoning:
Through some research, it was found that the names for the main sublayers of Building Scene Layers, the name field "Overview" and "Full Model", are not always in English. It would be more universally applicable to utilize the modelName field which is always in English. 


<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
