### PR TITLE
Fix: Andriod  - back button closes app

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -51,6 +51,12 @@
 // Other headers
 #include "ArcGISQt_global.h" // for LOCALSERVER_SUPPORTED
 
+// Platform specific headers
+#ifdef Q_OS_ANDROID
+#include <QJniObject>
+#include <QCoreApplication>
+#endif
+
 // toolkit authentication support
 #include "AuthenticatorController.h"
 #include "OAuthUserConfigurationManager.h"
@@ -536,6 +542,14 @@ void SampleManager::resetAuthenticationState()
   {
     authController->cancelOutstandingChallenges();
   }
+}
+
+void SampleManager::moveToBackgroundAndroid()
+{
+#ifdef Q_OS_ANDROID
+  QJniObject activity = QJniObject::callStaticObjectMethod("org/qtproject/qt/android/QtNative", "activity", "()Landroid/app/Activity;");
+  activity.callMethod<jboolean>("moveTaskToBack", true);
+#endif
 }
 
 bool SampleManager::dataItemsExists()

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -33,6 +33,7 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QKeyEvent>
 #include <QNetworkProxy>
 #include <QQmlEngine>
 #include <QSet>
@@ -176,6 +177,21 @@ DownloadsManager* SampleManager::downloadsManager() const
 
 void SampleManager::init()
 {
+  // Install event filter so SampleManager::eventFilter() runs
+  connect(qApp, &QGuiApplication::focusWindowChanged, this, [this](QWindow* window)
+  {
+    if (window)
+    {
+      window->installEventFilter(this);
+    }
+  });
+
+  // If window is already focused
+  if (QWindow* window = qApp->focusWindow())
+  {
+    window->installEventFilter(this);
+  }
+
   m_featuredSamples = new SampleListModel(this);
   m_offlineDataSamples = new SampleListModel(this);
 
@@ -298,6 +314,19 @@ bool SampleManager::appendCategoryToManager(SampleCategory* category)
   }
 
   return false;
+}
+
+bool SampleManager::eventFilter(QObject* obj, QEvent* event)
+{
+  if (event->type() == QEvent::KeyRelease)
+  {
+    if (static_cast<QKeyEvent*>(event)->key() == Qt::Key_Back)
+    {
+      emit backPressed();
+      return true;
+    }
+  }
+  return QObject::eventFilter(obj, event);
 }
 
 // Build the Samples List

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -142,11 +142,14 @@ signals:
   void currentSourceCodeChanged();
   void reachabilityChanged();
   void favoriteSamplesChanged();
+  void backPressed();
 
 protected:
   void buildCategoriesList();
   SampleCategory* createCategory(const QString& name, const QString& displayName, const QDir& dir);
   bool appendCategoryToManager(SampleCategory* category);
+
+  bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
   SampleListModel* buildSamplesList(const QDir& dir, const QString& prefix);

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -105,6 +105,7 @@ public:
   Q_INVOKABLE void setupProxy(const QString& hostName, quint16 port, const QString& user, const QString& pw);
   Q_INVOKABLE void setApiKey(bool isSupportsApiKey = true);
   Q_INVOKABLE void resetAuthenticationState();
+  Q_INVOKABLE void moveToBackgroundAndroid();
 
   // Favorites
   Q_INVOKABLE void addSampleToFavorites(Sample* sample);

--- a/SampleViewer/android/AndroidManifest.xml
+++ b/SampleViewer/android/AndroidManifest.xml
@@ -19,7 +19,7 @@
 
     <!-- %%INSERT_FEATURES -->
     <supports-screens android:anyDensity="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
