### PR TITLE
Add optional performance monitor to the sample viewer.

### DIFF
--- a/SampleViewer/PerformanceMonitor/PerfMetricsModel.cpp
+++ b/SampleViewer/PerformanceMonitor/PerfMetricsModel.cpp
@@ -1,0 +1,74 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+// Other headers
+#include "PerfMetricsModel.h"
+
+int PerfMetricsModel::rowCount(const QModelIndex& parent) const
+{
+  return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+}
+
+QVariant PerfMetricsModel::data(const QModelIndex& index, int role) const
+{
+  if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size())
+  {
+    return {};
+  }
+
+  const Row& row = m_rows.at(index.row());
+  if (static_cast<Role>(role) == Role::Label)
+  {
+    return row.label;
+  }
+
+  return static_cast<Role>(role) == Role::Value ? QVariant(row.value) : QVariant();
+}
+
+QHash<int, QByteArray> PerfMetricsModel::roleNames() const
+{
+  return {{static_cast<int>(Role::Label), "label"}, {static_cast<int>(Role::Value), "value"}};
+}
+
+// Updates the named row in place or appends a new one; first-report order is display order.
+void PerfMetricsModel::upsert(const QString& label, double value)
+{
+  for (int i = 0; i < static_cast<int>(m_rows.size()); ++i)
+  {
+    if (m_rows[i].label == label)
+    {
+      m_rows[i].value = value;
+      emit dataChanged(index(i), index(i), {static_cast<int>(Role::Value)});
+      return;
+    }
+  }
+
+  const int row = static_cast<int>(m_rows.size());
+  beginInsertRows(QModelIndex(), row, row);
+  m_rows.append({label, value});
+  endInsertRows();
+}
+
+void PerfMetricsModel::clear()
+{
+  if (m_rows.isEmpty())
+  {
+    return;
+  }
+
+  beginResetModel();
+  m_rows.clear();
+  endResetModel();
+}

