### PR TITLE
Don't show the MapView item unless it's active.

### DIFF
--- a/CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -50,6 +50,7 @@ CreateAndSaveMapSample {
     MapView {
         id: mapView
         objectName: "mapView"
+        visible: StackView.status === StackView.Active
 
         Component.onCompleted: {
             // Set the focus on MapView to initially enable keyboard navigation


### PR DESCRIPTION
# Description

After some attribution bar refactoring, the MapView's attribution bar started rendering when it wasn't the current stack view item. Looks like that was always an underlying issue with the sample, but it was never exposed because the attribution bar and UI button never appeared before.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

