### PR TITLE
fix clang-tidy + remove auto

### DIFF
--- a/CppSamples/EditData/EditGeometriesWithProgrammaticReticleTool/EditGeometriesWithProgrammaticReticleTool.cpp
+++ b/CppSamples/EditData/EditGeometriesWithProgrammaticReticleTool/EditGeometriesWithProgrammaticReticleTool.cpp
@@ -219,7 +219,7 @@ void EditGeometriesWithProgrammaticReticleTool::handleMapTapGeStarted(const QMou
     .then(this,
           [this](IdentifyGraphicsOverlayResult* rawResult)
   {
-    auto identifyResult = std::unique_ptr<IdentifyGraphicsOverlayResult>(rawResult);
+    const std::unique_ptr<IdentifyGraphicsOverlayResult> identifyResult = std::unique_ptr<IdentifyGraphicsOverlayResult>(rawResult);
     if (!identifyResult || identifyResult->graphics().isEmpty())
     {
       m_editingGraphic = nullptr;
@@ -289,7 +289,7 @@ void EditGeometriesWithProgrammaticReticleTool::handleMapTapGeStarted(const QMou
         default:
           break;
       }
-      m_mapView->setViewpointAsync(!targetPoint.isEmpty() ? targetPoint : geometry.extent().center(), m_mapView->mapScale());
+      m_mapView->setViewpointAsync(Viewpoint(!targetPoint.isEmpty() ? targetPoint : geometry.extent().center(), m_mapView->mapScale()));
 
       // Hide the selected graphic while editing.
       m_editingGraphic->setVisible(false);

--- a/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
+++ b/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
@@ -213,7 +213,7 @@ void EditWithBranchVersioning::onSgdbDoneLoadingCompleted_(const Error& error)
     }
 
     // once the service feature table is loaded set the mapview extent to the full extent of the feature layer
-    m_mapView->setViewpointAsync(m_featureLayer->fullExtent());
+    m_mapView->setViewpointAsync(Viewpoint(m_featureLayer->fullExtent()));
 
     m_busy = false;
     emit busyChanged();


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix - clang-tidy warnings
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
