### PR TITLE
Fix: Android  - back button closes app - Pt2

### DIFF
--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -42,18 +42,26 @@ ApplicationWindow {
 
     // Back navigation stack
     property var backStack: []
+    property bool backHandledByAutoClose: false
 
     function pushBack(tag, action) {
         backStack.push({ tag: tag, action: action });
     }
 
     function removeEntry(tag) {
+        var hadEntry = backStack.some(entry => entry.tag === tag);
         backStack = backStack.filter(entry => entry.tag !== tag);
+        if (hadEntry)
+            backHandledByAutoClose = true;
     }
 
     function popBack() {
         if (backStack.length > 0) {
-            backStack.pop().action();
+            backHandledByAutoClose = false;
+            var entry = backStack.pop();
+            entry.action();
+        } else if (backHandledByAutoClose) {
+            backHandledByAutoClose = false;
         } else {
             if (Qt.platform.os === "android") {
                 SampleManager.moveToBackgroundAndroid();
@@ -418,8 +426,20 @@ ApplicationWindow {
         }
 
         function onCurrentSampleChanged() {
-            // Clear stale mode history from previous sample
-            backStack = backStack.filter(entry => !entry.tag.startsWith("mode_"));
+            const overlayTags = ["drawer", "optionsMenu", "proxy", "about"];
+            backStack = backStack.filter(entry => overlayTags.includes(entry.tag));
+
+            // Back to home when new sample is opened
+            pushBack("homepage", () => {
+                         isNavigatingBack = true;
+                         SampleManager.currentMode = SampleManager.HomepageView;
+                         isNavigatingBack = false;
+                     });
+
+            // Reset state for new sample
+            lastStableMode = -1;
+            modeStackId = 0;
+
             // If we're in ManageOfflineData view and a download is in progress,
             // cancel all downloads and wait for completion before changing samples
             if (SampleManager.currentMode === SampleManager.ManageOfflineDataView &&
@@ -496,7 +516,8 @@ ApplicationWindow {
         function onCurrentModeChanged() {
             var current = SampleManager.currentMode;
 
-            if (!isNavigatingBack && !isTransientMode(current) && lastStableMode !== -1 && lastStableMode !== current) {
+            if (!isNavigatingBack && !isTransientMode(current)
+                    && lastStableMode !== -1 && lastStableMode !== current) {
                 var restoreMode = lastStableMode;
                 var tag = "mode_" + modeStackId++;
                 pushBack(tag, () => {

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -43,6 +43,7 @@ ApplicationWindow {
     // Back navigation stack
     property var backStack: []
     property bool backHandledByAutoClose: false
+    property bool backPressInProgress: false
 
     function pushBack(tag, action) {
         backStack.push({ tag: tag, action: action });
@@ -51,7 +52,7 @@ ApplicationWindow {
     function removeEntry(tag) {
         var hadEntry = backStack.some(entry => entry.tag === tag);
         backStack = backStack.filter(entry => entry.tag !== tag);
-        if (hadEntry)
+        if (hadEntry && backPressInProgress)
             backHandledByAutoClose = true;
     }
 
@@ -422,7 +423,9 @@ ApplicationWindow {
         property var pendingSampleChangeConnection: null
 
         function onBackPressed() {
+            backPressInProgress = true;
             popBack();
+            backPressInProgress = false;
         }
 
         function onCurrentSampleChanged() {

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -42,8 +42,9 @@ ApplicationWindow {
 
     // Back navigation stack
     property var backStack: []
-    property bool backHandledByAutoClose: false
+    property bool controlConsumedBack: false
     property bool backPressInProgress: false
+    readonly property var overlayTags: ["drawer", "optionsMenu", "proxy", "about"]
 
     function pushBack(tag, action) {
         backStack.push({ tag: tag, action: action });
@@ -53,16 +54,16 @@ ApplicationWindow {
         var hadEntry = backStack.some(entry => entry.tag === tag);
         backStack = backStack.filter(entry => entry.tag !== tag);
         if (hadEntry && backPressInProgress)
-            backHandledByAutoClose = true;
+            controlConsumedBack = true;
     }
 
     function popBack() {
         if (backStack.length > 0) {
-            backHandledByAutoClose = false;
+            controlConsumedBack = false;
             var entry = backStack.pop();
             entry.action();
-        } else if (backHandledByAutoClose) {
-            backHandledByAutoClose = false;
+        } else if (controlConsumedBack) {
+            controlConsumedBack = false;
         } else {
             if (Qt.platform.os === "android") {
                 SampleManager.moveToBackgroundAndroid();
@@ -429,7 +430,6 @@ ApplicationWindow {
         }
 
         function onCurrentSampleChanged() {
-            const overlayTags = ["drawer", "optionsMenu", "proxy", "about"];
             backStack = backStack.filter(entry => overlayTags.includes(entry.tag));
 
             // Back to home when new sample is opened


### PR DESCRIPTION
Follow up of https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/1988.

To avoid maintaining states and opening previously opened samples on pressing back. We now clear the stack on opening a new sample. Pressing back will take us to the homepage and we push to the cleared stack with the homepage.

Behavior feels to be in place and nothing unusual.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
