### PR TITLE
Raster rendering Rule UI - Fix UI still flowing off screen for largest option.

### DIFF
--- a/CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -41,18 +41,22 @@ RasterRenderingRuleSample {
                 top: parent.top
                 margins: 5
             }
-            height: childrenRect.height
-            width: childrenRect.width
+            width: Math.min(controlsLayout.implicitWidth, parent.width - 10)
+            height: controlsLayout.implicitHeight
             color: palette.base
             radius: 5
 
             GridLayout {
+                id: controlsLayout
+                width: parent.width
                 columns: 2
 
                 Label {
                     Layout.margins: 10
                     Layout.columnSpan: 2
+                    Layout.fillWidth: true
                     Layout.alignment: Qt.AlignHCenter
+                    horizontalAlignment: Text.AlignHCenter
                     text: qsTr("Apply a Rendering Rule")
                     font.pixelSize: 16
                 }
@@ -60,19 +64,24 @@ RasterRenderingRuleSample {
                 ComboBox {
                     id: renderingRulesCombo
                     property int modelWidth: 0
-                    Layout.minimumWidth: Math.min(modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10),
-                                                  rootRectangle.width * 0.5)
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                    Layout.preferredWidth: modelWidth + leftPadding + rightPadding +
+                                           (indicator ? indicator.width : 10)
+                    Layout.maximumWidth: rootRectangle.width - applyButton.implicitWidth - 50
                     Layout.margins: 10
                     model: renderingRuleNames
 
                     onModelChanged: {
-                        for (let i = 0; i < model.length; ++i) {
-                            metrics.text = model[i];
-                            modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = 0;
+                        for (let index = 0; index < model.length; ++index) {
+                            optionMetrics.text = model[index];
+                            modelWidth = Math.max(modelWidth, optionMetrics.width);
                         }
                     }
+
                     TextMetrics {
-                        id: metrics
+                        id: optionMetrics
                         font: renderingRulesCombo.font
                     }
                 }


### PR DESCRIPTION
# Description
While the previous fix https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/2002 fixes the UI default state from overflowing. The last option still causes overflow. So this fix prevents overflow by using implicit width.

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
