### PR TITLE
Resize image to fit in description view when window/screen size changes

### DIFF
--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -179,6 +179,7 @@ HEADERS += \
     $$COMMONVIEWER/SearchFilterSimpleKeywordCriteria.h \
     $$COMMONVIEWER/SourceCode.h \
     $$COMMONVIEWER/SourceCodeListModel.h \
+    $$COMMONVIEWER/TextDocumentUtils.h \
     $$COMMONVIEWER/ZipHelper.h \
     $$COMMONVIEWER/TaskCanceler.h \
     SampleDownloadState.h
@@ -200,6 +201,7 @@ SOURCES += \
     $$COMMONVIEWER/SearchFilterSimpleKeywordCriteria.cpp \
     $$COMMONVIEWER/SourceCode.cpp \
     $$COMMONVIEWER/SourceCodeListModel.cpp \
+    $$COMMONVIEWER/TextDocumentUtils.cpp \
     $$COMMONVIEWER/mainSample.cpp \
     $$COMMONVIEWER/ZipHelper.cpp
 

--- a/SampleViewer/TextDocumentUtils.cpp
+++ b/SampleViewer/TextDocumentUtils.cpp
@@ -13,20 +13,7 @@
 // limitations under the License.
 // [Legal]
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// [Legal]
-
-#include "TextDocumentUtils.h"
-
+// Qt headers
 #include <QTextBlock>
 #include <QTextCursor>
 #include <QTextDocument>
@@ -35,6 +22,9 @@
 #include <QTextImageFormat>
 #include <QTextLength>
 #include <QVector>
+
+// Other headers
+#include "TextDocumentUtils.h"
 
 namespace
 {

--- a/SampleViewer/TextDocumentUtils.cpp
+++ b/SampleViewer/TextDocumentUtils.cpp
@@ -26,37 +26,36 @@
 // Other headers
 #include "TextDocumentUtils.h"
 
-namespace
+struct ImageRange
 {
-  struct ImageRange
-  {
-    int position;
-    int length;
-    QTextImageFormat format;
-  };
+  int position;
+  int length;
+  QTextImageFormat format;
+};
 
-  void collectImageRanges(QTextFrame* frame, QVector<ImageRange>& imageRanges)
+static void collectImageRanges(QTextFrame* frame, QVector<ImageRange>& imageRanges)
+{
+  for (auto frameIterator = frame->begin(); !frameIterator.atEnd(); ++frameIterator)
   {
-    for (auto frameIterator = frame->begin(); !frameIterator.atEnd(); ++frameIterator)
+    if (QTextFrame* childFrame = frameIterator.currentFrame())
     {
-      if (QTextFrame* childFrame = frameIterator.currentFrame())
+      collectImageRanges(childFrame, imageRanges);
+      continue;
+    }
+
+    const QTextBlock block = frameIterator.currentBlock();
+    for (auto blockIterator = block.begin(); !blockIterator.atEnd(); ++blockIterator)
+    {
+      const QTextFragment fragment = blockIterator.fragment();
+      if (!fragment.isValid() || !fragment.charFormat().isImageFormat())
       {
-        collectImageRanges(childFrame, imageRanges);
         continue;
       }
 
-      const QTextBlock block = frameIterator.currentBlock();
-      for (auto blockIterator = block.begin(); !blockIterator.atEnd(); ++blockIterator)
-      {
-        const QTextFragment fragment = blockIterator.fragment();
-        if (fragment.isValid() && fragment.charFormat().isImageFormat())
-        {
-          imageRanges.append({fragment.position(), fragment.length(), fragment.charFormat().toImageFormat()});
-        }
-      }
+      imageRanges.append({fragment.position(), fragment.length(), fragment.charFormat().toImageFormat()});
     }
   }
-} // namespace
+}
 
 TextDocumentUtils::TextDocumentUtils(QObject* parent) :
   QObject(parent)

--- a/SampleViewer/TextDocumentUtils.cpp
+++ b/SampleViewer/TextDocumentUtils.cpp
@@ -1,0 +1,102 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#include "TextDocumentUtils.h"
+
+#include <QTextBlock>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QTextFragment>
+#include <QTextFrame>
+#include <QTextImageFormat>
+#include <QTextLength>
+#include <QVector>
+
+namespace
+{
+  struct ImageRange
+  {
+    int position;
+    int length;
+    QTextImageFormat format;
+  };
+
+  void collectImageRanges(QTextFrame* frame, QVector<ImageRange>& imageRanges)
+  {
+    for (auto frameIterator = frame->begin(); !frameIterator.atEnd(); ++frameIterator)
+    {
+      if (QTextFrame* childFrame = frameIterator.currentFrame())
+      {
+        collectImageRanges(childFrame, imageRanges);
+        continue;
+      }
+
+      const QTextBlock block = frameIterator.currentBlock();
+      for (auto blockIterator = block.begin(); !blockIterator.atEnd(); ++blockIterator)
+      {
+        const QTextFragment fragment = blockIterator.fragment();
+        if (fragment.isValid() && fragment.charFormat().isImageFormat())
+        {
+          imageRanges.append({fragment.position(), fragment.length(), fragment.charFormat().toImageFormat()});
+        }
+      }
+    }
+  }
+} // namespace
+
+TextDocumentUtils::TextDocumentUtils(QObject* parent) :
+  QObject(parent)
+{
+}
+
+void TextDocumentUtils::constrainImageWidths(QQuickTextDocument* quickTextDocument) const
+{
+  if (!quickTextDocument || !quickTextDocument->textDocument())
+  {
+    return;
+  }
+
+  QTextDocument* document = quickTextDocument->textDocument();
+  QVector<ImageRange> imageRanges;
+  collectImageRanges(document->rootFrame(), imageRanges);
+
+  if (imageRanges.isEmpty())
+  {
+    return;
+  }
+
+  QTextCursor cursor(document);
+  cursor.beginEditBlock();
+  for (ImageRange& imageRange : imageRanges)
+  {
+    imageRange.format.setMaximumWidth(QTextLength(QTextLength::PercentageLength, 100));
+    cursor.setPosition(imageRange.position);
+    cursor.setPosition(imageRange.position + imageRange.length, QTextCursor::KeepAnchor);
+    cursor.setCharFormat(imageRange.format);
+  }
+  cursor.endEditBlock();
+}