-    <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:extractNativeLibs="true" android:hardwareAccelerated="true" android:label="Qt Samples" android:allowBackup="true" android:allowNativeHeapPointerTagging="false" android:fullBackupOnly="false" android:icon="@drawable/icon">
+    <application android:name="org.qtproject.qt.android.bindings.QtApplication" android:extractNativeLibs="true" android:hardwareAccelerated="true" android:label="Qt Samples" android:allowBackup="true" android:allowNativeHeapPointerTagging="false" android:fullBackupOnly="false" android:icon="@drawable/icon" android:enableOnBackInvokedCallback="false">
         <activity android:name="org.qtproject.qt.android.bindings.QtActivity" android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:label="Qt Samples" android:launchMode="singleTop" android:screenOrientation="unspecified" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -406,6 +406,8 @@ ApplicationWindow {
         }
 
         function onCurrentSampleChanged() {
+            // Clear stale mode history from previous sample
+            backStack = backStack.filter(entry => !entry.tag.startsWith("mode_"));
             // If we're in ManageOfflineData view and a download is in progress,
             // cancel all downloads and wait for completion before changing samples
             if (SampleManager.currentMode === SampleManager.ManageOfflineDataView &&

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -39,6 +39,26 @@ ApplicationWindow {
     readonly property string os: Qt.platform.os
     readonly property string fontFamily: "Helvetica"
 
+
+    // Back navigation stack
+    property var backStack: []
+
+    function pushBack(tag, action) {
+        backStack.push({ tag: tag, action: action });
+    }
+
+    function removeBack(tag) {
+        backStack = backStack.filter(entry => entry.tag !== tag);
+    }
+
+    function popBack() {
+        if (backStack.length > 0) {
+            backStack.pop().action();
+        } else {
+            //Qt.quit();
+        }
+    }
+
     header: ToolBar {
         height: 42
 
@@ -167,6 +187,8 @@ ApplicationWindow {
                 x: parent.width - width
                 transformOrigin: Item.TopRight
                 width: 200
+                onOpened: pushBack("optionsMenu", () => optionsMenu.close())
+                onClosed: removeBack("optionsMenu")
 
                 readonly property real menuFontSize: 16
 
@@ -314,6 +336,9 @@ ApplicationWindow {
         id: drawer
         width: 252
         height: parent.height
+        onOpened: pushBack("drawer", () => drawer.close())
+        onClosed: removeBack("drawer")
+
     }
 
     SourceCodeView {
@@ -354,17 +379,29 @@ ApplicationWindow {
     ProxySetupView {
         id: proxySetupView
         anchors.fill: parent
+        onVisibleChanged: {
+            if (visible) pushBack("proxy", () => { proxySetupView.visible = false })
+            else removeBack("proxy")
+        }
     }
 
     AboutView {
         id: aboutView
         anchors.fill: parent
+        onVisibleChanged: {
+            if (visible) pushBack("about", () => { aboutView.visible = false })
+            else removeBack("about")
+        }
     }
 
     Connections {
         target: SampleManager
 
         property var pendingSampleChangeConnection: null
+
+        function onBackPressed() {
+            popBack();
+        }
 
         function onCurrentSampleChanged() {
             // If we're in ManageOfflineData view and a download is in progress,
@@ -431,7 +468,22 @@ ApplicationWindow {
             SampleManager.currentMode = SampleManager.HomepageView;
         }
 
+        property int previousMode: -1
+        property int modeStackId: 0
+        property bool isNavigatingBack: false
+
         function onCurrentModeChanged() {
+            if (!isNavigatingBack && previousMode !== -1 && previousMode !== SampleManager.currentMode) {
+                var restoreMode = previousMode;
+                var tag = "mode_" + modeStackId++;
+                pushBack(tag, () => {
+                    isNavigatingBack = true;
+                    SampleManager.currentMode = restoreMode;
+                    isNavigatingBack = false;
+                });
+            }
+            previousMode = SampleManager.currentMode;
+
             if (SampleManager.currentMode === SampleManager.LiveSampleView)
                 showSample();
         }

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -471,12 +471,19 @@ ApplicationWindow {
         }
 
         property int previousMode: -1
+        property int lastStableMode: -1
         property int modeStackId: 0
         property bool isNavigatingBack: false
 
+        function isTransientMode(mode) {
+            return mode === SampleManager.DownloadDataView;
+        }
+
         function onCurrentModeChanged() {
-            if (!isNavigatingBack && previousMode !== -1 && previousMode !== SampleManager.currentMode) {
-                var restoreMode = previousMode;
+            var current = SampleManager.currentMode;
+
+            if (!isNavigatingBack && !isTransientMode(current) && lastStableMode !== -1 && lastStableMode !== current) {
+                var restoreMode = lastStableMode;
                 var tag = "mode_" + modeStackId++;
                 pushBack(tag, () => {
                              isNavigatingBack = true;
@@ -484,9 +491,13 @@ ApplicationWindow {
                              isNavigatingBack = false;
                          });
             }
-            previousMode = SampleManager.currentMode;
 
-            if (SampleManager.currentMode === SampleManager.LiveSampleView)
+            if (!isTransientMode(current))
+                lastStableMode = current;
+
+            previousMode = current;
+
+            if (current === SampleManager.LiveSampleView)
                 showSample();
         }
     }

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -47,7 +47,7 @@ ApplicationWindow {
         backStack.push({ tag: tag, action: action });
     }
 
-    function removeBack(tag) {
+    function removeEntry(tag) {
         backStack = backStack.filter(entry => entry.tag !== tag);
     }
 
@@ -55,7 +55,9 @@ ApplicationWindow {
         if (backStack.length > 0) {
             backStack.pop().action();
         } else {
-            //Qt.quit();
+            if (Qt.platform.os === "android") {
+                SampleManager.moveToBackgroundAndroid();
+            }
         }
     }
 
@@ -188,7 +190,7 @@ ApplicationWindow {
                 transformOrigin: Item.TopRight
                 width: 200
                 onOpened: pushBack("optionsMenu", () => optionsMenu.close())
-                onClosed: removeBack("optionsMenu")
+                onClosed: removeEntry("optionsMenu")
 
                 readonly property real menuFontSize: 16
 
@@ -337,7 +339,7 @@ ApplicationWindow {
         width: 252
         height: parent.height
         onOpened: pushBack("drawer", () => drawer.close())
-        onClosed: removeBack("drawer")
+        onClosed: removeEntry("drawer")
 
     }
 
@@ -381,7 +383,7 @@ ApplicationWindow {
         anchors.fill: parent
         onVisibleChanged: {
             if (visible) pushBack("proxy", () => { proxySetupView.visible = false })
-            else removeBack("proxy")
+            else removeEntry("proxy")
         }
     }
 
@@ -390,7 +392,7 @@ ApplicationWindow {
         anchors.fill: parent
         onVisibleChanged: {
             if (visible) pushBack("about", () => { aboutView.visible = false })
-            else removeBack("about")
+            else removeEntry("about")
         }
     }
 
@@ -477,10 +479,10 @@ ApplicationWindow {
                 var restoreMode = previousMode;
                 var tag = "mode_" + modeStackId++;
                 pushBack(tag, () => {
-                    isNavigatingBack = true;
-                    SampleManager.currentMode = restoreMode;
-                    isNavigatingBack = false;
-                });
+                             isNavigatingBack = true;
+                             SampleManager.currentMode = restoreMode;
+                             isNavigatingBack = false;
+                         });
             }
             previousMode = SampleManager.currentMode;
 


### PR DESCRIPTION
# Description
This PR fixes the back button closing the app on devices running Android. The Idea  - 
- Maintain a stack with callback functions( Command object pattern). 
- Detect when the back button is pressed and pop from stack.
- Remove stale entries with `removeEntry()`; prevent mode change loops with `isNavigatingBack`

Set `android:enableOnBackInvokedCallback="false"` in the .xml so Qt can get back button events.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
