### PR TITLE
Remove <uses-sdk> tag from all AndroidManifest.xml

### DIFF
--- a/SampleViewer/android/AndroidManifest.xml
+++ b/SampleViewer/android/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <manifest package="com.esri.arcgisruntime.ArcGISRuntimeSDKQt_Samples" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="-- %%INSERT_VERSION_NAME%% --" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="28" android:targetSdkVersion="28"/>
 
     <!-- %%INSERT_PERMISSIONS -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>


### PR DESCRIPTION
# Description

Removed <uses-sdk> tag from all AndroidManifest.xml.
Verified on Qt6.11.0 and Qt6.10.0.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