--- a/SampleViewer/PerformanceMonitor/PerfMetricsModel.h
+++ b/SampleViewer/PerformanceMonitor/PerfMetricsModel.h
@@ -1,0 +1,51 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#ifndef PERFMETRICSMODEL_H
+#define PERFMETRICSMODEL_H
+
+// Qt headers
+#include <QAbstractListModel>
+
+// Ordered label -> value rows behind the overlay's Repeater; internal to the perf monitor module.
+class PerfMetricsModel : public QAbstractListModel
+{
+public:
+  enum class Role : int
+  {
+    Label = Qt::UserRole + 1,
+    Value,
+  };
+
+  using QAbstractListModel::QAbstractListModel;
+
+  int rowCount(const QModelIndex& parent) const override;
+  QVariant data(const QModelIndex& index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+  void upsert(const QString& label, double value);
+  void clear();
+
+private:
+  struct Row
+  {
+    QString label;
+    double value;
+  };
+
+  QList<Row> m_rows;
+};
+
+#endif // PERFMETRICSMODEL_H

--- a/SampleViewer/PerformanceMonitor/PerformanceMonitor.cpp
+++ b/SampleViewer/PerformanceMonitor/PerformanceMonitor.cpp
@@ -1,0 +1,218 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+// Qt headers
+#include <QDebug>
+#include <QMutexLocker>
+#include <QQmlApplicationEngine>
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QScreen>
+#include <QTimer>
+
+// Other headers
+#include "PerfMetricsModel.h"
+#include "PerformanceMonitor.h"
+
+static constexpr int PUBLISH_INTERVAL_MS = 1000;
+
+// Above every sample and above the viewer chrome.
+static constexpr qreal OVERLAY_Z = 9999.0;
+
+PerformanceMonitor* PerformanceMonitor::install(QQmlApplicationEngine* engine)
+{
+  if (!engine || engine->rootObjects().isEmpty())
+  {
+    qWarning() << "PerformanceMonitor: engine has no root objects; call install() after load()";
+    return nullptr;
+  }
+
+  auto* window = qobject_cast<QQuickWindow*>(engine->rootObjects().constFirst());
+  if (!window)
+  {
+    qWarning() << "PerformanceMonitor: root object is not a QQuickWindow; overlay not installed";
+    return nullptr;
+  }
+
+  auto* monitor = new PerformanceMonitor(window);
+  monitor->attachWindow(window);
+
+  // A child context keeps perfMonitor out of the root context, which the rest of the app shares.
+  auto* context = new QQmlContext(engine->rootContext(), engine);
+  context->setContextProperty("perfMonitor", monitor);
+
+  QQmlComponent component(engine, QUrl("qrc:/perf/PerformanceOverlay.qml"));
+  QObject* created = component.create(context);
+  auto* overlay = qobject_cast<QQuickItem*>(created);
+  if (!overlay)
+  {
+    // The span API and frame timing still work without the HUD.
+    qWarning() << "PerformanceMonitor: overlay not created:" << (created ? QStringLiteral("root object is not an Item") : component.errorString());
+    delete created;
+    return monitor;
+  }
+
+  QQuickItem* host = window->contentItem();
+
+  // Controls popups (drawers, dialogs) render in the QQuickOverlay layer above all content, so host the HUD there when present.
+  const QList<QQuickItem*> hostChildren = host->childItems();
+  for (QQuickItem* child : hostChildren)
+  {
+    if (child->inherits("QQuickOverlay"))
+    {
+      host = child;
+      break;
+    }
+  }
+
+  overlay->setParent(window);
+  overlay->setParentItem(host);
+  overlay->setZ(OVERLAY_Z);
+
+  return monitor;
+}
+
+PerformanceMonitor::PerformanceMonitor(QObject* parent) :
+  QObject(parent),
+  m_publishTimer(new QTimer(this)),
+  m_metricsModel(new PerfMetricsModel(this))
+{
+  m_publishTimer->setInterval(PUBLISH_INTERVAL_MS);
+  connect(m_publishTimer, &QTimer::timeout, this, &PerformanceMonitor::publishMetrics);
+  m_publishTimer->start();
+}
+
+PerformanceMonitor::~PerformanceMonitor() = default;
+
+QAbstractItemModel* PerformanceMonitor::metrics() const
+{
+  return m_metricsModel;
+}
+
+void PerformanceMonitor::beginSpan(const QString& name)
+{
+  m_openSpans[name].restart();
+}
+
+void PerformanceMonitor::endSpan(const QString& name)
+{
+  const auto it = m_openSpans.constFind(name);
+  if (it == m_openSpans.constEnd())
+  {
+    qDebug() << "PerformanceMonitor: endSpan for span that was never begun:" << name << "- ignored";
+    return;
+  }
+
+  const double ms = static_cast<double>(it->nsecsElapsed()) / 1.0e6;
+  m_openSpans.erase(it);
+  m_metricsModel->upsert(name, ms);
+}
+
+void PerformanceMonitor::setValue(const QString& name, double ms)
+{
+  m_metricsModel->upsert(name, ms);
+}
+
+void PerformanceMonitor::clearMetrics()
+{
+  m_openSpans.clear();
+  m_metricsModel->clear();
+}
+
+void PerformanceMonitor::attachWindow(QQuickWindow* window)
+{
+  m_window = window;
+  if (!m_window)
+  {
+    return;
+  }
+
+  // Direct connection: onFrameEnd runs on the render thread, safe only while the window owns this object.
+  connect(m_window, &QQuickWindow::afterFrameEnd, this, &PerformanceMonitor::onFrameEnd, Qt::DirectConnection);
+
+  updateRefreshRate();
+  connect(m_window, &QQuickWindow::screenChanged, this, &PerformanceMonitor::updateRefreshRate);
+}
+
+bool PerformanceMonitor::forceRender() const
+{
+  return m_forceRender.load(std::memory_order_relaxed);
+}
+
+void PerformanceMonitor::setForceRender(bool forceRender)
+{
+  if (m_forceRender.exchange(forceRender, std::memory_order_relaxed) == forceRender)
+  {
+    return;
+  }
+
+  // Kick the loop once; onFrameEnd keeps it going from there.
+  if (forceRender && m_window)
+  {
+    m_window->update();
+  }
+
+  emit forceRenderChanged();
+}
+
+void PerformanceMonitor::onFrameEnd()
+{
+  {
+    const QMutexLocker lock(&m_mutex);
+
+    const qint64 frameDtNs = m_frameTimer.isValid() ? m_frameTimer.nsecsElapsed() : 0;
+    m_frameTimer.restart();
+
+    if (frameDtNs > 0)
+    {
+      m_sumFrameNs += static_cast<quint64>(frameDtNs);
+      ++m_frameSamples;
+    }
+  }
+
+  // Queued rather than a direct call because update() is being requested from the render thread.
+  if (m_forceRender.load(std::memory_order_relaxed) && m_window)
+  {
+    QMetaObject::invokeMethod(m_window, &QQuickWindow::update, Qt::QueuedConnection);
+  }
+}
+
+void PerformanceMonitor::updateRefreshRate()
+{
+  const QScreen* screen = m_window ? m_window->screen() : nullptr;
+  m_refreshRateHz = screen ? screen->refreshRate() : 0.0;
+  emit refreshRateHzChanged();
+}
+
+void PerformanceMonitor::publishMetrics()
+{
+  // Snapshot and reset under the lock, then do the arithmetic unlocked.
+  quint64 sumFrameNs = 0;
+  int frameSamples = 0;
+  {
+    const QMutexLocker lock(&m_mutex);
+    sumFrameNs = m_sumFrameNs;
+    frameSamples = m_frameSamples;
+
+    m_sumFrameNs = 0;
+    m_frameSamples = 0;
+  }
+
+  m_frameTimeMs = frameSamples > 0 ? (static_cast<double>(sumFrameNs) / frameSamples) / 1.0e6 : 0.0;
+
+  emit metricsChanged();
+}

--- a/SampleViewer/PerformanceMonitor/PerformanceMonitor.h
+++ b/SampleViewer/PerformanceMonitor/PerformanceMonitor.h
@@ -1,0 +1,99 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#ifndef PERFORMANCEMONITOR_H
+#define PERFORMANCEMONITOR_H
+
+class PerfMetricsModel;
+class QQmlApplicationEngine;
+class QQuickWindow;
+class QTimer;
+
+#include <QAbstractItemModel>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QMutex>
+#include <QObject>
+
+#include <atomic>
+
+// Passive frame-timing overlay for any Qt Quick app, compiled only in CONFIG+=perfmonitor builds.
+class PerformanceMonitor : public QObject
+{
+  Q_OBJECT
+
+  // FPS is deliberately not a property: the overlay derives it from frameTimeMs so the two cannot drift.
+  Q_PROPERTY(double frameTimeMs MEMBER m_frameTimeMs NOTIFY metricsChanged)
+  // App-reported metrics, one row per name, in first-report order.
+  Q_PROPERTY(QAbstractItemModel* metrics READ metrics CONSTANT)
+  Q_PROPERTY(double refreshRateHz MEMBER m_refreshRateHz NOTIFY refreshRateHzChanged)
+  Q_PROPERTY(bool forceRender READ forceRender WRITE setForceRender NOTIFY forceRenderChanged)
+
+public:
+  // Call after QQmlApplicationEngine::load(); the returned monitor is owned by the engine's root window.
+  static PerformanceMonitor* install(QQmlApplicationEngine* engine);
+
+  ~PerformanceMonitor() override;
+
+  // App-facing API, GUI thread only; names double as overlay row labels.
+  Q_INVOKABLE void beginSpan(const QString& name);
+  Q_INVOKABLE void endSpan(const QString& name);
+  Q_INVOKABLE void setValue(const QString& name, double ms);
+  Q_INVOKABLE void clearMetrics();
+
+  QAbstractItemModel* metrics() const;
+
+signals:
+  void metricsChanged();
+  void refreshRateHzChanged();
+  void forceRenderChanged();
+
+private:
+  Q_DISABLE_COPY_MOVE(PerformanceMonitor)
+
+  explicit PerformanceMonitor(QObject* parent = nullptr);
+
+  void attachWindow(QQuickWindow* window);
+
+  bool forceRender() const;
+  void setForceRender(bool forceRender);
+
+  // Runs on the render thread.
+  void onFrameEnd();
+
+  void updateRefreshRate();
+  void publishMetrics();
+
+  // Frame timing, written on the render thread and drained on the GUI thread under m_mutex.
+  QMutex m_mutex;
+  quint64 m_sumFrameNs = 0;
+  int m_frameSamples = 0;
+  QElapsedTimer m_frameTimer;
+
+  // Read on the render thread, written on the GUI thread.
+  std::atomic<bool> m_forceRender{false};
+
+  QTimer* m_publishTimer = nullptr;
+  QQuickWindow* m_window = nullptr;
+
+  // Spans and reported metrics, GUI thread only.
+  QHash<QString, QElapsedTimer> m_openSpans;
+  PerfMetricsModel* m_metricsModel = nullptr;
+
+  double m_frameTimeMs = 0.0;
+  double m_refreshRateHz = 0.0;
+};
+
+#endif // PERFORMANCEMONITOR_H

--- a/SampleViewer/PerformanceMonitor/perf.qrc
+++ b/SampleViewer/PerformanceMonitor/perf.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/perf">
+        <file alias="PerformanceOverlay.qml">qml/PerformanceOverlay.qml</file>
+    </qresource>
+</RCC>

--- a/SampleViewer/PerformanceMonitor/perfmonitor.pri
+++ b/SampleViewer/PerformanceMonitor/perfmonitor.pri
@@ -1,0 +1,32 @@
+#-------------------------------------------------
+
+# [Legal]
+# Copyright 2026 Esri.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# [Legal]
+
+#-------------------------------------------------
+
+# Included only from the perfmonitor block in SampleViewer.pro. Nothing here is built otherwise.
+
+INCLUDEPATH += $$PWD
+
+HEADERS += \
+    $$PWD/PerfMetricsModel.h \
+    $$PWD/PerformanceMonitor.h
+
+SOURCES += \
+    $$PWD/PerfMetricsModel.cpp \
+    $$PWD/PerformanceMonitor.cpp
+
+RESOURCES += $$PWD/perf.qrc

--- a/SampleViewer/PerformanceMonitor/qml/PerformanceOverlay.qml
+++ b/SampleViewer/PerformanceMonitor/qml/PerformanceOverlay.qml
@@ -1,0 +1,262 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+// Draggable performance HUD, collapsed to a pill by default; colors are hardcoded so the module carries no toolkit dependency.
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+
+Item {
+    id: root
+
+    // perfMonitor is a context property set by PerformanceMonitor::install()
+    readonly property var monitor: perfMonitor
+
+    property bool expanded: false
+
+    // Locked at expand time so the panel grows toward the window center and collapses back onto the pill.
+    property bool expandLeft: false
+    property bool expandUp: false
+
+    readonly property real fps: monitor.frameTimeMs > 0 ? 1000 / monitor.frameTimeMs : 0
+    readonly property bool idle: monitor.frameTimeMs <= 0
+    readonly property real targetFps: monitor.refreshRateHz > 0 ? monitor.refreshRateHz : 60
+    readonly property color fpsColor: idle ? mutedColor : fps >= targetFps - 5 ? goodColor : fps >= 30 ? warnColor : badColor
+
+    readonly property color goodColor: "#3BB273"
+    readonly property color warnColor: "#E5B301"
+    readonly property color badColor: "#D6503C"
+    readonly property color mutedColor: "#8C8C8C"
+
+    // The root stays pill-sized; the panel expands out of it via anchors, so x/y never move on expand/collapse.
+    width: 78
+    height: 30
+
+    // Set once, not bound (a binding would fight the drag); top-left, below the 42px header ToolBar.
+    Component.onCompleted: {
+        x = 16;
+        y = 50;
+    }
+
+    Connections {
+        target: root.parent
+
+        function onWidthChanged() { root.x = Math.min(root.x, Math.max(0, root.parent.width - root.width - 8)) }
+        function onHeightChanged() { root.y = Math.min(root.y, Math.max(0, root.parent.height - root.height - 8)) }
+    }
+
+    function ms(value: real): string {
+        return value > 0 ? value.toFixed(1) + " ms" : "—";
+    }
+
+    // label + right-aligned value. Self-contained so it needs no ids from the enclosing scope.
+    component MetricRow: Item {
+        id: metricRow
+
+        // Not named "value": that name is reserved for auto-filling from the metrics model role.
+        required property string label
+        required property string valueText
+        property color valueColor: "#DDDDDD"
+
+        width: parent ? parent.width : 0
+        height: 16
+
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: metricRow.label
+            textFormat: Text.PlainText
+            color: "#8C8C8C"
+            font.pixelSize: 11
+        }
+
+        Text {
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            text: metricRow.valueText
+            textFormat: Text.PlainText
+            color: metricRow.valueColor
+
+            font {
+                pixelSize: 11
+                family: "Courier New"
+                preferShaping: false
+            }
+        }
+    }
+
+    // Declared before the panel so later siblings (the toggle) get first refusal on a press; misses fall through to drag/click here.
+    MouseArea {
+        anchors.fill: panel
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        hoverEnabled: true
+
+        drag {
+            target: root
+            threshold: 8
+            minimumX: 0
+            maximumX: root.parent ? Math.max(0, root.parent.width - root.width) : 0
+            minimumY: 0
+            maximumY: root.parent ? Math.max(0, root.parent.height - root.height) : 0
+        }
+
+        onClicked: mouse => {
+            if (mouse.button !== Qt.LeftButton)
+                return;
+            if (!root.expanded && root.parent) {
+                root.expandLeft = root.x + root.width / 2 > root.parent.width / 2;
+                root.expandUp = root.y + root.height / 2 > root.parent.height / 2;
+            }
+            root.expanded = !root.expanded;
+        }
+        onDoubleClicked: mouse => mouse.accepted = true
+        onWheel: wheel => wheel.accepted = true
+    }
+
+    Rectangle {
+        id: panel
+
+        // Grabs two-finger gestures so a pinch starting on the HUD cannot zoom the map beneath it.
+        PinchHandler { target: null }
+
+        // The anchored edge is the one nearest the window corner, so growth heads toward the center.
+        anchors {
+            left: root.expandLeft ? undefined : root.left
+            right: root.expandLeft ? root.right : undefined
+            top: root.expandUp ? undefined : root.top
+            bottom: root.expandUp ? root.bottom : undefined
+        }
+        width: root.expanded ? 186 : root.width
+        height: root.expanded ? content.implicitHeight + 20 : root.height
+        radius: 6
+        color: "#D91A1A1A"
+        border.color: "#33FFFFFF"
+        border.width: 1
+
+        Behavior on width { NumberAnimation { duration: 120; easing.type: Easing.OutQuad } }
+        Behavior on height { NumberAnimation { duration: 120; easing.type: Easing.OutQuad } }
+
+        // Collapsed: just the headline number.
+        Text {
+            anchors.centerIn: parent
+            visible: !root.expanded
+            text: root.idle ? "idle" : root.fps.toFixed(0) + " fps"
+            textFormat: Text.PlainText
+            color: root.fpsColor
+
+            font {
+                pixelSize: 13
+                bold: true
+                family: "Courier New"
+                preferShaping: false
+            }
+        }
+
+        Column {
+            id: content
+
+            anchors.fill: parent
+            anchors.margins: 10
+            visible: root.expanded
+            spacing: 5
+            clip: true
+
+            Text {
+                text: "PERFORMANCE"
+                textFormat: Text.PlainText
+                color: "#FFFFFF"
+
+                font {
+                    pixelSize: 10
+                    bold: true
+                    letterSpacing: 1.2
+                }
+            }
+
+            Rectangle { width: content.width; height: 1; color: "#33FFFFFF" }
+
+            MetricRow {
+                label: "FPS"
+                valueText: root.idle ? "idle" : root.fps.toFixed(1)
+                valueColor: root.fpsColor
+            }
+
+            MetricRow { label: "frame"; valueText: root.ms(root.monitor.frameTimeMs) }
+
+            // One row per app-reported metric, in first-report order; unbound while collapsed so hidden rows cost nothing.
+            Repeater {
+                model: root.expanded ? root.monitor.metrics : null
+
+                delegate: MetricRow {
+                    // label auto-fills from the model role of the same name.
+                    required property double value
+                    valueText: root.ms(value)
+                }
+            }
+
+            Rectangle { width: content.width; height: 1; color: "#33FFFFFF" }
+
+            Item {
+                width: content.width
+                height: 18
+
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "force render"
+                    color: root.mutedColor
+                    font.pixelSize: 11
+                }
+
+                // A plain rectangle rather than a Controls Switch, so the viewer's Calcite styling cannot reach this module.
+                Rectangle {
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 28
+                    height: 14
+                    radius: 7
+                    color: root.monitor.forceRender ? root.goodColor : "#4D4D4D"
+
+                    Rectangle {
+                        width: 10
+                        height: 10
+                        radius: 5
+                        color: "#FFFFFF"
+                        anchors.verticalCenter: parent.verticalCenter
+                        x: root.monitor.forceRender ? parent.width - width - 2 : 2
+
+                        Behavior on x { NumberAnimation { duration: 100 } }
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        // Negative margins enlarge the hit target for touch.
+                        anchors.margins: -6
+                        onClicked: root.monitor.forceRender = !root.monitor.forceRender
+                    }
+                }
+            }
+
+            Text {
+                text: root.monitor.refreshRateHz > 0
+                      ? "target " + root.monitor.refreshRateHz.toFixed(0) + " Hz"
+                      : ""
+                visible: root.monitor.refreshRateHz > 0
+                color: "#6E6E6E"
+                font.pixelSize: 10
+            }
+        }
+    }
+
+}

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -153,6 +153,17 @@ include(samples.pri)
 # contains source files for zlib-ng and minizip-ng
 include($$PWD/../3rdparty/zlib_minizip_ng.pri)
 