--- a/SampleViewer/TextDocumentUtils.h
+++ b/SampleViewer/TextDocumentUtils.h
@@ -1,0 +1,44 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#ifndef TEXTDOCUMENTUTILS_H
+#define TEXTDOCUMENTUTILS_H
+
+// Qt headers
+#include <QObject>
+#include <QQuickTextDocument>
+
+class TextDocumentUtils : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit TextDocumentUtils(QObject* parent = nullptr);
+  Q_INVOKABLE void constrainImageWidths(QQuickTextDocument* quickTextDocument) const;
+};
+
+#endif // TEXTDOCUMENTUTILS_H

--- a/SampleViewer/TextDocumentUtils.h
+++ b/SampleViewer/TextDocumentUtils.h
@@ -13,18 +13,6 @@
 // limitations under the License.
 // [Legal]
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// [Legal]
-
 #ifndef TEXTDOCUMENTUTILS_H
 #define TEXTDOCUMENTUTILS_H
 

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -51,6 +51,7 @@
 #include "SourceCode.h"
 #include "SourceCodeListModel.h"
 #include "SyntaxHighlighter/SyntaxHighlighter.h"
+#include "TextDocumentUtils.h"
 #include "../CppSamples/Layers/ManageOperationalLayers/DrawOrderLayerListModel.h"
 
 #ifdef ESRI_BUILD
@@ -309,6 +310,7 @@
 
 QObject* esriSampleManagerProvider(QQmlEngine* engine, QJSEngine* scriptEngine);
 QObject* syntaxHighlighterProvider(QQmlEngine* engine, QJSEngine* scriptEngine);
+QObject* textDocumentUtilsProvider(QQmlEngine* engine, QJSEngine* scriptEngine);
 void registerClasses();
 void registerCppSampleClasses();
 
@@ -634,6 +636,7 @@ void registerClasses()
   qmlRegisterSingletonType<SampleManager>("Esri.ArcGISRuntimeSamples", 1, 0, "SampleManager", &esriSampleManagerProvider);
 
   qmlRegisterSingletonType<SyntaxHighlighter>("Esri.ArcGISRuntimeSamples", 1, 0, "SyntaxHighlighter", &syntaxHighlighterProvider);
+  qmlRegisterSingletonType<TextDocumentUtils>("Esri.ArcGISRuntimeSamples", 1, 0, "TextDocumentUtils", &textDocumentUtilsProvider);
   qmlRegisterUncreatableType<DataItem>("Esri.ArcGISRuntimeSamples", 1, 0, "DataItem", "DataItem is an uncreatable type");
   qmlRegisterUncreatableType<DataItemListModel>("Esri.ArcGISRuntimeSamples", 1, 0, "DataItemListModel", "DataItemListModel is an uncreatable type");
   qmlRegisterUncreatableType<CategoryListModel>("Esri.ArcGISRuntimeSamples", 1, 0, "CategoryListModel", "CategoryListModel is an uncreatable type");
@@ -661,4 +664,10 @@ QObject* syntaxHighlighterProvider(QQmlEngine* engine, QJSEngine*)
 {
   static SyntaxHighlighter* syntaxHighlighter = new SyntaxHighlighter(engine);
   return syntaxHighlighter;
+}
+
+QObject* textDocumentUtilsProvider(QQmlEngine* engine, QJSEngine*)
+{
+  static TextDocumentUtils* textDocumentUtils = new TextDocumentUtils(engine);
+  return textDocumentUtils;
 }

--- a/SampleViewer/qml/DescriptionView.qml
+++ b/SampleViewer/qml/DescriptionView.qml
@@ -43,7 +43,6 @@ Rectangle {
         TextEdit {
             id: textEdit
             width: descriptionFlickable.width
-            // Percentage image widths require wrapping to give the document a finite text width.
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             readOnly: true
             activeFocusOnPress: false

--- a/SampleViewer/qml/DescriptionView.qml
+++ b/SampleViewer/qml/DescriptionView.qml
@@ -23,7 +23,15 @@ Rectangle {
     color: Calcite.background
     property string descriptionText: "text"
 
+    function constrainDescriptionImages() {
+        TextDocumentUtils.constrainImageWidths(textEdit.textDocument);
+    }
+
+    // Format changes also emit TextEdit.textChanged, so respond to the source property instead.
+    onDescriptionTextChanged: Qt.callLater(constrainDescriptionImages)
+
     Flickable {
+        id: descriptionFlickable
         anchors {
             margins: 15
             fill: parent
@@ -34,8 +42,8 @@ Rectangle {
 
         TextEdit {
             id: textEdit
-            anchors.margins: 15
-            width: descriptionView.width - (40)
+            width: descriptionFlickable.width
+            // Percentage image widths require wrapping to give the document a finite text width.
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             readOnly: true
             activeFocusOnPress: false


### PR DESCRIPTION
# Description

This PR resizes image in the description view to fit screen.
- Adds a `TextDocumentUtils` singleton to walk through the markdown and resize the image. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [x] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
