### PR TITLE
ShowPopup: QFuture::isValid() check is not necessary.

### DIFF
--- a/CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
+++ b/CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
@@ -126,11 +126,6 @@ void ShowPopup::onMouseClicked(QMouseEvent& mouseEvent)
     onIdentifyLayerCompleted(QUuid(), result);
   });
 
-  if (!m_future.isValid())
-  {
-    qWarning() << "Future not valid.";
-  }
-
   emit taskRunningChanged();
 }
 


### PR DESCRIPTION
# Description

[QFuture::isValid](https://doc.qt.io/qt-6/qfuture.html#isValid) is a bit misleading, "Returns true if a result or results can be accessed or taken from this [QFuture](https://doc.qt.io/qt-6/qfuture.html) object." . We are checking this too early which is why it's returning false.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