+# Optional performance overlay. Off by default; enable with: qmake CONFIG+=perfmonitor
+# When off, none of its sources, headers or QML are compiled into the binary.
+perfmonitor {
+  message("Performance monitor: ENABLED")
+  DEFINES += PERFORMANCE_MONITOR
+  include($$COMMONVIEWER/PerformanceMonitor/perfmonitor.pri)
+  # The adapter is app code, not module code - it knows SampleManager and the ArcGIS views.
+  HEADERS += $$COMMONVIEWER/SampleViewerPerfAdapter.h
+  SOURCES += $$COMMONVIEWER/SampleViewerPerfAdapter.cpp
+}
+
 CONFIG(precompile_header): DEFINES += PCH_BUILD
 
 android {

--- a/SampleViewer/SampleViewerPerfAdapter.cpp
+++ b/SampleViewer/SampleViewerPerfAdapter.cpp
@@ -1,0 +1,183 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#ifdef PERFORMANCE_MONITOR
+
+#include "pch.hpp"
+
+#include "SampleViewerPerfAdapter.h"
+
+#include "PerformanceMonitor.h"
+#include "SampleManager.h"
+
+// ArcGIS Maps SDK headers
+#include "LocalSceneQuickView.h"
+#include "MapQuickView.h"
+#include "SceneQuickView.h"
+
+// Qt headers
+#include <QDebug>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QTimer>
+#include <QVariant>
+
+using namespace Esri::ArcGISRuntime;
+
+static const QString DRAW_SPAN = QStringLiteral("previous draw time");
+static const QString INITIAL_LOAD_SPAN = QStringLiteral("initial load");
+
+// Walks the visual tree, not the QObject tree.
+template<typename ViewType>
+static ViewType* findViewInTree(QQuickItem* item)
+{
+  if (!item)
+  {
+    return nullptr;
+  }
+
+  if (auto* match = qobject_cast<ViewType*>(item))
+  {
+    return match;
+  }
+
+  const QList<QQuickItem*> children = item->childItems();
+  for (QQuickItem* child : children)
+  {
+    if (auto* match = findViewInTree<ViewType>(child))
+    {
+      return match;
+    }
+  }
+
+  return nullptr;
+}
+
+SampleViewerPerfAdapter::SampleViewerPerfAdapter(PerformanceMonitor* monitor, SampleManager* sampleManager, QQuickWindow* window, QObject* parent) :
+  QObject(parent),
+  m_monitor(monitor),
+  m_sampleManager(sampleManager),
+  m_window(window)
+{
+  if (!m_monitor || !m_sampleManager)
+  {
+    qWarning() << "SampleViewerPerfAdapter: monitor or SampleManager unavailable; sample metrics will not be reported";
+    return;
+  }
+
+  connect(m_sampleManager, &SampleManager::currentSampleChanged, this, &SampleViewerPerfAdapter::onSampleChanged);
+  connect(m_sampleManager, &SampleManager::currentModeChanged, this, &SampleViewerPerfAdapter::onModeChanged);
+}
+
+void SampleViewerPerfAdapter::onSampleChanged()
+{
+  m_monitor->clearMetrics();
+  m_monitor->beginSpan(INITIAL_LOAD_SPAN);
+  m_loadPending = true;
+  m_drawOpen = false;
+  disconnect(m_drawStatusConn);
+
+  QTimer::singleShot(0, this, &SampleViewerPerfAdapter::attachToGeoView);
+}
+
+void SampleViewerPerfAdapter::onModeChanged()
+{
+  if (!m_loadPending)
+  {
+    return;
+  }
+
+  // currentMode() is private (Q_PROPERTY-only), so read it the way QML does.
+  const QVariant mode = m_sampleManager->property("currentMode");
+  if (!mode.isValid())
+  {
+    qWarning() << "SampleViewerPerfAdapter: SampleManager has no currentMode property; re-arm disabled";
+    return;
+  }
+
+  if (mode.value<SampleManager::CurrentMode>() != SampleManager::LiveSampleView)
+  {
+    return;
+  }
+
+  // The sample Loader gets its source only after data is in place, so restarting here excludes download time.
+  m_monitor->beginSpan(INITIAL_LOAD_SPAN);
+  m_drawOpen = false;
+  disconnect(m_drawStatusConn);
+
+  QTimer::singleShot(0, this, &SampleViewerPerfAdapter::attachToGeoView);
+}
+
+void SampleViewerPerfAdapter::attachToGeoView()
+{
+  if (!m_window)
+  {
+    return;
+  }
+
+  // Two queued attach attempts can land in one event-loop turn; never stack connections.
+  disconnect(m_drawStatusConn);
+
+  QQuickItem* content = m_window->contentItem();
+
+  if (!attachIfFound<MapQuickView>(content) && !attachIfFound<SceneQuickView>(content) && !attachIfFound<LocalSceneQuickView>(content))
+  {
+    // m_loadPending stays set, so the mode flip to LiveSampleView after a download retries the hunt.
+    qDebug() << "SampleViewerPerfAdapter: no GeoView found for this sample (yet)";
+  }
+}
+
+template<typename ViewType>
+bool SampleViewerPerfAdapter::attachIfFound(QQuickItem* content)
+{
+  auto* view = findViewInTree<ViewType>(content);
+  if (!view)
+  {
+    return false;
+  }
+
+  m_drawStatusConn = connect(view, &ViewType::drawStatusChanged, this, &SampleViewerPerfAdapter::onDrawStatusChanged);
+  onDrawStatusChanged(view->drawStatus());
+  return true;
+}
+
+void SampleViewerPerfAdapter::onDrawStatusChanged(DrawStatus status)
+{
+  if (status == DrawStatus::InProgress)
+  {
+    m_monitor->beginSpan(DRAW_SPAN);
+    m_drawOpen = true;
+    return;
+  }
+
+  if (status != DrawStatus::Completed)
+  {
+    return;
+  }
+
+  if (m_drawOpen)
+  {
+    m_drawOpen = false;
+    m_monitor->endSpan(DRAW_SPAN);
+  }
+
+  if (m_loadPending)
+  {
+    m_loadPending = false;
+    m_monitor->endSpan(INITIAL_LOAD_SPAN);
+  }
+}
+
+#endif // PERFORMANCE_MONITOR

--- a/SampleViewer/SampleViewerPerfAdapter.h
+++ b/SampleViewer/SampleViewerPerfAdapter.h
@@ -1,0 +1,65 @@
+// [Legal]
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#ifndef SAMPLEVIEWERPERFADAPTER_H
+#define SAMPLEVIEWERPERFADAPTER_H
+
+#ifdef PERFORMANCE_MONITOR
+
+class PerformanceMonitor;
+class QQuickItem;
+class QQuickWindow;
+class SampleManager;
+
+// ArcGIS Maps SDK headers
+#include "MapViewTypes.h"
+
+#include <QMetaObject>
+#include <QObject>
+
+// Feeds Sample Viewer events (sample changes, GeoView draw status) into the monitor's generic span API.
+// App code, not module code: compiled from SampleViewer.pro's perfmonitor block only.
+class SampleViewerPerfAdapter : public QObject
+{
+  Q_OBJECT
+
+public:
+  SampleViewerPerfAdapter(PerformanceMonitor* monitor, SampleManager* sampleManager, QQuickWindow* window, QObject* parent = nullptr);
+
+private:
+  Q_DISABLE_COPY_MOVE(SampleViewerPerfAdapter)
+
+  void onSampleChanged();
+  void onModeChanged();
+  void attachToGeoView();
+  template<typename ViewType>
+  bool attachIfFound(QQuickItem* content);
+  void onDrawStatusChanged(Esri::ArcGISRuntime::DrawStatus status);
+
+  PerformanceMonitor* m_monitor = nullptr;
+  SampleManager* m_sampleManager = nullptr;
+  QQuickWindow* m_window = nullptr;
+  QMetaObject::Connection m_drawStatusConn;
+
+  // Set on sample change, cleared by the first completed draw; gates the re-arm in onModeChanged.
+  bool m_loadPending = false;
+
+  // GeoViews repeat Completed without a fresh InProgress; only the first one closes a draw cycle.
+  bool m_drawOpen = false;
+};
+
+#endif // PERFORMANCE_MONITOR
+
+#endif // SAMPLEVIEWERPERFADAPTER_H

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -58,6 +58,11 @@
 #include "buildnum.h"
 #endif
 
+#ifdef PERFORMANCE_MONITOR
+#include "PerformanceMonitor.h"
+#include "SampleViewerPerfAdapter.h"
+#endif // PERFORMANCE_MONITOR
+
 // All Samples
 #include "../CppSamples/Accessibility/NavigateMapViewAndIdentifyFeaturesWithKeyboard/NavigateMapViewAndIdentifyFeaturesWithKeyboard.h"
 #include "../CppSamples/Analysis/AnalyzeHotspots/AnalyzeHotspots.h"
@@ -375,6 +380,16 @@ int main(int argc, char* argv[])
   engine.addImageProvider(name, new MapImageProvider);
 
   engine.load(QUrl(QStringLiteral("qrc:/qml/main.qml")));
+
+#ifdef PERFORMANCE_MONITOR
+  // load() populates rootObjects() synchronously, so the window exists by now.
+  if (auto* monitor = PerformanceMonitor::install(&engine))
+  {
+    // The adapter feeds sample and GeoView events into the monitor and dies with its parent.
+    new SampleViewerPerfAdapter(monitor, engine.singletonInstance<SampleManager*>("Esri.ArcGISRuntimeSamples", "SampleManager"),
+                                qobject_cast<QQuickWindow*>(engine.rootObjects().constFirst()), monitor);
+  }
+#endif // PERFORMANCE_MONITOR
 
   return app.exec();
 }


### PR DESCRIPTION
# Description

Adds performance monitor as an optional module to the sample viewer.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
